### PR TITLE
Refactor EntityCapsService to decouple XEP-0115-specifics from core

### DIFF
--- a/aioxmpp/entitycaps/__init__.py
+++ b/aioxmpp/entitycaps/__init__.py
@@ -59,10 +59,10 @@ by the implementation.
 
 In general, you will not need to use these classes directly, nor encounter
 them, as the service filters them off the presence stanzas. If the filter is
-not loaded, the :class:`Caps` instance is available at
+not loaded, the :class:`Caps115` instance is available at
 :attr:`.Presence.xep0115_caps`.
 
-.. autoclass:: Caps
+.. autoclass:: Caps115
 
 
 """

--- a/aioxmpp/entitycaps/caps115.py
+++ b/aioxmpp/entitycaps/caps115.py
@@ -1,0 +1,119 @@
+########################################################################
+# File name: caps115.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import base64
+import hashlib
+
+from xml.sax.saxutils import escape
+
+
+def build_identities_string(identities):
+    identities = [
+        b"/".join([
+            escape(identity.category).encode("utf-8"),
+            escape(identity.type_).encode("utf-8"),
+            escape(str(identity.lang or "")).encode("utf-8"),
+            escape(identity.name or "").encode("utf-8"),
+        ])
+        for identity in identities
+    ]
+
+    if len(set(identities)) != len(identities):
+        raise ValueError("duplicate identity")
+
+    identities.sort()
+    identities.append(b"")
+    return b"<".join(identities)
+
+
+def build_features_string(features):
+    features = list(escape(feature).encode("utf-8") for feature in features)
+
+    if len(set(features)) != len(features):
+        raise ValueError("duplicate feature")
+
+    features.sort()
+    features.append(b"")
+    return b"<".join(features)
+
+
+def build_forms_string(forms):
+    types = set()
+    forms_list = []
+    for form in forms:
+        try:
+            form_types = set(
+                value
+                for field in form.fields.filter(attrs={"var": "FORM_TYPE"})
+                for value in field.values
+            )
+        except KeyError:
+            continue
+
+        if len(form_types) > 1:
+            raise ValueError("form with multiple types")
+        elif not form_types:
+            continue
+
+        type_ = escape(next(iter(form_types))).encode("utf-8")
+        if type_ in types:
+            raise ValueError("multiple forms of type {!r}".format(type_))
+        types.add(type_)
+        forms_list.append((type_, form))
+    forms_list.sort()
+
+    parts = []
+
+    for type_, form in forms_list:
+        parts.append(type_)
+
+        field_list = sorted(
+            (
+                (escape(field.var).encode("utf-8"), field.values)
+                for field in form.fields
+                if field.var != "FORM_TYPE"
+            ),
+            key=lambda x: x[0]
+        )
+
+        for var, values in field_list:
+            parts.append(var)
+            parts.extend(sorted(
+                escape(value).encode("utf-8") for value in values
+            ))
+
+    parts.append(b"")
+    return b"<".join(parts)
+
+
+def hash_query(query, algo):
+    hashimpl = hashlib.new(algo)
+    hashimpl.update(
+        build_identities_string(query.identities)
+    )
+    hashimpl.update(
+        build_features_string(query.features)
+    )
+    hashimpl.update(
+        build_forms_string(query.exts)
+    )
+
+    return base64.b64encode(hashimpl.digest()).decode("ascii")

--- a/aioxmpp/entitycaps/common.py
+++ b/aioxmpp/entitycaps/common.py
@@ -1,0 +1,105 @@
+########################################################################
+# File name: common.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import abc
+
+
+class AbstractKey(metaclass=abc.ABCMeta):
+    @abc.abstractproperty
+    def path(self):
+        """
+        Return the file system path relative to the root of a file-system based
+        caps database for this key.
+
+        The path includes all information of the key. Components of the path do
+        not exceed 255 codepoints and use only ASCII codepoints.
+
+        If it is not possible to create such a path, :class:`ValueError` is
+        raised.
+        """
+
+    @abc.abstractmethod
+    def verify(self, query_response):
+        """
+        Verify whether the cache key maches a piece of service discovery
+        information.
+
+        :param query_response: The full :xep:`30` disco#info query response.
+        :type query_response: :class:`~.disco.xso.InfoQuery`
+        :rtype: :class:`bool`
+        :return: true if the key matches and false otherwise.
+        """
+
+
+class AbstractImplementation(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def extract_keys(self, presence):
+        """
+        Extract cache keys from a presence stanza.
+
+        :param presence: Presence stanza to extract cache keys from.
+        :type presence: :class:`aioxmpp.Presence`
+        :rtype: :class:`~collections.abc.Iterable` of :class:`AbstractKey`
+        :return: The cache keys from the presence stanza.
+
+        The resulting iterable may be empty if the presence stanza does not
+        carry any capabilities information with it.
+
+        The resulting iterable cannot be iterated over multiple times.
+        """
+
+    @abc.abstractmethod
+    def put_keys(self, keys, presence):
+        """
+        Insert cache keys into a presence stanza.
+
+        :param keys: An iterable of cache keys to insert.
+        :type keys: :class:`~collections.abc.Iterable` of :class:`AbstractKey`
+            objects
+        :param presence: The presence stanza into which the cache keys shall be
+            injected.
+        :type presence: :class:`aioxmpp.Presence`
+
+        The presence stanza is modified in-place.
+        """
+
+    @abc.abstractmethod
+    def calculate_keys(self, query_response):
+        """
+        Calculate the cache keys for a disco#info response.
+
+        :param query_response: The full :xep:`30` disco#info query response.
+        :type query_response: :class:`~.disco.xso.InfoQuery`
+        :rtype: :class:`~collections.abc.Iterable` of :class:`AbstractKey`
+        :return: An iterable of the cache keys for the disco#info response.
+
+        ..
+
+            :param identities: The identities of the disco#info response.
+            :type identities: :class:`~collections.abc.Iterable` of
+                :class:`~.disco.xso.Identity`
+            :param features: The features of the disco#info response.
+            :type features: :class:`~collections.abc.Iterable` of
+                :class:`str`
+            :param features: The extensions of the disco#info response.
+            :type features: :class:`~collections.abc.Iterable` of
+                :class:`~.forms.xso.Data`
+        """

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -436,7 +436,7 @@ class EntityCapsService(aioxmpp.service.Service):
         if (self.ver is not None and
                 presence.type_ == aioxmpp.structs.PresenceType.AVAILABLE):
             self.logger.debug("injecting capabilities into outbound presence")
-            presence.xep0115_caps = my_xso.Caps(
+            presence.xep0115_caps = my_xso.Caps115(
                 self.NODE,
                 self.ver,
                 "sha-1",

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -20,16 +20,12 @@
 #
 ########################################################################
 import asyncio
-import base64
 import copy
 import functools
-import hashlib
 import logging
 import os
 import tempfile
 import urllib.parse
-
-from xml.sax.saxutils import escape
 
 import aioxmpp.callbacks
 import aioxmpp.disco as disco
@@ -38,103 +34,10 @@ import aioxmpp.xml
 import aioxmpp.xso
 
 from . import xso as my_xso
+from . import caps115
 
 
 logger = logging.getLogger("aioxmpp.entitycaps")
-
-
-def build_identities_string(identities):
-    identities = [
-        b"/".join([
-            escape(identity.category).encode("utf-8"),
-            escape(identity.type_).encode("utf-8"),
-            escape(str(identity.lang or "")).encode("utf-8"),
-            escape(identity.name or "").encode("utf-8"),
-        ])
-        for identity in identities
-    ]
-
-    if len(set(identities)) != len(identities):
-        raise ValueError("duplicate identity")
-
-    identities.sort()
-    identities.append(b"")
-    return b"<".join(identities)
-
-
-def build_features_string(features):
-    features = list(escape(feature).encode("utf-8") for feature in features)
-
-    if len(set(features)) != len(features):
-        raise ValueError("duplicate feature")
-
-    features.sort()
-    features.append(b"")
-    return b"<".join(features)
-
-
-def build_forms_string(forms):
-    types = set()
-    forms_list = []
-    for form in forms:
-        try:
-            form_types = set(
-                value
-                for field in form.fields.filter(attrs={"var": "FORM_TYPE"})
-                for value in field.values
-            )
-        except KeyError:
-            continue
-
-        if len(form_types) > 1:
-            raise ValueError("form with multiple types")
-        elif not form_types:
-            continue
-
-        type_ = escape(next(iter(form_types))).encode("utf-8")
-        if type_ in types:
-            raise ValueError("multiple forms of type {!r}".format(type_))
-        types.add(type_)
-        forms_list.append((type_, form))
-    forms_list.sort()
-
-    parts = []
-
-    for type_, form in forms_list:
-        parts.append(type_)
-
-        field_list = sorted(
-            (
-                (escape(field.var).encode("utf-8"), field.values)
-                for field in form.fields
-                if field.var != "FORM_TYPE"
-            ),
-            key=lambda x: x[0]
-        )
-
-        for var, values in field_list:
-            parts.append(var)
-            parts.extend(sorted(
-                escape(value).encode("utf-8") for value in values
-            ))
-
-    parts.append(b"")
-    return b"<".join(parts)
-
-
-def hash_query(query, algo):
-    hashimpl = hashlib.new(algo)
-    hashimpl.update(
-        build_identities_string(query.identities)
-    )
-    hashimpl.update(
-        build_features_string(query.features)
-    )
-    hashimpl.update(
-        build_forms_string(query.exts)
-    )
-
-    return base64.b64encode(hashimpl.digest()).decode("ascii")
 
 
 class Cache:
@@ -399,7 +302,7 @@ class EntityCapsService(aioxmpp.service.Service):
             require_fresh=True)
 
         try:
-            expected = hash_query(data, hash_.replace("-", ""))
+            expected = caps115.hash_query(data, hash_.replace("-", ""))
         except ValueError as exc:
             fut.set_exception(exc)
         else:
@@ -479,7 +382,7 @@ class EntityCapsService(aioxmpp.service.Service):
             features=self.disco_server.iter_features(),
         )
 
-        new_ver = hash_query(
+        new_ver = caps115.hash_query(
             info,
             "sha1",
         )

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -76,14 +76,14 @@ class Cache:
         self._system_db_path = None
         self._user_db_path = None
 
-    def _erase_future(self, for_hash, for_node, fut):
+    def _erase_future(self, key, fut):
         try:
-            existing = self._lookup_cache[for_hash, for_node]
+            existing = self._lookup_cache[key]
         except KeyError:
             pass
         else:
             if existing is fut:
-                del self._lookup_cache[for_hash, for_node]
+                del self._lookup_cache[key]
 
     def set_system_db_path(self, path):
         self._system_db_path = path
@@ -91,44 +91,45 @@ class Cache:
     def set_user_db_path(self, path):
         self._user_db_path = path
 
-    def lookup_in_database(self, hash_, node):
+    def lookup_in_database(self, key):
         try:
-            result = self._memory_overlay[hash_, node]
+            result = self._memory_overlay[key]
         except KeyError:
             pass
         else:
-            logger.debug("memory cache hit: %s %r", hash_, node)
+            logger.debug("memory cache hit: %s", key)
             return result
 
-        quoted = urllib.parse.quote(node, safe="")
+        key_path = key.path
+
         if self._system_db_path is not None:
             try:
                 f = (
-                    self._system_db_path / "{}_{}.xml".format(hash_, quoted)
+                    self._system_db_path / key_path
                 ).open("rb")
             except OSError:
                 pass
             else:
-                logger.debug("system db hit: %s %r", hash_, node)
+                logger.debug("system db hit: %s", key)
                 with f:
                     return aioxmpp.xml.read_single_xso(f, disco.xso.InfoQuery)
 
         if self._user_db_path is not None:
             try:
                 f = (
-                    self._user_db_path / "{}_{}.xml".format(hash_, quoted)
+                    self._user_db_path / key_path
                 ).open("rb")
             except OSError:
                 pass
             else:
-                logger.debug("user db hit: %s %r", hash_, node)
+                logger.debug("user db hit: %s", key)
                 with f:
                     return aioxmpp.xml.read_single_xso(f, disco.xso.InfoQuery)
 
-        raise KeyError(node)
+        raise KeyError(key)
 
     @asyncio.coroutine
-    def lookup(self, hash_, node):
+    def lookup(self, key):
         """
         Look up the given `node` URL using the given `hash_` first in the
         database and then by waiting on the futures created with
