### PR TITLE
Fixes and features for RFC 6121 roster implementation

### DIFF
--- a/aioxmpp/roster/service.py
+++ b/aioxmpp/roster/service.py
@@ -375,9 +375,9 @@ class RosterClient(aioxmpp.service.Service):
         except KeyError:
             stored_item = Item.from_xso_item(xso_item)
             self.items[xso_item.jid] = stored_item
-            self.on_entry_added(stored_item)
             for group in stored_item.groups:
                 self.groups.setdefault(group, set()).add(stored_item)
+            self.on_entry_added(stored_item)
             return
 
         to_call = []
@@ -430,11 +430,7 @@ class RosterClient(aioxmpp.service.Service):
                 except KeyError:
                     pass
                 else:
-                    for group in old_item.groups:
-                        groupset = self.groups[group]
-                        groupset.remove(old_item)
-                        if not groupset:
-                            del self.groups[group]
+                    self._remove_from_groups(old_item, old_item.groups)
                     self.on_entry_removed(old_item)
             else:
                 self._update_entry(item)

--- a/aioxmpp/roster/service.py
+++ b/aioxmpp/roster/service.py
@@ -228,6 +228,10 @@ class RosterClient(aioxmpp.service.Service):
        Fires when an `item` has been added to the roster. The attributes of the
        `item` are up-to-date when this callback fires.
 
+       When the event fires, the bookkeeping structures are already updated.
+       This implies that :meth:`on_group_added` is called before
+       :meth:`on_entry_added` if the entry adds a new group.
+
     .. signal:: on_entry_name_changed(item)
 
        Fires when a roster update changed the name of the `item`. The new name
@@ -253,6 +257,10 @@ class RosterClient(aioxmpp.service.Service):
 
        The name of the new group is in `group_name`.
 
+       At the time the event fires, the bookkeeping structures for the group
+       are already updated; this implies that :meth:`on_group_added` fires
+       *before* :meth:`on_entry_added_to_group` if the entry added a new group.
+
     .. signal:: on_entry_removed_from_group(item, group_name)
 
        Fires when an update removes an `item` from a group. The
@@ -265,11 +273,43 @@ class RosterClient(aioxmpp.service.Service):
 
        The name of the new group is in `group_name`.
 
+       At the time the event fires, the bookkeeping structures are already
+       updated; this implies that :meth:`on_group_removed` fires *before*
+       :meth:`on_entry_removed_from_group` if the removal of an entry from a
+       group causes the group to vanish.
+
     .. signal:: on_entry_removed(item)
 
        Fires after an entry has been removed from the roster. The entry is
        already removed from all bookkeeping structures, but the values on the
        `item` object are the same as right before the removal.
+
+       This implies that :meth:`on_group_removed` fires *before*
+       :meth:`on_entry_removed` if the removal of an entry causes a group to
+       vanish.
+
+    .. signal:: on_group_added(group)
+
+        Fires after a new group has been added to the bookkeeping structures.
+
+        :param group: Name of the new group.
+        :type group: :class:`str`
+
+        At the time the event fires, the group is empty.
+
+        .. versionadded:: 0.9
+
+    .. signal:: on_group_removed(group)
+
+        Fires after a new group has been removed from the bookkeeping
+        structures.
+
+        :param group: Name of the old group.
+        :type group: :class:`str`
+
+        At the time the event fires, the group is empty.
+
+        .. versionadded:: 0.9
 
     Modifying roster contents:
 
@@ -353,6 +393,9 @@ class RosterClient(aioxmpp.service.Service):
     on_entry_added_to_group = callbacks.Signal()
     on_entry_removed_from_group = callbacks.Signal()
 
+    on_group_added = callbacks.Signal()
+    on_group_removed = callbacks.Signal()
+
     on_subscribed = callbacks.Signal()
     on_subscribe = callbacks.Signal()
     on_unsubscribed = callbacks.Signal()
@@ -376,7 +419,12 @@ class RosterClient(aioxmpp.service.Service):
             stored_item = Item.from_xso_item(xso_item)
             self.items[xso_item.jid] = stored_item
             for group in stored_item.groups:
-                self.groups.setdefault(group, set()).add(stored_item)
+                try:
+                    group_members = self.groups[group]
+                except KeyError:
+                    group_members = self.groups.setdefault(group, set())
+                    self.on_group_added(group)
+                group_members.add(stored_item)
             self.on_entry_added(stored_item)
             return
 
