### PR TITLE
Implement client side support for private XML storage and bookmarks.

### DIFF
--- a/aioxmpp/bookmarks/__init__.py
+++ b/aioxmpp/bookmarks/__init__.py
@@ -1,0 +1,21 @@
+########################################################################
+# File name: __init__.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################

--- a/aioxmpp/bookmarks/__init__.py
+++ b/aioxmpp/bookmarks/__init__.py
@@ -19,3 +19,64 @@
 # <http://www.gnu.org/licenses/>.
 #
 ########################################################################
+""":mod:`~aioxmpp.bookmarks` – Bookmark support (:xep:`0048`)
+##########################################################
+
+This module provides support for storing and retrieving bookmarks on
+the server as per :xep:`Bookmarks <48>`.
+
+Service
+=======
+
+.. autoclass:: BookmarkClient
+
+XSOs
+====
+
+The following XSOs are used to represent an manipulate bookmark lists.
+
+.. autoclass:: Storage
+
+.. autoclass:: Conference
+
+.. autoclass:: URL
+
+Notes on usage
+==============
+
+It is important to use this class carefully to prevent race conditions
+with other clients modifying the bookmark data (unfortunately, this is
+not entirely preventable due to the design of the bookmark protocol).
+
+The recommended practice is to modify the bookmarks in a get, modify,
+set fashion, where the modify step should be as short as possible
+(that is, should not depend on user input).
+
+The individual bookmark classes support comparison by value. This
+allows useful manipulation of the bookmark list in agreement with
+the get-modify-set pattern. Where we reference the objects to operate
+on by with the value retrieved in an earlier get.
+
+Removal::
+
+  storage = bookmark_client.get_bookmarks()
+  storage.bookmarks.remove(old_bookmark)
+  bookmark_client.set_bookmarks(storage)
+
+Modifying::
+
+  storage = bookmark_client.get_bookmarks()
+  i = storage.bookmarks.index(old_bookmark)
+  storage.bookmarks[i].name = "New Shiny Name"
+  storage.bookmarks[i].nick = "new_nick"
+  bookmark_client.set_bookmarks(storage)
+
+Adding::
+
+  storage = bookmark_client.get_bookmarks()
+  storage.bookmarks.append(new_bookmark)
+  bookmark_client.set_bookmarks(storage)
+"""
+
+from .xso import (Storage, Conference, URL)  # NOQA
+from .service import BookmarkClient  # NOQA

--- a/aioxmpp/bookmarks/service.py
+++ b/aioxmpp/bookmarks/service.py
@@ -1,0 +1,85 @@
+########################################################################
+# File name: service.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import asyncio
+
+import aioxmpp
+import aioxmpp.callbacks as callbacks
+import aioxmpp.service as service
+import aioxmpp.disco as disco
+import aioxmpp.pubsub as pubsub
+import aioxmpp.private_xml as private_xml
+
+from . import xso as bookmark_xso
+
+
+# TODO: use private storage in pubsub where available.
+# TODO: sync bookmarks between pubsub and private xml storage
+class BookmarkClient(service.Service):
+    """
+    Supports retrieval and storage of bookmarks on the server.
+    It currently only supports :xep:`Private XML Storage <49>` as
+    backend.
+
+    .. automethod:: get_bookmarks
+
+    .. automethod:: set_bookmarks
+
+    .. note:: The bookmark protocol is prone to race conditions if
+              several clients access it concurrently. Be careful to
+              use a get-modify-set pattern.
+
+    .. note:: Some other clients extend the bookmark format. For now
+              those extensions are silently dropped by our XSOs, and
+              therefore are lost, when changing the bookmarks with
+              aioxmpp. This is considered a bug to be fixed in the future.
+    """
+
+    ORDER_AFTER = [
+        private_xml.PrivateXMLService,
+    ]
+
+    def __init__(self, client, **kwargs):
+        super().__init__(client, **kwargs)
+        self._private_xml = self.dependencies[private_xml.PrivateXMLService]
+
+    @asyncio.coroutine
+    def get_bookmarks(self):
+        """
+        Get the stored bookmarks from the server.
+
+        :returns: the bookmarks as a :class:`~bookmark_xso.Storage` object
+        """
+        res = yield from self._private_xml.get_private_xml(
+            bookmark_xso.Storage()
+        )
+        return res
+
+    @asyncio.coroutine
+    def set_bookmarks(self, bookmarks):
+        """
+        Set the bookmarks stored on the server.
+        """
+        if not isinstance(bookmarks, bookmark_xso.Storage):
+            raise TypeError(
+                "set_bookmarks only accepts bookmark.Storage objects"
+            )
+        yield from self._private_xml.set_private_xml(bookmarks)

