### PR TITLE
Some fixes to packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import codecs
 import os.path
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -28,5 +28,5 @@ setup(
         "Topic :: Communications :: Chat",
     ],
     keywords="asyncio xmpp library",
-    packages=["aioxmpp"],
+    packages=find_packages()
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
         "Topic :: Communications :: Chat",
     ],
     keywords="asyncio xmpp library",
+    install_requires=['dnspython3', 'lxml', 'orderedset', 'pyOpenSSL', 'pyasn1_modules', 'tzlocal'],
     packages=find_packages()
 )


### PR DESCRIPTION
make sure the sub-packages are included when installing.
add dependencies so they are automatically pulled with pip

bump the version and don't forget to upload an archive too:
```python setup.py sdist upload```