### PR TITLE
Fix EntityCapsService

### DIFF
--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -90,19 +90,28 @@ class Node(object):
         self._identities = {}
         self._features = set()
 
-    def iter_identities(self, stanza):
+    def iter_identities(self, stanza=None):
         """
         Return an iterator of tuples describing the identities of the node.
 
         :param stanza: The IQ request stanza
-        :type stanza: :class:`~aioxmpp.IQ`
+        :type stanza: :class:`~aioxmpp.IQ` or :data:`None`
         :rtype: iterable of (:class:`str`, :class:`str`, :class:`str` or :data:`None`, :class:`str` or :data:`None`) tuples
         :return: :xep:`30` identities of this node
 
-        `stanza` is the :class:`aioxmpp.IQ` stanza of the request. This can be
-        used to hide a node depending on who is asking. If the returned
+        `stanza` can be the :class:`aioxmpp.IQ` stanza of the request. This can
+        be used to hide a node depending on who is asking. If the returned
         iterable is empty, the :class:`~.DiscoServer` returns an
         ``<item-not-found/>`` error.
+
+        `stanza` may be :data:`None` if the identities are queried without
+        a specific request context. In that case, implementors should assume
+        that the result is visible to everybody.
+
+        .. note::
+
+           Subclasses must allow :data:`None` for `stanza` and default it to
+           :data:`None`.
 
         Return an iterator which yields tuples consisting of the category, the
         type, the language code and the name of each identity declared in this
@@ -117,7 +126,7 @@ class Node(object):
             if not names:
                 yield category, type_, None, None
 
-    def iter_features(self, stanza):
+    def iter_features(self, stanza=None):
         """
         Return an iterator which yields the features of the node.
 
@@ -129,6 +138,15 @@ class Node(object):
         `stanza` is the :class:`aioxmpp.IQ` stanza of the request. This can be
         used to filter the list according to who is asking (not recommended).
 
+        `stanza` may be :data:`None` if the features are queried without
+        a specific request context. In that case, implementors should assume
+        that the result is visible to everybody.
+
+        .. note::
+
+           Subclasses must allow :data:`None` for `stanza` and default it to
+           :data:`None`.
+
         The features are returned as strings. The features demanded by
         :xep:`30` are always returned.
 
@@ -138,7 +156,7 @@ class Node(object):
             iter(self._features)
         )
 