--- a/aioxmpp/bookmarks/xso.py
+++ b/aioxmpp/bookmarks/xso.py
@@ -30,37 +30,100 @@ from aioxmpp.utils import namespaces
 namespaces.xep0048 = "storage:bookmarks"
 
 
-class Nick(xso.XSO):
-    TAG = (namespaces.xep0049, "nick")
-    text = Text(type_=xso.String())
-
-
-class Password(xso.XSO):
-    TAG = (namespaces.xep0049, "password")
-    text = Text(type_=xso.String())
-
-
 class Conference(xso.XSO):
-    TAG = (namespaces.xep0049, "conference")
+    """
+    An bookmark for a groupchat.
+
+    .. attribute:: name
+
+       The name of the bookmark.
+
+    .. attribute:: jid
+
+       The jid under which the groupchat is accessible.
+
+    .. attribute:: autojoin
+
+       Whether to join automatically, when the client starts.
+
+    .. attribute:: nick
+
+       The nick to use in the groupchat.
+
+    .. attribute:: password
+
+       The password used to access the groupchat.
+    """
+
+    TAG = (namespaces.xep0048, "conference")
 
     autojoin = xso.Attr(tag="autojoin", type_=xso.Bool(), default=False)
     jid = xso.Attr(tag="jid", type_=xso.JID())
     name = xso.Attr(tag="name", type_=xso.String(), default=None)
 
-    nick = xso.Child([Nick()])
-    password = xso.Child([Password()])
+    nick = xso.ChildText(
+        (namespaces.xep0048, "nick"),
+        default=None
+    )
+    password = xso.ChildText(
+        (namespaces.xep0048, "password"),
+        default=None
+    )
+
+    def __init__(self, name, jid, *, autojoin=False, nick=None, password=None):
+        self.autojoin = autojoin
+        self.jid = jid
+        self.name = name
+        self.nick = nick
+        self.password = password
+
+    def __eq__(self, other):
+        return (isinstance(other, Conference) and
+                other.name == self.name and
+                other.jid == self.jid and
+                other.autojoin == self.autojoin and
+                other.name == self.name and
+                other.password == self.password)
 
 
 class URL(xso.XSO):
-    TAG = (namespaces.xep0049, "url")
+    """
+    An URL bookmark.
+
+    .. attribute:: name
+
+       The name of the bookmark.
+
+    .. attribute:: url
+
+       The URL the bookmark saves.
+    """
+    TAG = (namespaces.xep0048, "url")
 
     name = xso.Attr(tag="name", type_=xso.String(), default=None)
     # XXX: we might want to use a URL type once we have one
     url = xso.Attr(tag="url", type_=xso.String())
 
+    def __init__(self, name, url):
+        self.name = name
+        self.url = url
+
+    def __eq__(self, other):
+        return (isinstance(other, URL) and
+                other.name == self.name and
+                other.url == self.url)
+
 
 @private_xml.Query.as_payload_class
 class Storage(xso.XSO):
-    TAG = (namespaces.xep0049, "storage")
+    """
+    The container for storing bookmarks.
+
+    .. attribute:: bookmarks
+
+       A :class:`~xso.XSOList` of bookmarks.
+
+    """
+    TAG = (namespaces.xep0048, "storage")
 
     bookmarks = xso.ChildList([URL, Conference])