@@ -141,14 +142,14 @@ class Cache:
         is used as the result.
         """
         try:
-            result = self.lookup_in_database(hash_, node)
+            result = self.lookup_in_database(key)
         except KeyError:
             pass
         else:
             return result
 
         while True:
-            fut = self._lookup_cache[hash_, node]
+            fut = self._lookup_cache[key]
             try:
                 result = yield from fut
             except ValueError:
@@ -156,7 +157,7 @@ class Cache:
             else:
                 return result
 
-    def create_query_future(self, hash_, node):
+    def create_query_future(self, key):
         """
         Create and return a :class:`asyncio.Future` for the given `hash_`
         function and `node` URL. The future is referenced internally and used
@@ -168,12 +169,12 @@ class Cache:
         """
         fut = asyncio.Future()
         fut.add_done_callback(
-            functools.partial(self._erase_future, hash_, node)
+            functools.partial(self._erase_future, key)
         )
-        self._lookup_cache[hash_, node] = fut
+        self._lookup_cache[key] = fut
         return fut
 
-    def add_cache_entry(self, hash_, node, entry):
+    def add_cache_entry(self, key, entry):
         """
         Add the given `entry` (which must be a :class:`~.disco.xso.InfoQuery`
         instance) to the user-level database keyed with the hash function type