-    def iter_items(self, stanza):
+    def iter_items(self, stanza=None):
         """
         Return an iterator which yields the items of the node.
 
@@ -150,6 +168,15 @@ class Node(object):
         `stanza` is the :class:`aioxmpp.IQ` stanza of the request. This can be
         used to localize the list to the language of the stanza or filter it
         according to who is asking.
+
+        `stanza` may be :data:`None` if the items are queried without
+        a specific request context. In that case, implementors should assume
+        that the result is visible to everybody.
+
+        .. note::
+
+           Subclasses must allow :data:`None` for `stanza` and default it to
+           :data:`None`.
 
         A bare :class:`Node` cannot hold any items and will thus return an
         iterator which does not yield any element.
@@ -244,7 +271,7 @@ class StaticNode(Node):
         super().__init__()
         self.items = []
 
-    def iter_items(self, stanza):
+    def iter_items(self, stanza=None):
         return iter(self.items)
 
 

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -447,7 +447,6 @@ class EntityCapsService(aioxmpp.service.Service):
     @aioxmpp.service.inbound_presence_filter
     def handle_inbound_presence(self, presence):
         caps = presence.xep0115_caps
-        presence.xep0115_caps = None
 
         if caps is not None and caps.hash_ is not None:
             self.logger.debug(

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -88,6 +88,9 @@ Version 0.9
   objects are now a child of the client logger itself, and not at
   ``aioxmpp.XMLStream``.
 
+* Fix bug in :class:`aioxmpp.EntityCapsService` rendering it useless for
+  providing caps hashes to other entities.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -75,6 +75,23 @@ class TestNode(unittest.TestCase):
 
         cb.assert_called_with()
 
+    def test_iter_features_works_without_argument(self):
+        n = disco_service.Node()
+        cb = unittest.mock.Mock()
+        n.on_info_changed.connect(cb)
+
+        n.register_feature("uri:foo")
+
+        self.assertSetEqual(
+            {
+                "uri:foo",
+                namespaces.xep0030_info
+            },
+            set(n.iter_features())
+        )
+
+        cb.assert_called_with()
+
     def test_register_feature_prohibits_duplicate_registration(self):
         n = disco_service.Node()
         cb = unittest.mock.Mock()
@@ -195,6 +212,25 @@ class TestNode(unittest.TestCase):
                 ("client", "pc", None, None),
             },
             set(n.iter_identities(unittest.mock.sentinel.stanza))
+        )
+
+        cb.assert_called_with()
+
+    def test_iter_identities_works_without_stanza(self):
+        n = disco_service.Node()
+
+        cb = unittest.mock.Mock()
+        n.on_info_changed.connect(cb)
+
+        n.register_identity(
+            "client", "pc"
+        )
+
+        self.assertSetEqual(
+            {
+                ("client", "pc", None, None),
+            },
+            set(n.iter_identities())
         )
 
         cb.assert_called_with()
@@ -339,6 +375,13 @@ class TestNode(unittest.TestCase):
             set(n.iter_identities(unittest.mock.sentinel.stanza))
         )
 
+    def test_iter_items_works_without_argument(self):
+        n = disco_service.Node()
+        self.assertSequenceEqual(
+            list(n.iter_items()),
+            []
+        )
+
 
 class TestStaticNode(unittest.TestCase):
     def setUp(self):
@@ -359,6 +402,12 @@ class TestStaticNode(unittest.TestCase):
                 item2
             ],
             list(self.n.iter_items(unittest.mock.sentinel.jid))
+        )
+
+    def test_iter_items_works_without_argument(self):
+        self.assertSequenceEqual(
+            list(self.n.iter_items()),
+            []
         )
 
 

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -1,0 +1,78 @@
+import asyncio
+
+import aioxmpp.stream
+
+from aioxmpp.e2etest import (
+    blocking_timed,
+    blocking,
+    TestCase,
+)
+
+
+class TestEntityCapabilities(TestCase):
+    @blocking
+    @asyncio.coroutine
+    def setUp(self):
+        self.source, self.sink = yield from asyncio.gather(
+            self.provisioner.get_connected_client(
+                services=[
+                    aioxmpp.EntityCapsService,
+                    aioxmpp.PresenceServer,
+                    aioxmpp.PresenceClient,
+                ]
+            ),
+            self.provisioner.get_connected_client(
+                services=[
+                    aioxmpp.EntityCapsService,
+                    aioxmpp.PresenceServer,
+                    aioxmpp.PresenceClient,
+                ]
+            )
+        )
+
+    @blocking_timed
+    @asyncio.coroutine
+    def test_caps_are_sent_with_presence(self):
+        caps_server = self.source.summon(aioxmpp.EntityCapsService)
+        disco_client = self.sink.summon(aioxmpp.DiscoClient)
+        disco_server = self.source.summon(aioxmpp.DiscoServer)
+
+        fut = asyncio.Future()
+
+        def on_available(full_jid, stanza):
+            if full_jid != self.source.local_jid:
+                return False  # stay connected
+            fut.set_result(stanza)
+            return True  # disconnect
+
+        self.sink.summon(aioxmpp.PresenceClient).on_available.connect(
+            on_available
+        )
+
+        presence = aioxmpp.Presence(
+            type_=aioxmpp.PresenceType.AVAILABLE,
+            to=self.sink.local_jid,
+        )
+        yield from self.source.stream.send(presence)
+
+        presence = yield from fut
+
+        self.assertIsNotNone(
+            presence.xep0115_caps,
+        )
+        self.assertEqual(
+            presence.xep0115_caps.ver,
+            caps_server.ver,
+        )
+
+        info = yield from disco_client.query_info(
+            self.source.local_jid,
+            node="{}#{}".format(
+                presence.xep0115_caps.node,
+                presence.xep0115_caps.ver,
+            )
+        )
+        self.assertSetEqual(
+            info.features,
+            set(disco_server.iter_features()),
+        )

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -1186,7 +1186,7 @@ class TestService(unittest.TestCase):
             presence
         )
 
-        self.assertIsNone(presence.xep0115_caps)
+        self.assertIs(presence.xep0115_caps, caps)
 
     def test_handle_inbound_presence_deals_with_None(self):
         presence = stanza.Presence()
@@ -1240,7 +1240,7 @@ class TestService(unittest.TestCase):
             presence
         )
 
-        self.assertIsNone(presence.xep0115_caps)
+        self.assertIs(presence.xep0115_caps, caps)
 
     def test_query_and_cache(self):
         self.maxDiff = None


### PR DESCRIPTION
It was broken since e4388f7!

Should we release v0.8.1 due to this? We really need e2e tests for ecaps by the way, that would’ve been caught by those.

The impact is that outgoing capabilities are not generated, even though we advertise the feature.