### PR TITLE
Improve debugability of XMLStream

### DIFF
--- a/aioxmpp/connector.py
+++ b/aioxmpp/connector.py
@@ -90,7 +90,8 @@ class BaseConnector(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     @asyncio.coroutine
-    def connect(self, loop, metadata, domain, host, port, negotiation_timeout):
+    def connect(self, loop, metadata, domain, host, port, negotiation_timeout,
+                base_logger=None):
         """
         Establish a :class:`.protocol.XMLStream` for `domain` with the given
         `host` at the given TCP `port`.
@@ -109,6 +110,8 @@ class BaseConnector(metaclass=abc.ABCMeta):
         To detect the use of TLS on the stream, check whether
         :meth:`asyncio.Transport.get_extra_info` returns a non-:data:`None`
         value for ``"ssl_object"``.
+
+        `base_logger` is passed to :class:`aioxmpp.protocol.XMLStream`.
         """
 
 
@@ -129,7 +132,7 @@ class STARTTLSConnector(BaseConnector):
 
     @asyncio.coroutine
     def connect(self, loop, metadata, domain, host, port,
-                negotiation_timeout):
+                negotiation_timeout, base_logger=None):
         """
         .. seealso::
 
@@ -158,6 +161,7 @@ class STARTTLSConnector(BaseConnector):
         stream = protocol.XMLStream(
             to=domain,
             features_future=features_future,
+            base_logger=base_logger,
         )
 
         try:
@@ -261,7 +265,7 @@ class XMPPOverTLSConnector(BaseConnector):
 
     @asyncio.coroutine
     def connect(self, loop, metadata, domain, host, port,
-                negotiation_timeout):
+                negotiation_timeout, base_logger=None):
         """
         .. seealso::
 
@@ -287,6 +291,7 @@ class XMPPOverTLSConnector(BaseConnector):
         stream = protocol.XMLStream(
             to=domain,
             features_future=features_future,
+            base_logger=base_logger,
         )
 
         verifier = metadata.certificate_verifier_factory()

--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -217,6 +217,7 @@ def _try_options(options, exceptions,
                 host,
                 port,
                 negotiation_timeout,
+                base_logger=logger,
             )
         except OSError as exc:
             logger.warning(

--- a/aioxmpp/xml.py
+++ b/aioxmpp/xml.py
@@ -574,6 +574,8 @@ class XMPPXMLGenerator:
             with self._save_state():
                 yield
             old_write(self._buf.getbuffer())
+            if old_flush:
+                old_flush()
         finally:
             self._buf_in_use = False
             self._write = old_write

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -84,6 +84,10 @@ Version 0.9
   ``<service-unavailable/>`` instead of ``<feature-not-implemented/>``, as the
   former is actually specified in :rfc:`6120` section 8.4.
 
+* The :class:`aioxmpp.protocol.XMLStream` loggers for :class:`aioxmpp.Client`
+  objects are now a child of the client logger itself, and not at
+  ``aioxmpp.XMLStream``.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -139,6 +139,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.sentinel.host,
                 unittest.mock.sentinel.port,
                 unittest.mock.sentinel.timeout,
+                base_logger=unittest.mock.sentinel.base_logger,
             ))
 
         self.assertSequenceEqual(
@@ -150,6 +151,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=unittest.mock.sentinel.base_logger,
                 ),
                 unittest.mock.call.create_starttls_connection(
                     unittest.mock.sentinel.loop,
@@ -282,6 +284,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=None,
                 ),
                 unittest.mock.call.create_starttls_connection(
                     unittest.mock.sentinel.loop,
@@ -375,6 +378,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=None,
                 ),
                 unittest.mock.call.create_starttls_connection(
                     unittest.mock.sentinel.loop,
@@ -467,6 +471,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=None,
                 ),
                 unittest.mock.call.create_starttls_connection(
                     unittest.mock.sentinel.loop,
@@ -593,6 +598,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=None,
                 ),
                 unittest.mock.call.create_starttls_connection(
                     unittest.mock.sentinel.loop,
@@ -720,6 +726,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=None,
                 ),
                 unittest.mock.call.create_starttls_connection(
                     unittest.mock.sentinel.loop,
@@ -824,6 +831,7 @@ class TestXMPPOverTLSConnector(unittest.TestCase):
                 unittest.mock.sentinel.host,
                 unittest.mock.sentinel.port,
                 unittest.mock.sentinel.timeout,
+                base_logger=unittest.mock.sentinel.base_logger,
             ))
 
         self.assertSequenceEqual(
@@ -835,6 +843,7 @@ class TestXMPPOverTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=unittest.mock.sentinel.base_logger,
                 ),
                 unittest.mock.call.metadata.certificate_verifier_factory(),
                 unittest.mock.call.certificate_verifier.pre_handshake(
@@ -958,6 +967,7 @@ class TestXMPPOverTLSConnector(unittest.TestCase):
                 unittest.mock.call.XMLStream(
                     to=unittest.mock.sentinel.domain,
                     features_future=features_future,
+                    base_logger=None,
                 ),
                 unittest.mock.call.metadata.certificate_verifier_factory(),
                 unittest.mock.call.certificate_verifier.pre_handshake(

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -721,7 +721,8 @@ class Testconnect_xmlstream(unittest.TestCase):
                     jid.domain,
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
-                    60.
+                    60.,
+                    base_logger=logger,
                 )
                 for i in range(3)
             ]
@@ -793,6 +794,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     unittest.mock.sentinel.timeout,
+                    base_logger=node.logger,
                 )
                 for i in range(3)
             ]
@@ -897,6 +899,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     60.,
+                    base_logger=node.logger,
                 )
                 for i in range(NCONNECTORS)
             ]
@@ -996,6 +999,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     60.,
+                    base_logger=node.logger,
                 )
                 for i in range(3)
             ]
@@ -1056,6 +1060,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     60.,
+                    base_logger=node.logger,
                 )
                 for i in range(3)
             ]
@@ -1121,6 +1126,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     60.,
+                    base_logger=node.logger
                 )
                 for i in range(2)
             ]
@@ -1185,6 +1191,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     60.,
+                    base_logger=node.logger,
                 )
                 for i in range(3)
             ]
@@ -1251,6 +1258,7 @@ class Testconnect_xmlstream(unittest.TestCase):
                     getattr(unittest.mock.sentinel, "h{}".format(i)),
                     getattr(unittest.mock.sentinel, "p{}".format(i)),
                     60.,
+                    base_logger=node.logger,
                 )
                 for i in range(3)
             ]


### PR DESCRIPTION
* We now call flush from XMPPXMLGenerator, which makes the DebugWrapper used to show debug output work again (it relies on flush being called to assemble the output)
* The logger of the XMLStream is now put below the logger of the Client, improving debug output readability a lot (especially for e2etests)