### PR TITLE
Add the new `Topic :: Internet :: XMPP` classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Topic :: Communications :: Chat",
+        "Topic :: Internet :: XMPP",
     ],
     keywords="asyncio xmpp library",
     install_requires=install_requires,


### PR DESCRIPTION
Update our setup.py to use the `Topic :: Internet :: XMPP` classifier.

See <https://github.com/pypa/warehouse/issues/1287> and <https://pypi.python.org/pypi?%3Aaction=list_classifiers>.