@@ -182,15 +183,12 @@ class Cache:
         that the caller perfoms the validation.
         """
         copied_entry = copy.copy(entry)
-        copied_entry.node = node
-        self._memory_overlay[hash_, node] = copied_entry
+        self._memory_overlay[key] = copied_entry
         if self._user_db_path is not None:
             asyncio.async(asyncio.get_event_loop().run_in_executor(
                 None,
                 writeback,
-                self._user_db_path,
-                hash_,
-                node,
+                self._user_db_path / key.path,
                 entry.captured_events))
 
 
@@ -247,7 +245,7 @@ class EntityCapsService(aioxmpp.service.Service):
     def __init__(self, node, **kwargs):
         super().__init__(node, **kwargs)
 
-        self.ver = None
+        self.__current_keys = None
         self._cache = Cache()
 
         self.disco_server = self.dependencies[disco.DiscoServer]
@@ -255,6 +253,8 @@ class EntityCapsService(aioxmpp.service.Service):
         self.disco_server.register_feature(
             "http://jabber.org/protocol/caps"
         )
+
+        self.__115 = caps115.Implementation(self.NODE)
 
     @property
     def cache(self):
@@ -289,80 +289,65 @@ class EntityCapsService(aioxmpp.service.Service):
         self.disco_server.unregister_feature(
             "http://jabber.org/protocol/caps"
         )
-        if self.ver is not None:
-            self.disco_server.unmount_node(
-                self.NODE + "#" + self.ver
-            )
+        if self.__current_keys:
+            for key in self.__current_keys:
+                self.disco_server.unmount_node(key.node)
 
     @asyncio.coroutine
-    def query_and_cache(self, jid, node, ver, hash_, fut):
+    def query_and_cache(self, jid, key, fut):
         data = yield from self.disco_client.query_info(
             jid,
-            node=node+"#"+ver,
+            node=key.node,
             require_fresh=True)
 
         try:
-            expected = caps115.hash_query(data, hash_.replace("-", ""))
-        except ValueError as exc:
-            fut.set_exception(exc)
-        else:
-            if expected == ver:
-                self.cache.add_cache_entry(hash_, node+"#"+ver, data)
+            if key.verify(data):
+                self.cache.add_cache_entry(key, data)
                 fut.set_result(data)
             else:
-                fut.set_exception(ValueError("hash mismatch"))
+                raise ValueError("hash mismatch")
+        except ValueError as exc:
+            fut.set_exception(exc)
 
         return data
 
     @asyncio.coroutine
-    def lookup_info(self, jid, node, ver, hash_):
-        try:
-            info = yield from self.cache.lookup(hash_, node+"#"+ver)
-        except KeyError:
-            pass
-        else:
-            self.logger.debug("found ver=%r in cache", ver)
+    def lookup_info(self, jid, keys):
+        for key in keys:
+            try:
+                info = yield from self.cache.lookup(key)
+            except KeyError:
+                continue
+
+            self.logger.debug("found %s in cache", key)
             return info
 
-        self.logger.debug("have to query for ver=%r", ver)
-        fut = self.cache.create_query_future(hash_, node+"#"+ver)
+        first_key = keys[0]
+        self.logger.debug("using key %s to query peer", first_key)
+        fut = self.cache.create_query_future(first_key)
         info = yield from self.query_and_cache(
-            jid, node, ver, hash_,
-            fut
+            jid, first_key, fut
         )
-        self.logger.debug("ver=%r maps to %r", ver, info)
+        self.logger.debug("%s maps to %r", key, info)
 
         return info
 
     @aioxmpp.service.outbound_presence_filter
     def handle_outbound_presence(self, presence):
-        if (self.ver is not None and
-                presence.type_ == aioxmpp.structs.PresenceType.AVAILABLE):
+        if (presence.type_ == aioxmpp.structs.PresenceType.AVAILABLE and
+                self.__current_keys):
             self.logger.debug("injecting capabilities into outbound presence")
-            presence.xep0115_caps = my_xso.Caps115(
-                self.NODE,
-                self.ver,
-                "sha-1",
-            )
+            self.__115.put_keys(self.__current_keys, presence)
 
         return presence
 
     @aioxmpp.service.inbound_presence_filter
     def handle_inbound_presence(self, presence):
-        caps = presence.xep0115_caps
-
-        if caps is not None and caps.hash_ is not None:
-            self.logger.debug(
-                "inbound presence with ver=%r and hash=%r from %s",
-                caps.ver, caps.hash_,
-                presence.from_)
-            task = asyncio.async(
-                self.lookup_info(presence.from_,
-                                 caps.node,
-                                 caps.ver,
-                                 caps.hash_)
-            )
-            self.disco_client.set_info_future(presence.from_, None, task)
+        keys = list(self.__115.extract_keys(presence))
+        lookup_task = asyncio.async(
+            self.lookup_info(presence.from_, keys)
+        )
+        self.disco_client.set_info_future(presence.from_, None, lookup_task)
 
         return presence
 
@@ -382,19 +367,17 @@ class EntityCapsService(aioxmpp.service.Service):
             features=self.disco_server.iter_features(),
         )
 
-        new_ver = caps115.hash_query(
-            info,
-            "sha1",
-        )
+        current_keys = frozenset(self.__115.calculate_keys(info))
 
-        self.logger.debug("new ver=%r (features=%r)", new_ver, info.features)
+        self.logger.debug("new keys=%r", current_keys)
 
-        if self.ver != new_ver:
-            if self.ver is not None:
-                self.disco_server.unmount_node(self.NODE + "#" + self.ver)
-            self.ver = new_ver
-            self.disco_server.mount_node(self.NODE + "#" + self.ver,
-                                         self.disco_server)
+        if self.__current_keys != current_keys:
+            if self.__current_keys:
+                for key in self.__current_keys:
+                    self.disco_server.unmount_node(key.node)
+            self.__current_keys = current_keys
+            for key in current_keys:
+                self.disco_server.mount_node(key.node, self.disco_server)
             self.on_ver_changed()
 
 

--- a/aioxmpp/entitycaps/xso.py
+++ b/aioxmpp/entitycaps/xso.py
@@ -28,7 +28,7 @@ from aioxmpp.utils import namespaces
 namespaces.xep0115_caps = "http://jabber.org/protocol/caps"
 
 
-class Caps(xso.XSO):
+class Caps115(xso.XSO):
     """
     An entity capabilities extension for :class:`~.Presence`.
 