@@ -403,7 +451,12 @@ class RosterClient(aioxmpp.service.Service):
             cb(stored_item)
 
         for group in added_to_groups:
-            self.groups.setdefault(group, set()).add(stored_item)
+            try:
+                group_members = self.groups[group]
+            except KeyError:
+                group_members = self.groups.setdefault(group, set())
+                self.on_group_added(group)
+            group_members.add(stored_item)
             self.on_entry_added_to_group(stored_item, group)
 
         for group in removed_from_groups:
@@ -411,6 +464,7 @@ class RosterClient(aioxmpp.service.Service):
             groupset.remove(stored_item)
             if not groupset:
                 del self.groups[group]
+                self.on_group_removed(group)
             self.on_entry_removed_from_group(stored_item, group)
 
     @aioxmpp.service.iq_handler(
@@ -470,6 +524,7 @@ class RosterClient(aioxmpp.service.Service):
             group_members.remove(item_to_remove)
             if not group_members:
                 del self.groups[group]
+                self.on_group_removed(group)
 
     @asyncio.coroutine
     def _request_initial_roster(self):

--- a/aioxmpp/roster/service.py
+++ b/aioxmpp/roster/service.py
@@ -465,6 +465,16 @@ class RosterClient(aioxmpp.service.Service):
     def handle_unsubscribe(self, stanza):
         self.on_unsubscribe(stanza)
 
+    def _remove_from_groups(self, item_to_remove, groups):
+        for group in groups:
+            try:
+                group_members = self.groups[group]
+            except KeyError:
+                continue
+            group_members.remove(item_to_remove)
+            if not group_members:
+                del self.groups[group]
+
     @asyncio.coroutine
     def _request_initial_roster(self):
         iq = stanza.IQ(type_=structs.IQType.GET)
@@ -498,6 +508,7 @@ class RosterClient(aioxmpp.service.Service):
 
         for removed_jid in removed_jids:
             old_item = self.items.pop(removed_jid)
+            self._remove_from_groups(old_item, old_item.groups)
             self.on_entry_removed(old_item)
 
         logger.debug("jids updated: %r", actual_jids - removed_jids)

--- a/aioxmpp/roster/service.py
+++ b/aioxmpp/roster/service.py
@@ -182,7 +182,7 @@ class RosterClient(aioxmpp.service.Service):
 
     .. attribute:: items
 
-       A dictionary mapping :class:`~aioxmpp.JID instances to corresponding
+       A dictionary mapping :class:`~aioxmpp.JID` instances to corresponding
        :class:`Item` instances.
 
     .. attribute:: groups

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -106,6 +106,24 @@ def run_coroutine_with_peer(
     return local_future.result()
 
 
+def make_listener(instance):
+    """
+    Return a :class:`unittest.mock.Mock` which has children connected to each
+    :class:`aioxmpp.callbacks.Signal` of `instance`.
+
+    The children are named exactly like the signals.
+    """
+    result = unittest.mock.Mock()
+    for name, obj in type(instance).__dict__.items():
+        if not isinstance(obj, callbacks.Signal):
+            continue
+        cb = getattr(result, name)
+        cb.return_value = None
+        getattr(instance, name).connect(cb)
+    return result
+
+
+
 class FilterMock(unittest.mock.Mock):
     def __init__(self):
         super().__init__([

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -107,6 +107,9 @@ Version 0.9
 
 * **Breaking change:** Re-design of interface to :mod:`aioxmpp.muc`.
 
+* Fix :attr:`aioxmpp.RosterClient.groups` not being updated when items are
+  removed during initial roster update.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -110,6 +110,9 @@ Version 0.9
 * Fix :attr:`aioxmpp.RosterClient.groups` not being updated when items are
   removed during initial roster update.
 
+* :meth:`aioxmpp.RosterClient.on_group_added`,
+  :meth:`~aioxmpp.RosterClient.on_group_removed`.
+
 .. _api-changelog-0.8:
 
 Version 0.8


### PR DESCRIPTION
The main point is to provide ``on_group_added`` and ``on_group_removed`` signals in ``RosterClient``. While implementing that, I stumbled across the fact that the ``groups`` data structure does not get updated when an entry is removed from the roster during the initial roster update.