--- a/aioxmpp/bookmarks/xso.py
+++ b/aioxmpp/bookmarks/xso.py
@@ -1,0 +1,66 @@
+########################################################################
+# File name: xso.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import aioxmpp
+import aioxmpp.private_xml as private_xml
+import aioxmpp.xso as xso
+
+
+from aioxmpp.utils import namespaces
+
+
+namespaces.xep0048 = "storage:bookmarks"
+
+
+class Nick(xso.XSO):
+    TAG = (namespaces.xep0049, "nick")
+    text = Text(type_=xso.String())
+
+
+class Password(xso.XSO):
+    TAG = (namespaces.xep0049, "password")
+    text = Text(type_=xso.String())
+
+
+class Conference(xso.XSO):
+    TAG = (namespaces.xep0049, "conference")
+
+    autojoin = xso.Attr(tag="autojoin", type_=xso.Bool(), default=False)
+    jid = xso.Attr(tag="jid", type_=xso.JID())
+    name = xso.Attr(tag="name", type_=xso.String(), default=None)
+
+    nick = xso.Child([Nick()])
+    password = xso.Child([Password()])
+
+
+class URL(xso.XSO):
+    TAG = (namespaces.xep0049, "url")
+
+    name = xso.Attr(tag="name", type_=xso.String(), default=None)
+    # XXX: we might want to use a URL type once we have one
+    url = xso.Attr(tag="url", type_=xso.String())
+
+
+@private_xml.Query.as_payload_class
+class Storage(xso.XSO):
+    TAG = (namespaces.xep0049, "storage")
+
+    bookmarks = xso.ChildList([URL, Conference])

--- a/aioxmpp/private_xml/__init__.py
+++ b/aioxmpp/private_xml/__init__.py
@@ -1,0 +1,23 @@
+########################################################################
+# File name: __init__.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+from .xso import Query  # NOQA
+from .service import PrivateXMLService  # NOQA

--- a/aioxmpp/private_xml/__init__.py
+++ b/aioxmpp/private_xml/__init__.py
@@ -19,5 +19,21 @@
 # <http://www.gnu.org/licenses/>.
 #
 ########################################################################
+"""
+:mod:`~aioxmpp.private_xml` – Private XML Storage support (:xep:`0049`)
+#######################################################################
+
+This module provides support for storing and retrieving private XML data on
+the server as per :xep:`Private XML Storage <49>`.
+
+.. autoclass:: PrivateXMLService
+
+To register payload XSOs for private storage :class:`Query` is
+exposed:
+
+.. autoclass:: Query
+
+"""
+
 from .xso import Query  # NOQA
 from .service import PrivateXMLService  # NOQA

--- a/aioxmpp/private_xml/service.py
+++ b/aioxmpp/private_xml/service.py
@@ -28,12 +28,31 @@ from . import xso as private_xml_xso
 
 
 class PrivateXMLService(service.Service):
+    """
+    Service for handling server side private XML storage.
+
+    .. automethod:: get_private_xml
+
+    .. automethod:: set_private_xml
+    """
 
     def __init__(self, client, **kwargs):
         super().__init__(client, **kwargs)
 
     @asyncio.coroutine
     def get_private_xml(self, query_xso):