@@ -72,4 +72,4 @@ class Caps(xso.XSO):
         self.hash_ = hash_
 
 
-stanza.Presence.xep0115_caps = xso.Child([Caps], required=False)
+stanza.Presence.xep0115_caps = xso.Child([Caps115], required=False)

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -779,3 +779,16 @@ class XMLStreamMock(InteractivityMock):
         fut = asyncio.Future()
         self._error_futures.append(fut)
         return fut
+
+
+if not hasattr(unittest.mock.Mock, "assert_not_called"):
+    def _assert_not_called(m):
+        if any(not call[0] for call in m.mock_calls):
+            raise AssertionError(
+                "expected {!r} to not have been called. "
+                "Called {} times".format(
+                    m._mock_name or 'mock',
+                    m.call_count)
+            )
+    unittest.mock.Mock.assert_not_called = _assert_not_called
+    del _assert_not_called

--- a/tests/entitycaps/test_caps115.py
+++ b/tests/entitycaps/test_caps115.py
@@ -1,0 +1,569 @@
+########################################################################
+# File name: test_caps115.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import contextlib
+import functools
+import unittest
+import unittest.mock
+
+import aioxmpp.disco as disco
+import aioxmpp.entitycaps.caps115 as caps115
+import aioxmpp.forms.xso as forms_xso
+import aioxmpp.structs as structs
+
+
+class Testbuild_identities_string(unittest.TestCase):
+    def test_identities(self):
+        identities = [
+            disco.xso.Identity(category="fnord",
+                               type_="bar"),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp library"),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp Bibliothek",
+                               lang=structs.LanguageTag.fromstr("de-de")),
+        ]
+
+        self.assertEqual(
+            b"client/bot//aioxmpp library<"
+            b"client/bot/de-de/aioxmpp Bibliothek<"
+            b"fnord/bar//<",
+            caps115.build_identities_string(identities)
+        )
+
+    def test_escaping(self):
+        identities = [
+            disco.xso.Identity(category="fnord",
+                               type_="bar"),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp library > 0.5"),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp Bibliothek <& 0.5",
+                               lang=structs.LanguageTag.fromstr("de-de")),
+        ]
+
+        self.assertEqual(
+            b"client/bot//aioxmpp library &gt; 0.5<"
+            b"client/bot/de-de/aioxmpp Bibliothek &lt;&amp; 0.5<"
+            b"fnord/bar//<",
+            caps115.build_identities_string(identities)
+        )
+
+    def test_reject_duplicate_identities(self):
+        identities = [
+            disco.xso.Identity(category="fnord",
+                               type_="bar"),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp library > 0.5"),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp Bibliothek <& 0.5",
+                               lang=structs.LanguageTag.fromstr("de-de")),
+            disco.xso.Identity(category="client",
+                               type_="bot",
+                               name="aioxmpp library > 0.5"),
+        ]
+
+        with self.assertRaisesRegex(ValueError,
+                                    "duplicate identity"):
+            caps115.build_identities_string(identities)
+
+
+class Testbuild_features_string(unittest.TestCase):
+    def test_features(self):
+        features = [
+            "http://jabber.org/protocol/disco#info",
+            "http://jabber.org/protocol/caps",
+            "http://jabber.org/protocol/disco#items",
+        ]
+
+        self.assertEqual(
+            b"http://jabber.org/protocol/caps<"
+            b"http://jabber.org/protocol/disco#info<"
+            b"http://jabber.org/protocol/disco#items<",
+            caps115.build_features_string(features)
+        )
+
+    def test_escaping(self):
+        features = [
+            "http://jabber.org/protocol/c<>&aps",
+        ]
+
+        self.assertEqual(
+            b"http://jabber.org/protocol/c&lt;&gt;&amp;aps<",
+            caps115.build_features_string(features)
+        )
+
+    def test_reject_duplicate_features(self):
+        features = [
+            "http://jabber.org/protocol/disco#info",
+            "http://jabber.org/protocol/caps",
+            "http://jabber.org/protocol/disco#items",
+            "http://jabber.org/protocol/caps",
+        ]
+
+        with self.assertRaisesRegex(ValueError,
+                                    "duplicate feature"):
+            caps115.build_features_string(features)
+
+
+class Testbuild_forms_string(unittest.TestCase):
+    def test_xep_form(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM)]
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os",
+                values=[
+                    "Mac",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="ip_version",
+                values=[
+                    "ipv4",
+                    "ipv6",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="software",
+                values=[
+                    "Psi",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="software_version",
+                values=[
+                    "0.11",
+                ]
+            ),
+        ])
+
+        self.assertEqual(
+            b"urn:xmpp:dataforms:softwareinfo<"
+            b"ip_version<ipv4<ipv6<"
+            b"os<Mac<"
+            b"os_version<10.5.1<"
+            b"software<Psi<"
+            b"software_version<0.11<",
+            caps115.build_forms_string(forms)
+        )
+
+    def test_value_and_var_escaping(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM)]
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:<dataforms:softwareinfo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.&5.1",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os>",
+                values=[
+                    "Mac",
+                ]
+            ),
+        ])
+
+        self.assertEqual(
+            b"urn:xmpp:&lt;dataforms:softwareinfo<"
+            b"os&gt;<Mac<"
+            b"os_version<10.&amp;5.1<",
+            caps115.build_forms_string(forms)
+        )
+
+    def test_reject_multiple_identical_form_types(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM),
+                 forms_xso.Data(type_=forms_xso.DataType.FORM)]
+
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os",
+                values=[
+                    "Mac",
+                ]
+            ),
+        ])
+
+        forms[1].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os",
+                values=[
+                    "Mac",
+                ]
+            ),
+        ])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "multiple forms of type b'urn:xmpp:dataforms:softwareinfo'"):
+            caps115.build_forms_string(forms)
+
+    def test_reject_form_with_multiple_different_types(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM)]
+
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo",
+                    "urn:xmpp:dataforms:softwarefoo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os",
+                values=[
+                    "Mac",
+                ]
+            ),
+        ])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                "form with multiple types"):
+            caps115.build_forms_string(forms)
+
+    def test_ignore_form_without_type(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM),
+                 forms_xso.Data(type_=forms_xso.DataType.FORM)]
+
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+        ])
+
+        forms[1].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os",
+                values=[
+                    "Mac",
+                ]
+            ),
+        ])
+
+        self.assertEqual(
+            b"urn:xmpp:dataforms:softwareinfo<"
+            b"os<Mac<"
+            b"os_version<10.5.1<",
+            caps115.build_forms_string(forms)
+        )
+
+    def test_accept_form_with_multiple_identical_types(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM)]
+
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo",
+                    "urn:xmpp:dataforms:softwareinfo",
+                ]
+            ),
+
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+        ])
+
+        caps115.build_forms_string(forms)
+
+    def test_multiple(self):
+        forms = [forms_xso.Data(type_=forms_xso.DataType.FORM),
+                 forms_xso.Data(type_=forms_xso.DataType.FORM)]
+
+        forms[0].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "uri:foo",
+                ]
+            ),
+        ])
+
+        forms[1].fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "uri:bar",
+                ]
+            ),
+        ])
+
+        self.assertEqual(
+            b"uri:bar<uri:foo<",
+            caps115.build_forms_string(forms)
+        )
+
+
+class Testhash_query(unittest.TestCase):
+    def test_impl(self):
+        self.maxDiff = None
+        base = unittest.mock.Mock()
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch(
+                "aioxmpp.entitycaps.caps115.build_identities_string",
+                new=base.build_identities_string,
+            ))
+
+            stack.enter_context(unittest.mock.patch(
+                "aioxmpp.entitycaps.caps115.build_features_string",
+                new=base.build_features_string,
+            ))
+
+            stack.enter_context(unittest.mock.patch(
+                "aioxmpp.entitycaps.caps115.build_forms_string",
+                new=base.build_forms_string,
+            ))
+
+            stack.enter_context(unittest.mock.patch(
+                "hashlib.new",
+                new=base.hashlib_new,
+            ))
+
+            stack.enter_context(unittest.mock.patch(
+                "base64.b64encode",
+                new=base.base64_b64encode,
+            ))
+
+            result = caps115.hash_query(
+                base.query,
+                base.algo
+            )
+
+        calls = list(base.mock_calls)
+        self.assertSequenceEqual(
+            calls,
+            [
+                unittest.mock.call.hashlib_new(base.algo),
+                unittest.mock.call.build_identities_string(
+                    base.query.identities,
+                ),
+                unittest.mock.call.hashlib_new().update(
+                    base.build_identities_string()
+                ),
+                unittest.mock.call.build_features_string(
+                    base.query.features
+                ),
+                unittest.mock.call.hashlib_new().update(
+                    base.build_features_string()
+                ),
+                unittest.mock.call.build_forms_string(
+                    base.query.exts
+                ),
+                unittest.mock.call.hashlib_new().update(
+                    base.build_forms_string()
+                ),
+                unittest.mock.call.hashlib_new().digest(),
+                unittest.mock.call.base64_b64encode(
+                    base.hashlib_new().digest()
+                ),
+                unittest.mock.call.base64_b64encode().decode("ascii")
+            ]
+        )
+
+        self.assertEqual(
+            result,
+            base.base64_b64encode().decode()
+        )
+
+    def test_simple_xep_data(self):
+        info = disco.xso.InfoQuery()
+        info.identities.extend([
+            disco.xso.Identity(category="client",
+                               name="Exodus 0.9.1",
+                               type_="pc"),
+        ])
+
+        info.features.update({
+                "http://jabber.org/protocol/caps",
+                "http://jabber.org/protocol/disco#info",
+                "http://jabber.org/protocol/disco#items",
+                "http://jabber.org/protocol/muc",
+        })
+
+        self.assertEqual(
+            "QgayPKawpkPSDYmwT/WM94uAlu0=",
+            caps115.hash_query(info, "sha1")
+        )
+
+    def test_complex_xep_data(self):
+        info = disco.xso.InfoQuery()
+        info.identities.extend([
+            disco.xso.Identity(category="client",
+                               name="Psi 0.11",
+                               type_="pc",
+                               lang=structs.LanguageTag.fromstr("en")),
+            disco.xso.Identity(category="client",
+                               name="Ψ 0.11",
+                               type_="pc",
+                               lang=structs.LanguageTag.fromstr("el")),
+        ])
+
+        info.features.update({
+            "http://jabber.org/protocol/caps",
+            "http://jabber.org/protocol/disco#info",
+            "http://jabber.org/protocol/disco#items",
+            "http://jabber.org/protocol/muc",
+        })
+
+        ext_form = forms_xso.Data(type_=forms_xso.DataType.FORM)
+
+        ext_form.fields.extend([
+            forms_xso.Field(
+                var="FORM_TYPE",
+                values=[
+                    "urn:xmpp:dataforms:softwareinfo"
+                ]
+            ),
+
+            forms_xso.Field(
+                var="ip_version",
+                values=[
+                    "ipv6",
+                    "ipv4",
+                ]
+            ),
+            forms_xso.Field(
+                var="os",
+                values=[
+                    "Mac"
+                ]
+            ),
+            forms_xso.Field(
+                var="os_version",
+                values=[
+                    "10.5.1",
+                ]
+            ),
+            forms_xso.Field(
+                var="software",
+                values=[
+                    "Psi",
+                ]
+            ),
+            forms_xso.Field(
+                var="software_version",
+                values=[
+                    "0.11"
+                ]
+            ),
+        ])
+
+        info.exts.append(ext_form)
+
+        self.assertEqual(
+            "q07IKJEyjvHSyhy//CH0CxmKi8w=",
+            caps115.hash_query(info, "sha1")
+        )

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -83,10 +83,6 @@ class TestEntityCapabilities(TestCase):
         self.assertIsNotNone(
             presence.xep0115_caps,
         )