+        """
+        Get the private XML data for the element `query_xso` from the
+        server.
+
+        :param query_xso: the object to retrieve.
+        :returns: the stored private XML data.
+
+        `query_xso` *must* serialize to an empty XML node of the
+        wanted namespace and type and *must* be registered as private
+        XML :class:`~private_xml_xso.Query` payload.
+
+        """
         iq = aioxmpp.IQ(
             type_=aioxmpp.IQType.GET,
             payload=private_xml_xso.Query(query_xso)
@@ -42,6 +61,12 @@ class PrivateXMLService(service.Service):
 
     @asyncio.coroutine
     def set_private_xml(self, xso):
+        """
+        Store the serialization of `xso` on the server as the private XML
+        data for the namespace of `xso`.
+
+        :param xso: the XSO whose serialization is send as private XML data.
+        """
         iq = aioxmpp.IQ(
             type_=aioxmpp.IQType.SET,
             payload=private_xml_xso.Query(xso)

--- a/aioxmpp/private_xml/service.py
+++ b/aioxmpp/private_xml/service.py
@@ -1,0 +1,49 @@
+########################################################################
+# File name: service.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import asyncio
+
+import aioxmpp
+import aioxmpp.service as service
+
+from . import xso as private_xml_xso
+
+
+class PrivateXMLService(service.Service):
+
+    def __init__(self, client, **kwargs):
+        super().__init__(client, **kwargs)
+
+    @asyncio.coroutine
+    def get_private_xml(self, query_xso):
+        iq = aioxmpp.IQ(
+            type_=aioxmpp.IQType.GET,
+            payload=private_xml_xso.Query(query_xso)
+        )
+        return (yield from self.client.stream.send(iq))
+
+    @asyncio.coroutine
+    def set_private_xml(self, xso):
+        iq = aioxmpp.IQ(
+            type_=aioxmpp.IQType.SET,
+            payload=private_xml_xso.Query(xso)
+        )
+        yield from self.client.stream.send(iq)

--- a/aioxmpp/private_xml/xso.py
+++ b/aioxmpp/private_xml/xso.py
@@ -1,5 +1,5 @@
 ########################################################################
-# File name: service.py
+# File name: xso.py
 # This file is part of: aioxmpp
 #
 # LICENSE

--- a/aioxmpp/private_xml/xso.py
+++ b/aioxmpp/private_xml/xso.py
@@ -1,0 +1,54 @@
+########################################################################
+# File name: service.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import aioxmpp
+import aioxmpp.xso as xso
+
+from aioxmpp.utils import namespaces
+
+
+namespaces.xep0049 = "jabber:iq:private"
+
+
+@aioxmpp.IQ.as_payload_class
+class Query(xso.XSO):
+    TAG = (namespaces.xep0049, "query")
+
+    registered_payload = xso.Child([])
+    unregistered_payload = xso.Collector()
+
+    def __init__(self, payload):
+        self.registered_payload = payload
+
+    @classmethod
+    def as_payload_class(mycls, xso_class):
+        """
+        Register the given class `xso_class` as possible payload
+        for private XML storage.
+
+        Return `xso_class`, to allow this to be used as a decorator.
+        """
+        mycls.register_child(
+            Query.registered_payload,
+            xso_class
+        )
+
+        return xso_class

--- a/aioxmpp/private_xml/xso.py
+++ b/aioxmpp/private_xml/xso.py
@@ -30,6 +30,11 @@ namespaces.xep0049 = "jabber:iq:private"
 
 @aioxmpp.IQ.as_payload_class
 class Query(xso.XSO):
+    """
+    The XSO for queries to private XML storage.
+
+    .. automethod:: as_payload_class
+    """
     TAG = (namespaces.xep0049, "query")
 
     registered_payload = xso.Child([])

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -74,6 +74,10 @@ Version 0.9
 
 * :mod:`aioxmpp.misc`
 
+* :mod:`aioxmpp.private_xml`
+
+* :mod:`aioxmpp.bookmarks`
+
 * :xep:`Stream Management <198>` counters now wrap around as unsigned
   32 bit integers, as the standard specifies.
 

--- a/docs/api/public/bookmarks.rst
+++ b/docs/api/public/bookmarks.rst
@@ -1,0 +1,1 @@
+.. automodule:: aioxmpp.bookmarks

--- a/docs/api/public/index.rst
+++ b/docs/api/public/index.rst
@@ -29,12 +29,14 @@ functionality or provide backwards compatibility.
    adhoc
    avatar
    blocking
+   bookmarks
    carbons
    disco
    entitycaps
    forms
    muc
    presence
+   private_xml
    pubsub
    roster
    rfc6120

--- a/docs/api/public/private_xml.rst
+++ b/docs/api/public/private_xml.rst
@@ -1,0 +1,1 @@
+.. automodule:: aioxmpp.private_xml

--- a/examples/get_bookmarks_raw.py
+++ b/examples/get_bookmarks_raw.py
@@ -1,0 +1,55 @@
+########################################################################
+# File name: get_bookmarks_raw.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import asyncio
+
+import lxml.etree
+
+import aioxmpp
+import aioxmpp.private_xml as private_xml
+import aioxmpp.xso as xso
+
+from framework import Example, exec_example
+
+class Storage(xso.XSO):
+    TAG = ("storage:bookmarks", "storage")
+
+class GetBookmarksRaw(Example):
+
+    def make_simple_client(self):
+        client = super().make_simple_client()
+        self.avatar = client.summon(private_xml.PrivateXMLService)
+        return client
+
+    @asyncio.coroutine
+    def run_simple_example(self):
+        res = yield from self.avatar.get_private_xml(
+            Storage()
+        )
+        for item in res.unregistered_payload:
+            print(lxml.etree.tostring(item, pretty_print=True).decode("utf-8"))
+
+    @asyncio.coroutine
+    def run_example(self):
+        yield from super().run_example()
+
+if __name__ == "__main__":
+    exec_example(GetBookmarksRaw())

--- a/tests/bookmarks/test_service.py
+++ b/tests/bookmarks/test_service.py
@@ -1,0 +1,126 @@
+########################################################################
+# File name: test_service.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import asyncio
+import io
+import unittest
+import unittest.mock
+
+import lxml.etree
+import lxml.sax
+
+import aioxmpp
+import aioxmpp.private_xml
+import aioxmpp.xso
+
+import aioxmpp.bookmarks
+
+from aioxmpp.testutils import (
+    make_connected_client,
+    CoroutineMock,
+    run_coroutine
+)
+
+class TestBookmarkClient(unittest.TestCase):
+
+    def test_is_service(self):
+        self.assertTrue(issubclass(
+            aioxmpp.bookmarks.BookmarkClient,
+            aioxmpp.service.Service
+        ))
+
+    def test_after_private_xml(self):
+        self.assertIn(
+            aioxmpp.private_xml.PrivateXMLService,
+            aioxmpp.bookmarks.BookmarkClient.ORDER_AFTER
+        )
+
+    def setUp(self):
+        self.cc = make_connected_client()
+        self.private_xml = aioxmpp.private_xml.PrivateXMLService(self.cc)
+        self.s = aioxmpp.bookmarks.BookmarkClient(self.cc, dependencies={
+            aioxmpp.private_xml.PrivateXMLService: self.private_xml
+        })
+
+    def tearDown(self):
+        del self.cc
+        del self.private_xml
+        del self.s
+
+    def test_get_bookmarks(self):
+        with unittest.mock.patch.object(
+                self.private_xml,
+                "get_private_xml",
+                new=CoroutineMock()) as get_private_xml_mock:
+            get_private_xml_mock.return_value = unittest.mock.sentinel.result
+            res = run_coroutine(self.s.get_bookmarks())
+
+        self.assertIs(res, unittest.mock.sentinel.result)
+        self.assertEqual(
+            len(get_private_xml_mock.mock_calls),
+            1
+        )
+        (_, (arg,), kwargs), = get_private_xml_mock.mock_calls
+        self.assertEqual(len(kwargs), 0)
+        self.assertIsInstance(arg, aioxmpp.bookmarks.Storage)
+        self.assertEqual(len(arg.bookmarks), 0)
+
+    def test_set_bookmarks(self):
+        bookmarks = aioxmpp.bookmarks.Storage()
+        bookmarks.bookmarks.append(
+            aioxmpp.bookmarks.Conference(
+                "Coven", aioxmpp.JID.fromstr("coven@example.com")),
+        )
+        bookmarks.bookmarks.append(
+            aioxmpp.bookmarks.URL(
+                "Interesting",
+                "http://example.com/"),
+        )
+
+        with unittest.mock.patch.object(
+                self.private_xml,
+                "set_private_xml",
+                new=CoroutineMock()) as set_private_xml_mock:
+            run_coroutine(self.s.set_bookmarks(bookmarks))
+
+        self.assertEqual(
+            len(set_private_xml_mock.mock_calls),
+            1
+        )
+        (_, (arg,), kwargs), = set_private_xml_mock.mock_calls
+        self.assertEqual(len(kwargs), 0)
+        self.assertIs(arg, bookmarks)
+
+    def test_set_bookmarks_failure(self):
+        bookmarks = unittest.mock.sentinel.something_else
+        with unittest.mock.patch.object(
+                self.private_xml,
+                "set_private_xml",
+                new=CoroutineMock()) as set_private_xml_mock:
+            with self.assertRaisesRegex(
+                    TypeError,
+                    "^set_bookmarks only accepts bookmark.Storage objects$"):
+                run_coroutine(self.s.set_bookmarks(bookmarks))
+
+        self.assertEqual(
+            len(set_private_xml_mock.mock_calls),
+            0
+        )

--- a/tests/bookmarks/test_xso.py
+++ b/tests/bookmarks/test_xso.py
@@ -1,0 +1,150 @@
+########################################################################
+# File name: test_xso.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import unittest
+import logging
+
+import aioxmpp.structs
+import aioxmpp.private_xml as private_xml
+import aioxmpp.bookmarks.xso as bookmark_xso
+import aioxmpp.xso as xso
+
+from aioxmpp.utils import namespaces
+
+EXAMPLE_JID1 = aioxmpp.JID.fromstr("coven@conference.shakespeare.lit")
+EXAMPLE_JID2 = aioxmpp.JID.fromstr("open_field@conference.shakespeare.lit")
+
+class TestNamespace(unittest.TestCase):
+
+    def test_namespace(self):
+        self.assertEqual(namespaces.xep0048, "storage:bookmarks")
+
+
+class TestStorage(unittest.TestCase):
+
+    def test_is_xso(self):
+        self.assertTrue(issubclass(bookmark_xso.Storage, xso.XSO))
+
+    def test_tag(self):
+        self.assertEqual(
+            bookmark_xso.Storage.TAG,
+            (namespaces.xep0048, "storage")
+        )
+
+
+class TestConference(unittest.TestCase):
+
+    def test_is_xso(self):
+        self.assertTrue(issubclass(bookmark_xso.Conference, xso.XSO))
+
+    def test_tag(self):
+        self.assertEqual(
+            bookmark_xso.Conference.TAG,
+            (namespaces.xep0048, "conference")
+        )
+
+    def test_init(self):
+        conference = bookmark_xso.Conference("Coven", EXAMPLE_JID1)
+        self.assertEqual(conference.name, "Coven")
+        self.assertEqual(conference.jid, EXAMPLE_JID1)
+        self.assertEqual(conference.autojoin, False)
+        self.assertEqual(conference.nick, None)
+        self.assertEqual(conference.password, None)
+
+        conference = bookmark_xso.Conference(
+            "Coven", EXAMPLE_JID1,
+            autojoin=True, nick="First Witch",
+            password="h3c473"
+        )
+        self.assertEqual(conference.name, "Coven")
+        self.assertEqual(conference.jid, EXAMPLE_JID1)
+        self.assertEqual(conference.autojoin, True)
+        self.assertEqual(conference.nick, "First Witch")
+        self.assertEqual(conference.password, "h3c473")
+
+    def test_eq(self):
+        conf = bookmark_xso.Conference("Coven", EXAMPLE_JID1)
+        conf1 = bookmark_xso.Conference("Coven", EXAMPLE_JID1)
+        conf2 = bookmark_xso.Conference(
+            "Coven1", EXAMPLE_JID1,
+            autojoin=True, nick="First Witch",
+            password="h3c473"
+        )
+        conf3 = bookmark_xso.Conference(
+            "Coven", EXAMPLE_JID2,
+            autojoin=True, nick="First Witch",
+            password="h3c473"
+        )
+        conf4 = bookmark_xso.Conference(
+            "Coven", EXAMPLE_JID1,
+            nick="First Witch",
+            password="h3c473"
+        )
+        conf5 = bookmark_xso.Conference(
+            "Coven", EXAMPLE_JID1,
+            autojoin=True,
+            password="h3c473"
+        )
+        conf6 = bookmark_xso.Conference(
+            "Coven", EXAMPLE_JID1,
+            autojoin=True, nick="First Witch"
+        )
+        url = bookmark_xso.URL(
+            "Coven", "xmpp://coven@conference.shakespeare.lit"
+        )
+        self.assertEqual(conf, conf)
+        self.assertEqual(conf, conf1)
+        self.assertNotEqual(conf, conf2)
+        self.assertNotEqual(conf, conf3)
+        self.assertNotEqual(conf, conf4)
+        self.assertNotEqual(conf, conf5)
+        self.assertNotEqual(conf, conf6)
+        self.assertNotEqual(conf, url)
+
+
+class TestURL(unittest.TestCase):
+
+    def test_is_xso(self):
+        self.assertTrue(issubclass(bookmark_xso.URL, xso.XSO))
+
+    def test_tag(self):
+        self.assertEqual(
+            bookmark_xso.URL.TAG,
+            (namespaces.xep0048, "url")
+        )
+
+    def test_init(self):
+        url = bookmark_xso.URL("Url1", "http://example.com")
+        self.assertEqual(url.name, "Url1")
+        self.assertEqual(url.url, "http://example.com")
+
+    def test_eq(self):
+        url = bookmark_xso.URL("Url", "http://example.com")
+        url1 = bookmark_xso.URL("Url", "http://example.com")
+        url2 = bookmark_xso.URL("Url1", "http://example.com")
+        url3 = bookmark_xso.URL("Url", "http://example.com/foo")
+        conf = bookmark_xso.Conference("Coven", EXAMPLE_JID1)
+
+        self.assertEqual(url, url)
+        self.assertEqual(url, url1)
+        self.assertNotEqual(url, url2)
+        self.assertNotEqual(url, url3)
+        self.assertNotEqual(url, conf)

--- a/tests/private_xml/test_e2e.py
+++ b/tests/private_xml/test_e2e.py
@@ -1,0 +1,103 @@
+########################################################################
+# File name: test_e2e.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import asyncio
+import unittest
+
+import aioxmpp.private_xml as private_xml
+import aioxmpp.xso as xso
+
+from aioxmpp.e2etest import (
+    blocking,
+    blocking_timed,
+    TestCase,
+)
+
+
+@unittest.skip("Does not work with prosody and SASL ANONYMOUS")
+class TestPrivateXMLStorage(TestCase):
+
+    @blocking
+    @asyncio.coroutine
+    def setUp(self):
+        self.client, = yield from asyncio.gather(
+            self.provisioner.get_connected_client(
+                services=[
+                    private_xml.PrivateXMLService
+                ]
+            ),
+        )
+
+    @blocking_timed
+    @asyncio.coroutine
+    def test_store_and_retrieve_xml_unregistered(self):
+        p = self.client.summon(private_xml.PrivateXMLService)
+
+        class Payload(xso.XSO):
+            TAG = ("urn:example:unregistered", "payload")
+            data = xso.Text(type_=xso.String())
+
+            def __init__(self, text=""):
+                self.data = text
+
+        class Example(xso.XSO):
+            TAG = ("urn:example:unregistered", "example")
+            payload = xso.Child([Payload])
+
+            def __init__(self, payload=None):
+                self.payload = payload
+
+        yield from p.set_private_xml(Example(Payload("foobar")))
+        retrieved = yield from p.get_private_xml(Example())
+        self.assertEqual(len(retrieved.unregistered_payload), 1)
+        self.assertEqual(
+            retrieved.unregistered_payload[0].tag,
+            "{urn:example:unregistered}example"
+        )
+        self.assertEqual(len(retrieved.unregistered_payload[0]), 1)
+        self.assertEqual(
+            retrieved.unregistered_payload[0][0].tag,
+            "{urn:example:unregistered}payload"
+        )
+        self.assertEqual(
+            retrieved.unregistered_payload[0][0].text,
+            "foobar"
+        )
+
+    @blocking_timed
+    @asyncio.coroutine
+    def test_store_and_retrieve_xml_registered(self):
+        p = self.client.summon(private_xml.PrivateXMLService)
+
+        @private_xml.Query.as_payload_class
+        class Example(xso.XSO):
+            TAG = ("urn:example:registered", "example")
+            data = xso.Text(type_=xso.String())
+
+            def __init__(self, text=""):
+                self.data = text
+
+        yield from p.set_private_xml(Example("foobar"))
+        retrieved = yield from p.get_private_xml(Example())
+
+        self.assertEqual(len(retrieved.unregistered_payload), 0)
+        self.assertTrue(isinstance(retrieved.registered_payload, Example))
+        self.assertEqual(retrieved.registered_payload.data, "foobar")

--- a/tests/private_xml/test_e2e.py
+++ b/tests/private_xml/test_e2e.py
@@ -32,7 +32,6 @@ from aioxmpp.e2etest import (
 )
 
 
-@unittest.skip("Does not work with prosody and SASL ANONYMOUS")
 class TestPrivateXMLStorage(TestCase):
 
     @blocking

--- a/tests/private_xml/test_service.py
+++ b/tests/private_xml/test_service.py
@@ -1,0 +1,92 @@
+########################################################################
+# File name: test_service.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import unittest
+
+import aioxmpp
+import aioxmpp.private_xml.service as private_xml_service
+import aioxmpp.private_xml.xso as private_xml_xso
+
+from aioxmpp.testutils import (
+    make_connected_client,
+    CoroutineMock,
+    run_coroutine,
+)
+
+
+class TestService(unittest.TestCase):
+
+    def setUp(self):
+        self.cc = make_connected_client()
+        self.s = private_xml_service.PrivateXMLService(
+            self.cc,
+            dependencies={},
+        )
+        self.cc.mock_calls.clear()
+
+    def tearDown(self):
+        del self.cc
+        del self.s
+
+    def test_is_service(self):
+        self.assertTrue(issubclass(
+            private_xml_service.PrivateXMLService,
+            aioxmpp.service.Service
+        ))
+
+    def test_get_private_xml(self):
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            mock_send.return_value = unittest.mock.sentinel.result
+            res = run_coroutine(self.s.get_private_xml(
+                unittest.mock.sentinel.payload))
+
+        self.assertEqual(len(mock_send.mock_calls), 1)
+        try:
+            (_, (arg,), kwargs), = mock_send.mock_calls
+        except ValueError:
+            self.fail("send called with wrong signature")
+        self.assertEqual(len(kwargs), 0)
+        self.assertIsInstance(arg, aioxmpp.IQ)
+        self.assertEqual(arg.type_, aioxmpp.IQType.GET)
+        self.assertIsInstance(arg.payload, private_xml_xso.Query)
+        self.assertEqual(arg.payload.registered_payload,
+                         unittest.mock.sentinel.payload)
+
+        self.assertEqual(res, unittest.mock.sentinel.result)
+
+    def test_set_private_xml(self):
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            run_coroutine(self.s.set_private_xml(
+                unittest.mock.sentinel.payload))
+
+        self.assertEqual(len(mock_send.mock_calls), 1)
+        try:
+            (_, (arg,), kwargs), = mock_send.mock_calls
+        except ValueError:
+            self.fail("send called with wrong signature")
+        self.assertEqual(len(kwargs), 0)
+        self.assertIsInstance(arg, aioxmpp.IQ)
+        self.assertEqual(arg.type_, aioxmpp.IQType.SET)
+        self.assertIsInstance(arg.payload, private_xml_xso.Query)
+        self.assertEqual(arg.payload.registered_payload,
+                         unittest.mock.sentinel.payload)

--- a/tests/private_xml/test_xso.py
+++ b/tests/private_xml/test_xso.py
@@ -1,0 +1,74 @@
+########################################################################
+# File name: test_xso.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import contextlib
+import unittest
+import unittest.mock
+
+import aioxmpp.private_xml.xso as private_xml_xso
+import aioxmpp.xso as xso
+
+from aioxmpp.utils import namespaces
+
+
+class TestQuery(unittest.TestCase):
+
+    def test_namespace(self):
+        self.assertEqual(
+            namespaces.xep0049,
+            "jabber:iq:private"
+        )
+
+    def test_is_xso(self):
+        self.assertTrue(issubclass(private_xml_xso.Query, xso.XSO))
+
+    def test_tag(self):
+        self.assertEqual(
+            private_xml_xso.Query.TAG,
+            (namespaces.xep0049, "query")
+        )
+
+    def test_init(self):
+        query = private_xml_xso.Query(unittest.mock.sentinel.payload)
+        self.assertEqual(
+            query.registered_payload,
+            unittest.mock.sentinel.payload
+        )
+
+    def test_as_payload_class(self):
+        with contextlib.ExitStack() as stack:
+            at_Query = stack.enter_context(
+                unittest.mock.patch.object(
+                    private_xml_xso.Query,
+                    "register_child"
+                )
+            )
+
+            result = private_xml_xso.Query.as_payload_class(
+                unittest.mock.sentinel.cls
+            )
+
+        self.assertIs(result, unittest.mock.sentinel.cls)
+
+        at_Query.assert_called_with(
+            private_xml_xso.Query.registered_payload,
+            unittest.mock.sentinel.cls
+        )


### PR DESCRIPTION
Closes #50 and #48.

Note: The design of the bookmark service was reworked to be radically simple. It is out of scope for aioxmpp to solve the subtle issues when modifying bookmarks. However, groundwork has been laid
and explained in the documentation: The XSOs representing bookmarks have a definition of equality, this allows the use of by value list operations to modify Storage.bookmarks.