-        self.assertEqual(
-            presence.xep0115_caps.ver,
-            caps_server.ver,
-        )
 
         info = yield from disco_client.query_info(
             self.source.local_jid,

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -22,6 +22,8 @@
 import asyncio
 
 import aioxmpp.stream
+import aioxmpp.entitycaps as caps
+import aioxmpp.disco as disco
 
 from aioxmpp.e2etest import (
     blocking_timed,
@@ -97,3 +99,77 @@ class TestEntityCapabilities(TestCase):
             info.features,
             set(disco_server.iter_features()),
         )
+
+    @blocking_timed
+    @asyncio.coroutine
+    def test_caps_are_processed_when_received(self):
+        info = disco.xso.InfoQuery()
+        info.features.add("http://feature.test/feature")
+        info.features.add("http://feature.test/another-feature")
+
+        info_hash = caps.caps115.hash_query(info, "sha1")
+
+        disco_called = asyncio.Future()
+        disco_called_again = False
+
+        @asyncio.coroutine
+        def fake_disco_handler(iq):
+            nonlocal disco_called_again
+            if not disco_called.done():
+                disco_called.set_result(iq)
+            else:
+                disco_called_again = True
+            return info
+
+        self.source, self.sink = yield from asyncio.gather(
+            self.provisioner.get_connected_client(
+                services=[
+                    aioxmpp.PresenceServer,
+                ]
+            ),
+            self.provisioner.get_connected_client(
+                services=[
+                    aioxmpp.EntityCapsService,
+                    aioxmpp.PresenceServer,
+                    aioxmpp.PresenceClient,
+                ]
+            )
+        )
+
+        self.source.stream.register_iq_request_coro(
+            aioxmpp.IQType.GET,
+            disco.xso.InfoQuery,
+            fake_disco_handler,
+        )
+
+        presence = aioxmpp.Presence(
+            type_=aioxmpp.PresenceType.AVAILABLE,
+            to=self.sink.local_jid,
+        )
+        presence.xep0115_caps = caps.xso.Caps115(
+            "http://test",
+            info_hash,
+            "sha-1",
+        )
+
+        yield from self.source.stream.send(presence)
+
+        info_request = (yield from disco_called).payload
+        self.assertEqual(
+            info_request.node,
+            "http://test#{}".format(info_hash)
+        )
+
+        disco_client = self.sink.summon(aioxmpp.DiscoClient)
+        info1 = yield from disco_client.query_info(
+            self.source.local_jid,
+            node="http://test#{}".format(info_hash),
+        )
+        self.assertEqual(info1.features, info.features)
+
+        info2 = yield from disco_client.query_info(
+            self.source.local_jid,
+        )
+        self.assertEqual(info2.features, info.features)
+
+        self.assertFalse(disco_called_again)

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -1145,7 +1145,7 @@ class TestService(unittest.TestCase):
         self.assertIs(self.s.cache, c)
 
     def test_handle_inbound_presence_queries_disco(self):
-        caps = entitycaps_xso.Caps(
+        caps = entitycaps_xso.Caps115(
             TEST_DB_ENTRY_NODE_BARE,
             TEST_DB_ENTRY_VER,
             TEST_DB_ENTRY_HASH,
@@ -1215,7 +1215,7 @@ class TestService(unittest.TestCase):
         self.assertIsNone(presence.xep0115_caps)
 
     def test_handle_inbound_presence_discards_if_hash_unset(self):
-        caps = entitycaps_xso.Caps(
+        caps = entitycaps_xso.Caps115(
             TEST_DB_ENTRY_NODE_BARE,
             TEST_DB_ENTRY_VER,
             TEST_DB_ENTRY_HASH,
@@ -1224,7 +1224,7 @@ class TestService(unittest.TestCase):
         # we have to hack deeply here, the validators are too smart for us
         # it is still possible to receive such a stanza, as the validator is
         # set to FROM_CODE
-        caps._xso_contents[entitycaps_xso.Caps.hash_.xq_descriptor] = None
+        caps._xso_contents[entitycaps_xso.Caps115.hash_.xq_descriptor] = None
         self.assertIsNone(caps.hash_)
 
         presence = stanza.Presence()
@@ -1715,7 +1715,7 @@ class TestService(unittest.TestCase):
 
         self.assertIsInstance(
             presence.xep0115_caps,
-            entitycaps_xso.Caps
+            entitycaps_xso.Caps115
         )
         self.assertEqual(
             presence.xep0115_caps.ver,

--- a/tests/entitycaps/test_xso.py
+++ b/tests/entitycaps/test_xso.py
@@ -36,80 +36,80 @@ class TestNamespaces(unittest.TestCase):
         )
 
 
-class TestCaps(unittest.TestCase):
+class TestCaps115(unittest.TestCase):
     def test_is_xso(self):
         self.assertTrue(issubclass(
-            entitycaps_xso.Caps,
+            entitycaps_xso.Caps115,
             xso.XSO
         ))
 
     def test_tag(self):
         self.assertEqual(
             (namespaces.xep0115_caps, "c"),
-            entitycaps_xso.Caps.TAG
+            entitycaps_xso.Caps115.TAG
         )
 
     def test_node_attr(self):
         self.assertIsInstance(
-            entitycaps_xso.Caps.node,
+            entitycaps_xso.Caps115.node,
             xso.Attr
         )
         self.assertEqual(
             (None, "node"),
-            entitycaps_xso.Caps.node.tag
+            entitycaps_xso.Caps115.node.tag
         )
         self.assertIs(
-            entitycaps_xso.Caps.node.default,
+            entitycaps_xso.Caps115.node.default,
             xso.NO_DEFAULT
         )
 
     def test_hash_attr(self):
         self.assertIsInstance(
-            entitycaps_xso.Caps.hash_,
+            entitycaps_xso.Caps115.hash_,
             xso.Attr
         )
         self.assertEqual(
             (None, "hash"),
-            entitycaps_xso.Caps.hash_.tag
+            entitycaps_xso.Caps115.hash_.tag
         )
         self.assertIsInstance(
-            entitycaps_xso.Caps.hash_.validator,
+            entitycaps_xso.Caps115.hash_.validator,
             xso.Nmtoken
         )
         self.assertEqual(
             xso.ValidateMode.FROM_CODE,
-            entitycaps_xso.Caps.hash_.validate
+            entitycaps_xso.Caps115.hash_.validate
         )
         self.assertIs(
-            entitycaps_xso.Caps.hash_.default,
+            entitycaps_xso.Caps115.hash_.default,
             None
         )
 
     def test_ver_attr(self):
         self.assertIsInstance(
-            entitycaps_xso.Caps.ver,
+            entitycaps_xso.Caps115.ver,
             xso.Attr
         )
         self.assertEqual(
             (None, "ver"),
-            entitycaps_xso.Caps.ver.tag
+            entitycaps_xso.Caps115.ver.tag
         )
         self.assertIs(
-            entitycaps_xso.Caps.ver.default,
+            entitycaps_xso.Caps115.ver.default,
             xso.NO_DEFAULT
         )
 
     def test_ext_attr(self):
         self.assertIsInstance(
-            entitycaps_xso.Caps.ext,
+            entitycaps_xso.Caps115.ext,
             xso.Attr
         )
         self.assertEqual(
             (None, "ext"),
-            entitycaps_xso.Caps.ext.tag
+            entitycaps_xso.Caps115.ext.tag
         )
         self.assertIs(
-            entitycaps_xso.Caps.ext.default,
+            entitycaps_xso.Caps115.ext.default,
             None
         )
 
@@ -120,13 +120,13 @@ class TestCaps(unittest.TestCase):
         )
         self.assertSetEqual(
             {
-                entitycaps_xso.Caps
+                entitycaps_xso.Caps115
             },
             set(stanza.Presence.xep0115_caps._classes)
         )
 
     def test_init(self):
-        caps = entitycaps_xso.Caps(
+        caps = entitycaps_xso.Caps115(
             "node",
             "ver",
             "hash",
@@ -138,4 +138,4 @@ class TestCaps(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError,
                                     "positional argument"):
-            entitycaps_xso.Caps()
+            entitycaps_xso.Caps115()

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -1050,3 +1050,14 @@ class TestCoroutineMock(unittest.TestCase):
             ],
             m.mock_calls
         )
+
+
+class TestMockMonkeyPatches(unittest.TestCase):
+    def test_assert_not_called_works(self):
+        m = unittest.mock.Mock()
+        m.assert_not_called()
+        self.assertFalse(m.mock_calls)
+
+        m()
+        with self.assertRaises(AssertionError):
+            m.assert_not_called()


### PR DESCRIPTION
This is the first step towards #76. It doesn’t address any issues with entitycaps support as-is, but refactors for easier improvements later on.