### PR TITLE
Support for XEP-0390 (Entity Capabilities 2.0)

### DIFF
--- a/aioxmpp/disco/__init__.py
+++ b/aioxmpp/disco/__init__.py
@@ -78,6 +78,8 @@ Entity information
 
 .. autoclass:: register_feature
 
+.. autoclass:: RegisteredFeature
+
 .. module:: aioxmpp.disco.xso
 
 .. currentmodule:: aioxmpp.disco.xso
@@ -114,4 +116,4 @@ Item queries
 
 from . import xso  # NOQA
 from .service import (DiscoClient, DiscoServer, Node, StaticNode,  # NOQA
-                      mount_as_node, register_feature)
+                      mount_as_node, register_feature, RegisteredFeature)

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -430,6 +430,7 @@ class DiscoServer(service.Service, Node):
             )
 
         response = node.as_info_xso(iq)
+        response.node = request.node
 
         if not response.identities:
             raise errors.XMPPModifyError(

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -794,6 +794,32 @@ class RegisteredFeature:
     :param feature: The feature to register.
     :type feature: :class:`str`
 
+    .. note::
+
+        Normally, you would not create an instance of this object manually.
+        Use the :class:`register_feature` descriptor on your
+        :class:`aioxmpp.Service` which will provide a
+        :class:`RegisteredFeature` object::
+
+            class Foo(aioxmpp.Service):
+                _some_feature = aioxmpp.disco.register_feature(
+                    "urn:of:the:feature"
+                )
+
+                # after __init__, self._some_feature is a RegisteredFeature
+                # instance.
+
+                @property
+                def some_feature_enabled(self):
+                    # better do not expose the enabled boolean directly; this
+                    # gives you the opportunity to do additional things when it
+                    # is changed, such as disabling multiple features at once.
+                    return self._some_feature.enabled
+
+                @some_feature_enabled.setter
+                def some_feature_enabled(self, value):
+                    self._some_feature.enabled = value
+
     .. versionadded:: 0.9
 
     This object can be used as a context manager. Upon entering the context,

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -96,7 +96,8 @@ class Node(object):
 
         :param stanza: The IQ request stanza
         :type stanza: :class:`~aioxmpp.IQ` or :data:`None`
-        :rtype: iterable of (:class:`str`, :class:`str`, :class:`str` or :data:`None`, :class:`str` or :data:`None`) tuples
+        :rtype: iterable of (:class:`str`, :class:`str`, :class:`str` or
+            :data:`None`, :class:`str` or :data:`None`) tuples
         :return: :xep:`30` identities of this node
 
         `stanza` can be the :class:`aioxmpp.IQ` stanza of the request. This can
@@ -265,6 +266,8 @@ class StaticNode(Node):
        It is the responsibility of the user to ensure that the set of items is
        valid. This includes avoiding duplicate items.
 
+    .. automethod:: clone
+
     """
 
     def __init__(self):
@@ -273,6 +276,39 @@ class StaticNode(Node):
 
     def iter_items(self, stanza=None):
         return iter(self.items)
+
+    @classmethod
+    def clone(cls, other_node):
+        """
+        Clone another :class:`Node` and return as :class:`StaticNode`.
+
+        :param other_node: The node which shall be cloned
+        :type other_node: :class:`Node`
+        :rtype: :class:`StaticNode`
+        :return: A static node which has the exact same features, identities
+            and items as `other_node`.
+
+        The features and identities are copied over into the resulting
+        :class:`StaticNode`. The items of `other_node` are not copied but
+        merely referenced, so changes to the item *objects* of `other_node`
+        will be reflected in the result.
+
+        .. versionadded:: 0.9
+        """
+
+        result = cls()
+        result._features = {
+            feature for feature in other_node.iter_features()
+            if feature not in cls.STATIC_FEATURES
+        }
+        for category, type_, lang, name in other_node.iter_identities():
+            names = result._identities.setdefault(
+                (category, type_),
+                aioxmpp.structs.LanguageMap()
+            )
+            names[lang] = name
+        result.items = list(other_node.iter_items())
+        return result
 
 
 class DiscoServer(service.Service, Node):

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -61,6 +61,8 @@ class Node(object):
 
     .. automethod:: iter_identities
 
+    .. automethod:: as_info_xso
+
     To access items, use:
 
     .. automethod:: iter_items
@@ -252,6 +254,42 @@ class Node(object):
             raise ValueError("cannot remove last identity")
         del self._identities[key]
         self.on_info_changed()
+
+    def as_info_xso(self, stanza=None):
+        """
+        Construct a :class:`~.disco.xso.InfoQuery` response object for this
+        node.
+
+        :param stanza: The IQ request stanza
+        :type stanza: :class:`~aioxmpp.IQ`
+        :rtype: iterable of :class:`~.disco.xso.InfoQuery`
+        :return: The disco#info response for this node.
+
+        The resulting :class:`~.disco.xso.InfoQuery` carries the features and
+        identities as returned by :meth:`iter_features` and
+        :meth:`iter_identities`. The :attr:`~.disco.xso.InfoQuery.node`
+        attribute is at its default value and may need to be set by the caller
+        accordingly.
+
+        `stanza` is passed to :meth:`iter_features` and
+        :meth:`iter_identities`. See those methods for information on the
+        effects.
+
+        .. versionadded:: 0.9
+        """
+
+        result = disco_xso.InfoQuery()
+        result.features.update(self.iter_features(stanza))
+        result.identities[:] = (
+            disco_xso.Identity(
+                category=category,
+                type_=type_,
+                lang=lang,
+                name=name,
+            )
+            for category, type_, lang, name in self.iter_identities(stanza)
+        )
+        return result
 
 
 class StaticNode(Node):

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -429,22 +429,12 @@ class DiscoServer(service.Service, Node):
                 condition=(namespaces.stanzas, "item-not-found")
             )
 
-        response = disco_xso.InfoQuery()
-
-        for category, type_, lang, name in node.iter_identities(iq):
-            response.identities.append(disco_xso.Identity(
-                category=category,
-                type_=type_,
-                lang=lang,
-                name=name
-            ))
+        response = node.as_info_xso(iq)
 
         if not response.identities:
             raise errors.XMPPModifyError(
                 condition=(namespaces.stanzas, "item-not-found"),
             )
-
-        response.features.update(node.iter_features(iq))
 
         return response
 

--- a/aioxmpp/e2etest/__init__.py
+++ b/aioxmpp/e2etest/__init__.py
@@ -324,7 +324,7 @@ def setup_package():
                 "this is not the aioxmpp test runner"
         return
 
-    timeout = config.get("global", "timeout", fallback=timeout)
+    timeout = config.getfloat("global", "timeout", fallback=timeout)
 
     provisioner_name = config.get("global", "provisioner")
     module_path, class_name = provisioner_name.rsplit(".", 1)

--- a/aioxmpp/entitycaps/__init__.py
+++ b/aioxmpp/entitycaps/__init__.py
@@ -20,14 +20,19 @@
 #
 ########################################################################
 """
-:mod:`~aioxmpp.entitycaps` --- Entity Capabilities support (:xep:`0115`)
-########################################################################
+:mod:`~aioxmpp.entitycaps` --- Entity Capabilities support (:xep:`390`, :xep:`0115`)
+####################################################################################
 
-This module provides support for :xep:`XEP-0115 (Entity Capabilities) <0115>`.
-To use it, :meth:`.Client.summon` the :class:`EntityCapsService` on a
+This module provides support for :xep:`XEP-0115 (Entity Capabilities) <0115>`
+and :xep:`XEP-0390 (Entity Capabilities 2.0) <0390>`. To use it,
+:meth:`.Client.summon` the :class:`aioxmpp.EntityCapsService` on a
 :class:`~.Client`. See the service documentation for more information.
 
 .. versionadded:: 0.5
+
+.. versionchanged:: 0.9
+
+    Support for :xep:`390` was added.
 
 Service
 =======
@@ -49,20 +54,6 @@ Service
 .. autoclass:: Cache
 
 .. currentmodule:: aioxmpp.entitycaps.xso
-
-:mod:`.entitycaps.xso` --- Presence payload
-===========================================
-
-The submodule :mod:`aioxmpp.entitycaps.xso` contains the
-:class:`~aioxmpp.xso.XSO` subclasses which describe the presence payload used
-by the implementation.
-
-In general, you will not need to use these classes directly, nor encounter
-them, as the service filters them off the presence stanzas. If the filter is
-not loaded, the :class:`Caps115` instance is available at
-:attr:`.Presence.xep0115_caps`.
-
-.. autoclass:: Caps115
 
 
 """

--- a/aioxmpp/entitycaps/caps390.py
+++ b/aioxmpp/entitycaps/caps390.py
@@ -1,0 +1,191 @@
+########################################################################
+# File name: caps390.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import base64
+import pathlib
+import collections
+import urllib.parse
+
+import aioxmpp.hashes
+
+from .common import AbstractKey
+from . import xso as caps_xso
+
+
+def _process_features(features):
+    """
+    Generate the `Features String` from an iterable of features.
+
+    :param features: The features to generate the features string from.
+    :type features: :class:`~collections.abc.Iterable` of :class:`str`
+    :return: The `Features String`
+    :rtype: :class:`bytes`
+
+    Generate the `Features String` from the given `features` as specified in
+    :xep:`390`.
+    """
+    parts = [
+        feature.encode("utf-8")+b"\x1f"
+        for feature in features
+    ]
+    parts.sort()
+    return b"".join(parts)+b"\x1c"
+
+
+def _process_identity(identity):
+    category = (identity.category or "").encode("utf-8")+b"\x1f"
+    type_ = (identity.type_ or "").encode("utf-8")+b"\x1f"
+    lang = str(identity.lang or "").encode("utf-8")+b"\x1f"
+    name = (identity.name or "").encode("utf-8")+b"\x1f"
+
+    return b"".join([category, type_, lang, name]) + b"\x1e"
+
+
+def _process_identities(identities):
+    """
+    Generate the `Identities String` from an iterable of identities.
+
+    :param identities: The identities to generate the features string from.
+    :type identities: :class:`~collections.abc.Iterable` of
+        :class:`~.disco.xso.Identity`
+    :return: The `Identities String`
+    :rtype: :class:`bytes`
+
+    Generate the `Identities String` from the given `identities` as specified
+    in :xep:`390`.
+    """
+    parts = [
+        _process_identity(identity)
+        for identity in identities
+    ]
+    parts.sort()
+    return b"".join(parts)+b"\x1c"
+
+
+def _process_field(field):
+    parts = [
+        (value or "").encode("utf-8") + b"\x1f"
+        for value in field.values
+    ]
+
+    parts.insert(0, field.var.encode("utf-8")+b"\x1f")
+    return b"".join(parts)+b"\x1e"
+
+
+def _process_form(form):
+    parts = [
+        _process_field(form)
+        for form in form.fields
+    ]
+
+    parts.sort()
+    return b"".join(parts)+b"\x1d"
+
+
+def _process_extensions(exts):
+    """
+    Generate the `Extensions String` from an iterable of data forms.
+
+    :param exts: The data forms to generate the extensions string from.
+    :type exts: :class:`~collections.abc.Iterable` of
+        :class:`~.forms.xso.Data`
+    :return: The `Extensions String`
+    :rtype: :class:`bytes`
+
+    Generate the `Extensions String` from the given `exts` as specified
+    in :xep:`390`.
+    """
+    parts = [
+        _process_form(form)
+        for form in exts
+    ]
+    parts.sort()
+    return b"".join(parts)+b"\x1c"
+
+
+def _get_hash_input(info):
+    return b"".join([
+        _process_features(info.features),
+        _process_identities(info.identities),
+        _process_extensions(info.exts)
+    ])
+
+
+def _calculate_hash(algo, hash_input):
+    impl = aioxmpp.hashes.hash_from_algo(algo)
+    impl.update(hash_input)
+    return impl.digest()
+
+
+Key = collections.namedtuple("Key", ["algo", "digest"])
+
+
+class Key(Key, AbstractKey):
+    @property
+    def node(self):
+        return "urn:xmpp:caps#{}.{}".format(
+            self.algo,
+            base64.b64encode(self.digest).decode("ascii")
+        )
+
+    @property
+    def path(self):
+        encoded = base64.b32encode(
+            self.digest
+        ).decode("ascii").rstrip("=").lower()
+        return (pathlib.Path("caps2") /
+                urllib.parse.quote(self.algo, safe="") /
+                encoded[:2] /
+                encoded[2:4] /
+                "{}.xml".format(encoded[4:]))
+
+    def verify(self, info):
+        if not isinstance(info, bytes):
+            info = _get_hash_input(info)
+        digest = _calculate_hash(self.algo, info)
+        return digest == self.digest
+
+
+class Implementation:
+    def __init__(self, algorithms, **kwargs):
+        super().__init__(**kwargs)
+        self.__algorithms = algorithms
+
+    def extract_keys(self, presence):
+        if presence.xep0390_caps is None:
+            return ()
+
+        return (
+            Key(algo, digest)
+            for algo, digest in presence.xep0390_caps.digests.items()
+        )
+
+    def put_keys(self, keys, presence):
+        presence.xep0390_caps = caps_xso.Caps390()
+        presence.xep0390_caps.digests.update({
+            key.algo: key.digest
+            for key in keys
+        })
+
+    def calculate_keys(self, query_response):
+        input = _get_hash_input(query_response)
+        for algo in self.__algorithms:
+            yield Key(algo, _calculate_hash(algo, input))

--- a/aioxmpp/entitycaps/caps390.py
+++ b/aioxmpp/entitycaps/caps390.py
@@ -176,6 +176,7 @@ class Implementation:
         return (
             Key(algo, digest)
             for algo, digest in presence.xep0390_caps.digests.items()
+            if aioxmpp.hashes.is_algo_supported(algo)
         )
 
     def put_keys(self, keys, presence):

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -272,6 +272,8 @@ class EntityCapsService(aioxmpp.service.Service):
         self.__active_hashsets = []
         self.__key_users = collections.Counter()
 
+        self.__delayed_update_hash = None
+
     @property
     def xep115_support(self):
         """
@@ -346,8 +348,14 @@ class EntityCapsService(aioxmpp.service.Service):
         "on_info_changed")
     def _info_changed(self):
         self.logger.debug("info changed, scheduling re-calculation of version")
-        asyncio.get_event_loop().call_soon(
-            self.update_hash
+
+        if self.__delayed_update_hash is not None:
+            self.__delayed_update_hash.cancel()
+
+        loop = asyncio.get_event_loop()
+        self.__delayed_update_hash = loop.call_later(
+            0.1,
+            self.update_hash,
         )
 
     @asyncio.coroutine

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -231,22 +231,6 @@ class EntityCapsService(aioxmpp.service.Service):
 
     .. autoattribute:: xep390_support
 
-    .. attribute:: update_delay
-        :annotation: = 0.1
-
-        Number of seconds (can be a float) by which the update of the
-        Capability Hash Set is delayed.
-
-        This is used to rate-limit the generation of caps-related presences. It
-        can be set to 0 ot effectively remove that rate-limit if rate-limiting
-        is applied elsewhere, but using a rate-limit is encouraged.
-
-        The Capability Hash Set is updated `update_delay` seconds after the
-        most recent change to the features/identities set on the
-        :class:`aioxmpp.DiscoServer`. That means if you those are changed in
-        intervals of ``0.9*update_delay``, the Capability Hash Set is never
-        updated.
-
     .. versionchanged:: 0.8
 
        This class was formerly known as :class:`aioxmpp.entitycaps.Service`. It
@@ -272,13 +256,6 @@ class EntityCapsService(aioxmpp.service.Service):
     _xep390_feature = disco.register_feature(namespaces.xep0390_caps)
 
     def __init__(self, node, **kwargs):
-        # this **must** be set before calling the inherited __init__, because
-        # that will trigger a call to _info_changed (due to our registration
-        # of features)
-        # the initial update shall happen quickly
-        self.__delayed_update_hash = None
-        self.update_delay = 0.01
-
         super().__init__(node, **kwargs)
 
         self.__current_keys = {}
@@ -295,7 +272,7 @@ class EntityCapsService(aioxmpp.service.Service):
         self.__active_hashsets = []
         self.__key_users = collections.Counter()
 
-        self.update_delay = 0.1
+        self.__delayed_update_hash = None
 
     @property
     def xep115_support(self):
@@ -377,7 +354,7 @@ class EntityCapsService(aioxmpp.service.Service):
 
         loop = asyncio.get_event_loop()
         self.__delayed_update_hash = loop.call_later(
-            self.update_delay,
+            0.1,
             self.update_hash,
         )
 

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -231,6 +231,22 @@ class EntityCapsService(aioxmpp.service.Service):
 
     .. autoattribute:: xep390_support
 
+    .. attribute:: update_delay
+        :annotation: = 0.1
+
+        Number of seconds (can be a float) by which the update of the
+        Capability Hash Set is delayed.
+
+        This is used to rate-limit the generation of caps-related presences. It
+        can be set to 0 ot effectively remove that rate-limit if rate-limiting
+        is applied elsewhere, but using a rate-limit is encouraged.
+
+        The Capability Hash Set is updated `update_delay` seconds after the
+        most recent change to the features/identities set on the
+        :class:`aioxmpp.DiscoServer`. That means if you those are changed in
+        intervals of ``0.9*update_delay``, the Capability Hash Set is never
+        updated.
+
     .. versionchanged:: 0.8
 
        This class was formerly known as :class:`aioxmpp.entitycaps.Service`. It
@@ -256,6 +272,13 @@ class EntityCapsService(aioxmpp.service.Service):
     _xep390_feature = disco.register_feature(namespaces.xep0390_caps)
 
     def __init__(self, node, **kwargs):
+        # this **must** be set before calling the inherited __init__, because
+        # that will trigger a call to _info_changed (due to our registration
+        # of features)
+        # the initial update shall happen quickly
+        self.__delayed_update_hash = None
+        self.update_delay = 0.01
+
         super().__init__(node, **kwargs)
 
         self.__current_keys = {}
@@ -272,7 +295,7 @@ class EntityCapsService(aioxmpp.service.Service):
         self.__active_hashsets = []
         self.__key_users = collections.Counter()
 
-        self.__delayed_update_hash = None
+        self.update_delay = 0.1
 
     @property
     def xep115_support(self):
@@ -354,7 +377,7 @@ class EntityCapsService(aioxmpp.service.Service):
 
         loop = asyncio.get_event_loop()
         self.__delayed_update_hash = loop.call_later(
-            0.1,
+            self.update_delay,
             self.update_hash,
         )
 

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -272,8 +272,6 @@ class EntityCapsService(aioxmpp.service.Service):
         self.__active_hashsets = []
         self.__key_users = collections.Counter()
 
-        self.__delayed_update_hash = None
-
     @property
     def xep115_support(self):
         """
@@ -348,14 +346,8 @@ class EntityCapsService(aioxmpp.service.Service):
         "on_info_changed")
     def _info_changed(self):
         self.logger.debug("info changed, scheduling re-calculation of version")
-
-        if self.__delayed_update_hash is not None:
-            self.__delayed_update_hash.cancel()
-
-        loop = asyncio.get_event_loop()
-        self.__delayed_update_hash = loop.call_later(
-            0.1,
-            self.update_hash,
+        asyncio.get_event_loop().call_soon(
+            self.update_hash
         )
 
     @asyncio.coroutine

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -433,7 +433,8 @@ class EntityCapsService(aioxmpp.service.Service):
         return presence
 
     def update_hash(self):
-        info = self.disco_server.as_info_xso()
+        node = disco.StaticNode.clone(self.disco_server)
+        info = node.as_info_xso()
 
         new_keys = {}
 
@@ -458,7 +459,7 @@ class EntityCapsService(aioxmpp.service.Service):
 
         for group in new_keys.values():
             for key in group:
-                self.disco_server.mount_node(key.node, self.disco_server)
+                self.disco_server.mount_node(key.node, node)
 
         self.on_ver_changed()
 

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -226,11 +226,19 @@ class EntityCapsService(aioxmpp.service.Service):
 
     .. autoattribute:: cache
 
+    .. autoattribute:: xep115_support
+
+    .. autoattribute:: xep390_support
+
     .. versionchanged:: 0.8
 
        This class was formerly known as :class:`aioxmpp.entitycaps.Service`. It
        is still available under that name, but the alias will be removed in
        1.0.
+
+    .. versionchanged:: 0.9
+
+        Support for :xep:`390` was added.
 
     """
 
@@ -262,6 +270,28 @@ class EntityCapsService(aioxmpp.service.Service):
 
     @property
     def xep115_support(self):
+        """
+        Boolean to control whether :xep:`115` support is enabled or not.
+
+        Defaults to :data:`True`.
+
+        If set to false, inbound :xep:`115` capabilities will not be processed
+        and no :xep:`115` capabilities will be emitted.
+
+        .. note::
+
+            At some point, this will default to :data:`False` to save
+            bandwidth. The exact release depends on the adoption of :xep:`390`
+            and will be announced in time. If you depend on :xep:`115` support,
+            set this boolean to :data:`True`.
+
+            The attribute itself will not be removed until :xep:`115` support
+            is removed from :mod:`aioxmpp` entirely, which is unlikely to
+            happen any time soon.
+
+        .. versionadded:: 0.9
+        """
+
         return self._xep115_feature.enabled
 
     @xep115_support.setter
@@ -270,6 +300,18 @@ class EntityCapsService(aioxmpp.service.Service):
 
     @property
     def xep390_support(self):
+        """
+        Boolean to control whether :xep:`390` support is enabled or not.
+
+        Defaults to :data:`True`.
+
+        If set to false, inbound :xep:`390` Capability Hash Sets will not be
+        processed and no Capability Hash Sets or Capability Nodes will be
+        generated.
+
+        The hash algortihms used for generating Capability Hash Sets are those
+        from :data:`aioxmpp.hashes.default_hash_algorithms`.
+        """
         return self._xep390_feature.enabled
 
     @xep390_support.setter

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -208,8 +208,20 @@ class EntityCapsService(aioxmpp.service.Service):
        :meth:`on_ver_changed` signal and re-emit their current presence when it
        fires.
 
+       .. note::
+
+           Keeping peers up-to-date is a MUST in :xep:`390`.
+
        The service takes care of attaching capabilities information on the
        outgoing stanza, using a stanza filter.
+
+       .. warning::
+
+           :meth:`on_ver_changed` may be emitted at a considerable rate when
+           services are loaded or certain features (such as PEP-based services)
+           are configured. It is up to the application to limit the rate at
+           which presences are sent for the sole purpose of updating peers with
+           new capability information.
 
     2. Users should use a process-wide :class:`Cache` instance and assign it to
        the :attr:`cache` of each :class:`.entitycaps.Service` they use. This

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -433,20 +433,7 @@ class EntityCapsService(aioxmpp.service.Service):
         return presence
 
     def update_hash(self):
-        identities = []
-        for category, type_, lang, name in self.disco_server.iter_identities():
-            identity = disco.xso.Identity(category=category,
-                                          type_=type_)
-            if lang is not None:
-                identity.lang = lang
-            if name is not None:
-                identity.name = name
-            identities.append(identity)
-
-        info = disco.xso.InfoQuery(
-            identities=identities,
-            features=self.disco_server.iter_features(),
-        )
+        info = self.disco_server.as_info_xso()
 
         new_keys = {}
 

--- a/aioxmpp/entitycaps/xso.py
+++ b/aioxmpp/entitycaps/xso.py
@@ -19,6 +19,7 @@
 # <http://www.gnu.org/licenses/>.
 #
 ########################################################################
+import aioxmpp.hashes
 import aioxmpp.stanza as stanza
 import aioxmpp.xso as xso
 
@@ -26,6 +27,7 @@ from aioxmpp.utils import namespaces
 
 
 namespaces.xep0115_caps = "http://jabber.org/protocol/caps"
+namespaces.xep0390_caps = "urn:xmpp:caps"
 
 
 class Caps115(xso.XSO):
@@ -72,4 +74,9 @@ class Caps115(xso.XSO):
         self.hash_ = hash_
 
 
-stanza.Presence.xep0115_caps = xso.Child([Caps115], required=False)
+class Caps390(aioxmpp.hashes.HashesParent, xso.XSO):
+    TAG = namespaces.xep0390_caps, "c"
+
+
+stanza.Presence.xep0115_caps = xso.Child([Caps115])
+stanza.Presence.xep0390_caps = xso.Child([Caps390])

--- a/aioxmpp/hashes.py
+++ b/aioxmpp/hashes.py
@@ -1,0 +1,263 @@
+########################################################################
+# File name: hashes.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+"""
+:mod:`~aioxmpp.hashes` --- Hash Functions for use with XMPP (:xep:`300`)
+########################################################################
+
+:xep:`300` consolidates the use of hash functions and their digests in XMPP.
+Identifiers (usually called `algo`) are defined to refer to specific
+implementations and parametrisations of hashes (:func:`hash_from_algo`,
+:func:`algo_of_hash`) and there is a defined XML format for carrying hash
+digests (:class:`Hash`).
+
+This allows other extensions to easily embed hash digests in their protocols
+(:class:`HashesParent`).
+
+.. note::
+
+    Compliance with :xep:`300` depends on your build of Python and possibly
+    OpenSSL. Version 0.5.1 of :xep:`300` requires support of SHA3 and BLAKE2b,
+    which was only introduced in Python 3.6.
+
+Utilities for Working with Hash Algorithm Identifiers
+=====================================================
+
+.. autofunction:: hash_from_algo
+
+.. autofunction:: algo_of_hash
+
+.. data:: default_hash_algorithms
+
+    A set of `algo` values which consists of hash functions matching the
+    following criteria:
+
+    * They are specified as ``MUST`` or ``SHOULD`` in the supported version of
+      :xep:`300`.
+    * They are supported by :mod:`hashlib`.
+    * Only one function from each matching family is selected. If multiple
+      functions apply, ``MUST`` is preferred over ``SHOULD``.
+
+    The set thus varies based on the build of Python and possibly OpenSSL. The
+    algorithms in the set are guaranteed to return a valid hash implementation
+    when passed to :func:`~aioxmpp.misc.hash_from_algo`.
+
+    In a fully compliant build, this set consists of ``sha-256``, ``sha3-256``
+    and ``blake2b-256``.
+
+XSOs
+====
+
+.. autoclass:: Hash
+
+.. autoclass:: HashesParent()
+"""
+import hashlib
+
+import aioxmpp.xso as xso
+
+from aioxmpp.utils import namespaces
+
+namespaces.xep0300_hashes2 = "urn:xmpp:hashes:2"
+
+
+_HASH_ALGO_MAPPING = [
+    ("md2", (False, ("md2", (), {}))),
+    ("md4", (False, ("md4", (), {}))),
+    ("md5", (False, ("md5", (), {}))),
+    ("sha-1", (True, ("sha1", (), {}))),
+    ("sha-224", (True, ("sha224", (), {}))),
+    ("sha-256", (True, ("sha256", (), {}))),
+    ("sha-384", (True, ("sha384", (), {}))),
+    ("sha-512", (True, ("sha512", (), {}))),
+    ("sha3-256", (True, ("sha3_256", (), {}))),
+    ("sha3-512", (True, ("sha3_512", (), {}))),
+    ("blake2b-256", (True, ("blake2b", (), {"digest_size": 32}))),
+    ("blake2b-512", (True, ("blake2b", (), {"digest_size": 64}))),
+]
+
+
+_HASH_ALGO_MAP = dict(_HASH_ALGO_MAPPING)
+_HASH_ALGO_REVERSE_MAP = {
+    fun_name: (enabled, algo)
+    for algo, (enabled, (fun_name, fun_args, fun_kwargs)) in _HASH_ALGO_MAPPING
+    if not fun_args and not fun_kwargs
+}
+
+
+def is_algo_supported(algo):
+    try:
+        enabled, (fun_name, _, _) = _HASH_ALGO_MAP[algo]
+    except KeyError:
+        return False
+
+    return enabled and hasattr(hashlib, fun_name)
+
+
+def hash_from_algo(algo):
+    """
+    Return a :mod:`hashlib` hash given the :xep:`300` `algo`.
+
+    :param algo: The algorithm identifier as defined in :xep:`300`.
+    :type algo: :class:`str`
+    :raises NotImplementedError: if the hash algortihm is not supported by
+        :mod:`hashlib`.
+    :raises ValueError: if the hash algorithm MUST NOT be supported.
+    :return: A hash object from :mod:`hashlib` or compatible.
+
+    If the `algo` is not supported by the :mod:`hashlib` module,
+    :class:`NotImplementedError` is raised.
+    """
+
+    try:
+        enabled, (fun_name, fun_args, fun_kwargs) = _HASH_ALGO_MAP[algo]
+    except KeyError as exc:
+        raise NotImplementedError(
+            "hash algorithm {!r} unknown".format(algo)
+        ) from None
+
+    if not enabled:
+        raise ValueError(
+            "support of {} in XMPP is forbidden".format(algo)
+        )
+
+    try:
+        fun = getattr(hashlib, fun_name)
+    except AttributeError as exc:
+        raise NotImplementedError(
+            "{} not supported by hashlib".format(algo)
+        ) from exc
+
+    return fun(*fun_args, **fun_kwargs)
+
+
+def algo_of_hash(h):
+    """
+    Return a :xep:`300` `algo` from a given :mod:`hashlib` hash.
+
+    :param h: Hash object from :mod:`hashlib`.
+    :raises ValueError: if `h` does not have a defined `algo` value.
+    :raises ValueError: if the hash function MUST NOT be supported.
+    :return: The `algo` value for the given hash.
+    :rtype: :class:`str`
+
+    .. warning::
+
+        Use with caution for :func:`hashlib.blake2b` hashes.
+        :func:`algo_of_hash` cannot safely determine whether blake2b was
+        initialised with a salt, personality, key or other non-default
+        :xep:`300` mode.
+
+        In such a case, the return value will be the matching ``blake2b-*``
+        `algo`, but the digest will not be compatible with the results of other
+        implementations.
+
+    """
+    try:
+        enabled, algo = _HASH_ALGO_REVERSE_MAP[h.name]
+    except KeyError:
+        pass
+    else:
+        if not enabled:
+            raise ValueError("support of {} in XMPP is forbidden".format(
+                algo
+            ))
+        return algo
+
+    if h.name == "blake2b":
+        return "blake2b-{}".format(h.digest_size * 8)
+
+    raise ValueError(
+        "unknown hash implementation: {!r}".format(h)
+    )
+
+
+class Hash(xso.XSO):
+    """
+    Represent a single hash digest.
+
+    .. attribute:: algo
+
+        The hash algorithm used. The name is as specified in :xep:`300`.
+
+    .. attribute:: digest
+
+        The digest as :class:`bytes`.
+
+    """
+
+    TAG = namespaces.xep0300_hashes2, "hash"
+
+    algo = xso.Attr(
+        "algo",
+    )
+
+    digest = xso.Text(
+        type_=xso.Base64Binary()
+    )
+
+    def __init__(self, algo, digest):
+        super().__init__()
+        self.algo = algo
+        self.digest = digest
+
+    def get_impl(self):
+        """
+        Return a new :mod:`hashlib` hash for the :attr:`algo` set on this
+        object.
+
+        See :func:`hash_from_algo` for details and exceptions.
+        """
+        return hash_from_algo(self.algo)
+
+
+class HashType(xso.AbstractType):
+    @classmethod
+    def get_formatted_type(cls):
+        return Hash
+
+    def parse(self, obj):
+        return obj.algo, obj.digest
+
+    def format(self, pair):
+        return Hash(*pair)
+
+
+class HashesParent(xso.XSO):
+    """
+    Mix-in class for XSOs which use :class:`Hash` children.
+
+    .. attribute:: digests
+
+        A mapping which maps from the :attr:`Hash.algo` to the
+        :attr:`Hash.digest`.
+    """
+
+    digests = xso.ChildValueMap(
+        type_=HashType(),
+    )
+
+
+default_hash_algorithms = {
+    algo
+    for algo in ["sha-256", "sha3-256", "blake2b-256"]
+    if is_algo_supported(algo)
+}

--- a/aioxmpp/misc/__init__.py
+++ b/aioxmpp/misc/__init__.py
@@ -27,11 +27,6 @@ This subpackage bundles XSO definitions for several XEPs. They do not get their
 own subpackage because they often only define one or two XSOs without any logic
 involved. The XSOs are often intended for re-use by other protocols.
 
-Stanza Forwarding (:xep:`297`)
-==============================
-
-.. autoclass:: Forwarded()
-
 
 Delayed Delivery (:xep:`203`)
 =============================
@@ -42,6 +37,12 @@ Delayed Delivery (:xep:`203`)
 
    A :class:`Delay` instance which indicates that the message has been
    delivered with delay.
+
+
+Stanza Forwarding (:xep:`297`)
+==============================
+
+.. autoclass:: Forwarded()
 
 
 """

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -125,6 +125,9 @@ Version 0.9
   to temporarily or permanently disable the registration of the feature on a
   service object.
 
+* **Breaking change:** Re-design of :class:`aioxmpp.entitycaps` to support
+  :xep:`390`. The interface of the :class:`aioxmpp.entitycaps.Cache` class has
+  been redesigned and some internal classes and functions have been renamed.
 
 .. _api-changelog-0.8:
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -129,6 +129,8 @@ Version 0.9
   :xep:`390`. The interface of the :class:`aioxmpp.entitycaps.Cache` class has
   been redesigned and some internal classes and functions have been renamed.
 
+* :meth:`aioxmpp.disco.StaticNode.clone`
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -116,6 +116,8 @@ Version 0.9
 * Roster pushes are now accepted also if the :attr:`~.StanzaBase.from_` is the
   bare local JID instead of missing/empty (those are semantically equivalent).
 
+* :mod:`aioxmpp.hashes`
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -118,6 +118,14 @@ Version 0.9
 
 * :mod:`aioxmpp.hashes`
 
+* :class:`aioxmpp.disco.RegisteredFeature` and changes to
+  :class:`aioxmpp.disco.register_feature`. Effectively, attributes described by
+  :class:`~aioxmpp.disco.register_feature` now have an
+  :attr:`~aioxmpp.disco.RegisteredFeature.enabled` attribute which can be used
+  to temporarily or permanently disable the registration of the feature on a
+  service object.
+
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -131,6 +131,8 @@ Version 0.9
 
 * :meth:`aioxmpp.disco.StaticNode.clone`
 
+* :meth:`aioxmpp.disco.Node.as_info_xso`
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/public/hashes.rst
+++ b/docs/api/public/hashes.rst
@@ -1,0 +1,1 @@
+.. automodule:: aioxmpp.hashes

--- a/docs/api/public/index.rst
+++ b/docs/api/public/index.rst
@@ -34,6 +34,7 @@ functionality or provide backwards compatibility.
    disco
    entitycaps
    forms
+   hashes
    im
    muc
    presence

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,6 +110,8 @@ From XMPP Extension Proposals (XEPs)
 * :xep:`203` (Delayed Delivery), see :mod:`aioxmpp.misc`
 * :xep:`297` (Stanza Forwarding), see :mod:`aioxmpp.misc`
 * :xep:`280` (Message Carbons), see :mod:`aioxmpp.carbons`
+* :xep:`300` (Use of Cryptographic Hash Functions in XMPP),
+  see :mod:`aioxmpp.hashes`
 * :xep:`368` (SRV records for XMPP over TLS)
 
 

--- a/tests/avatar/test_e2e.py
+++ b/tests/avatar/test_e2e.py
@@ -133,6 +133,13 @@ class TestAvatar(TestCase):
                 ]
             ),
         )
+        self.client.summon(aioxmpp.EntityCapsService).update_delay = 0
+
+        # wait for EntityCapsService to update
+        yield from asyncio.sleep(0.11)
+
+        # and force re-send of presence
+        self.client.summon(aioxmpp.PresenceServer).resend_presence()
 
     @blocking_timed
     @asyncio.coroutine

--- a/tests/avatar/test_e2e.py
+++ b/tests/avatar/test_e2e.py
@@ -133,13 +133,6 @@ class TestAvatar(TestCase):
                 ]
             ),
         )
-        self.client.summon(aioxmpp.EntityCapsService).update_delay = 0
-
-        # wait for EntityCapsService to update
-        yield from asyncio.sleep(0.11)
-
-        # and force re-send of presence
-        self.client.summon(aioxmpp.PresenceServer).resend_presence()
 
     @blocking_timed
     @asyncio.coroutine

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -383,6 +383,120 @@ class TestNode(unittest.TestCase):
             []
         )
 
+    def test_as_info_xso(self):
+        n = disco_service.Node()
+
+        features = [
+            "http://jabber.org/protocol/disco#info",
+            unittest.mock.sentinel.f1,
+            unittest.mock.sentinel.f2,
+            unittest.mock.sentinel.f3,
+        ]
+
+        identities = [
+            ("cat1", "t1",
+             structs.LanguageTag.fromstr("lang-a"), "name11"),
+            ("cat1", "t1",
+             structs.LanguageTag.fromstr("lang-b"), "name12"),
+            ("cat2", "t2", None, "name2"),
+            ("cat3", "t3", None, None),
+        ]
+
+        with contextlib.ExitStack() as stack:
+            iter_features = stack.enter_context(
+                unittest.mock.patch.object(n, "iter_features")
+            )
+            iter_features.return_value = iter(features)
+
+            iter_identities = stack.enter_context(
+                unittest.mock.patch.object(n, "iter_identities")
+            )
+            iter_identities.return_value = iter(identities)
+
+            iter_items = stack.enter_context(
+                unittest.mock.patch.object(n, "iter_items")
+            )
+
+            result = n.as_info_xso()
+
+        self.assertIsInstance(
+            result,
+            disco_xso.InfoQuery,
+        )
+
+        iter_items.assert_not_called()
+
+        iter_features.assert_called_once_with(None)
+        iter_identities.assert_called_once_with(None)
+
+        self.assertSetEqual(
+            result.features,
+            set(features),
+        )
+
+        self.assertCountEqual(
+            [
+                (i.category, i.type_, i.lang, i.name)
+                for i in result.identities
+            ],
+            identities,
+        )
+
+    def test_as_info_xso_with_stanza(self):
+        n = disco_service.Node()
+
+        features = [
+            "http://jabber.org/protocol/disco#info",
+            unittest.mock.sentinel.f1,
+        ]
+
+        identities = [
+            ("cat1", "t1",
+             structs.LanguageTag.fromstr("lang-a"), "name11"),
+            ("cat1", "t1",
+             structs.LanguageTag.fromstr("lang-b"), "name12"),
+        ]
+
+        with contextlib.ExitStack() as stack:
+            iter_features = stack.enter_context(
+                unittest.mock.patch.object(n, "iter_features")
+            )
+            iter_features.return_value = iter(features)
+
+            iter_identities = stack.enter_context(
+                unittest.mock.patch.object(n, "iter_identities")
+            )
+            iter_identities.return_value = iter(identities)
+
+            iter_items = stack.enter_context(
+                unittest.mock.patch.object(n, "iter_items")
+            )
+
+            result = n.as_info_xso(unittest.mock.sentinel.stanza)
+
+        self.assertIsInstance(
+            result,
+            disco_xso.InfoQuery,
+        )
+
+        iter_items.assert_not_called()
+
+        iter_features.assert_called_once_with(unittest.mock.sentinel.stanza)
+        iter_identities.assert_called_once_with(unittest.mock.sentinel.stanza)
+
+        self.assertSetEqual(
+            result.features,
+            set(features),
+        )
+
+        self.assertCountEqual(
+            [
+                (i.category, i.type_, i.lang, i.name)
+                for i in result.identities
+            ],
+            identities,
+        )
+
 
 class TestStaticNode(unittest.TestCase):
     def setUp(self):

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -411,6 +411,63 @@ class TestStaticNode(unittest.TestCase):
             []
         )
 
+    def test_clone(self):
+        other_node = unittest.mock.Mock([
+            "iter_features",
+            "iter_identities",
+            "iter_items",
+        ])
+
+        features = [
+            "http://jabber.org/protocol/disco#info",
+            unittest.mock.sentinel.f1,
+            unittest.mock.sentinel.f2,
+            unittest.mock.sentinel.f3,
+        ]
+
+        identities = [
+            (unittest.mock.sentinel.cat1, unittest.mock.sentinel.t1,
+             unittest.mock.sentinel.lang11, unittest.mock.sentinel.name11),
+            (unittest.mock.sentinel.cat1, unittest.mock.sentinel.t1,
+             unittest.mock.sentinel.lang12, unittest.mock.sentinel.name12),
+            (unittest.mock.sentinel.cat2, unittest.mock.sentinel.t2,
+             None, unittest.mock.sentinel.name2),
+            (unittest.mock.sentinel.cat3, unittest.mock.sentinel.t3,
+             None, None),
+        ]
+
+        items = [
+            unittest.mock.sentinel.item1,
+            unittest.mock.sentinel.item2,
+        ]
+
+        other_node.iter_features.return_value = iter(features)
+        other_node.iter_identities.return_value = iter(identities)
+        other_node.iter_items.return_value = iter(items)
+
+        n = disco_service.StaticNode.clone(other_node)
+
+        self.assertIsInstance(n, disco_service.StaticNode)
+
+        other_node.iter_features.assert_called_once_with()
+        other_node.iter_identities.assert_called_once_with()
+        other_node.iter_items.assert_called_once_with()
+
+        self.assertCountEqual(
+            features,
+            list(n.iter_features()),
+        )
+
+        self.assertCountEqual(
+            identities,
+            list(n.iter_identities()),
+        )
+
+        self.assertCountEqual(
+            items,
+            list(n.iter_items()),
+        )
+
 
 class TestDiscoServer(unittest.TestCase):
     def setUp(self):

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -903,25 +903,19 @@ class TestDiscoServer(unittest.TestCase):
 
     def test_info_query_forwards_stanza(self):
         node = unittest.mock.Mock()
-        node.iter_features.return_value = iter([])
-        node.iter_identities.return_value = iter([
-            ("automation", "command-list", None, None)
-        ])
 
         self.s.mount_node("foo", node)
-
         self.request_iq.payload.node = "foo"
-        run_coroutine(
+
+        result = run_coroutine(
             self.s.handle_info_request(self.request_iq)
         )
 
-        node.iter_features.assert_called_once_with(
+        node.as_info_xso.assert_called_once_with(
             self.request_iq
         )
 
-        node.iter_identities.assert_called_once_with(
-            self.request_iq
-        )
+        self.assertEqual(result, node.as_info_xso())
 
 
 class TestDiscoClient(unittest.TestCase):

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -917,6 +917,23 @@ class TestDiscoServer(unittest.TestCase):
 
         self.assertEqual(result, node.as_info_xso())
 
+    def test_info_query_sets_node(self):
+        node = unittest.mock.Mock()
+
+        self.s.mount_node("foo", node)
+        self.request_iq.payload.node = "foo"
+
+        result = run_coroutine(
+            self.s.handle_info_request(self.request_iq)
+        )
+
+        node.as_info_xso.assert_called_once_with(
+            self.request_iq
+        )
+
+        self.assertEqual(result.node, "foo")
+        self.assertEqual(result, node.as_info_xso())
+
 
 class TestDiscoClient(unittest.TestCase):
     def setUp(self):

--- a/tests/entitycaps/test_caps390.py
+++ b/tests/entitycaps/test_caps390.py
@@ -1,0 +1,701 @@
+########################################################################
+# File name: test_caps390.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import contextlib
+import io
+import pathlib
+import unittest
+import unittest.mock
+import urllib.parse
+
+import aioxmpp
+import aioxmpp.entitycaps.caps390 as caps390
+import aioxmpp.entitycaps.xso as caps_xso
+
+
+def _parse_testcase(data):
+    src = io.BytesIO(data)
+    return aioxmpp.xml.read_single_xso(src, aioxmpp.disco.xso.InfoQuery)
+
+
+TEST_SMALL = _parse_testcase(b"""\
+<query xmlns="http://jabber.org/protocol/disco#info">
+  <identity category="client" name="BombusMod" type="mobile"/>
+  <feature var="http://jabber.org/protocol/si"/>
+  <feature var="http://jabber.org/protocol/bytestreams"/>
+  <feature var="http://jabber.org/protocol/chatstates"/>
+  <feature var="http://jabber.org/protocol/disco#info"/>
+  <feature var="http://jabber.org/protocol/disco#items"/>
+  <feature var="urn:xmpp:ping"/>
+  <feature var="jabber:iq:time"/>
+  <feature var="jabber:iq:privacy"/>
+  <feature var="jabber:iq:version"/>
+  <feature var="http://jabber.org/protocol/rosterx"/>
+  <feature var="urn:xmpp:time"/>
+  <feature var="jabber:x:oob"/>
+  <feature var="http://jabber.org/protocol/ibb"/>
+  <feature var="http://jabber.org/protocol/si/profile/file-transfer"/>
+  <feature var="urn:xmpp:receipts"/>
+  <feature var="jabber:iq:roster"/>
+  <feature var="jabber:iq:last"/>
+</query>""")
+
+TEST_LARGE = _parse_testcase("""\
+<query xmlns="http://jabber.org/protocol/disco#info">
+  <identity category="client" name="Tkabber" type="pc" xml:lang="en"/>
+  <identity category="client" name="Ткаббер" type="pc" xml:lang="ru"/>
+  <feature var="games:board"/>
+  <feature var="http://jabber.org/protocol/activity"/>
+  <feature var="http://jabber.org/protocol/activity+notify"/>
+  <feature var="http://jabber.org/protocol/bytestreams"/>
+  <feature var="http://jabber.org/protocol/chatstates"/>
+  <feature var="http://jabber.org/protocol/commands"/>
+  <feature var="http://jabber.org/protocol/disco#info"/>
+  <feature var="http://jabber.org/protocol/disco#items"/>
+  <feature var="http://jabber.org/protocol/evil"/>
+  <feature var="http://jabber.org/protocol/feature-neg"/>
+  <feature var="http://jabber.org/protocol/geoloc"/>
+  <feature var="http://jabber.org/protocol/geoloc+notify"/>
+  <feature var="http://jabber.org/protocol/ibb"/>
+  <feature var="http://jabber.org/protocol/iqibb"/>
+  <feature var="http://jabber.org/protocol/mood"/>
+  <feature var="http://jabber.org/protocol/mood+notify"/>
+  <feature var="http://jabber.org/protocol/rosterx"/>
+  <feature var="http://jabber.org/protocol/si"/>
+  <feature var="http://jabber.org/protocol/si/profile/file-transfer"/>
+  <feature var="http://jabber.org/protocol/tune"/>
+  <feature var="http://www.facebook.com/xmpp/messages"/>
+  <feature var="http://www.xmpp.org/extensions/xep-0084.html#ns-metadata+notify"/>
+  <feature var="jabber:iq:avatar"/>
+  <feature var="jabber:iq:browse"/>
+  <feature var="jabber:iq:dtcp"/>
+  <feature var="jabber:iq:filexfer"/>
+  <feature var="jabber:iq:ibb"/>
+  <feature var="jabber:iq:inband"/>
+  <feature var="jabber:iq:jidlink"/>
+  <feature var="jabber:iq:last"/>
+  <feature var="jabber:iq:oob"/>
+  <feature var="jabber:iq:privacy"/>
+  <feature var="jabber:iq:roster"/>
+  <feature var="jabber:iq:time"/>
+  <feature var="jabber:iq:version"/>
+  <feature var="jabber:x:data"/>
+  <feature var="jabber:x:event"/>
+  <feature var="jabber:x:oob"/>
+  <feature var="urn:xmpp:avatar:metadata+notify"/>
+  <feature var="urn:xmpp:ping"/>
+  <feature var="urn:xmpp:receipts"/>
+  <feature var="urn:xmpp:time"/>
+  <x xmlns="jabber:x:data" type="result">
+    <field type="hidden" var="FORM_TYPE">
+      <value>urn:xmpp:dataforms:softwareinfo</value>
+    </field>
+    <field var="software">
+      <value>Tkabber</value>
+    </field>
+    <field var="software_version">
+      <value>0.11.1-svn-20111216-mod (Tcl/Tk 8.6b2)</value>
+    </field>
+    <field var="os">
+      <value>Windows</value>
+    </field>
+    <field var="os_version">
+      <value>XP</value>
+    </field>
+  </x>
+</query>""".encode("utf-8"))
+
+
+class Test_process_features(unittest.TestCase):
+    def test_on_small_testcase(self):
+        self.assertEqual(
+            caps390._process_features(TEST_SMALL.features),
+            b'http://jabber.org/protocol/bytestreams\x1fhttp://jabber.org/prot'
+            b'ocol/chatstates\x1fhttp://jabber.org/protocol/disco#info\x1fhttp'
+            b'://jabber.org/protocol/disco#items\x1fhttp://jabber.org/protocol'
+            b'/ibb\x1fhttp://jabber.org/protocol/rosterx\x1fhttp://jabber.org/'
+            b'protocol/si\x1fhttp://jabber.org/protocol/si/profile/file-transf'
+            b'er\x1fjabber:iq:last\x1fjabber:iq:privacy\x1fjabber:iq:roster'
+            b'\x1fjabber:iq:time\x1fjabber:iq:version\x1fjabber:x:oob\x1furn:x'
+            b'mpp:ping\x1furn:xmpp:receipts\x1furn:xmpp:time\x1f\x1c'
+        )
+
+    def test_on_large_testcase(self):
+        self.assertEqual(
+            caps390._process_features(TEST_LARGE.features),
+            b'games:board\x1fhttp://jabber.org/protocol/activity\x1fhttp://jab'
+            b'ber.org/protocol/activity+notify\x1fhttp://jabber.org/protocol/b'
+            b'ytestreams\x1fhttp://jabber.org/protocol/chatstates\x1fhttp://ja'
+            b'bber.org/protocol/commands\x1fhttp://jabber.org/protocol/disco#i'
+            b'nfo\x1fhttp://jabber.org/protocol/disco#items\x1fhttp://jabber.o'
+            b'rg/protocol/evil\x1fhttp://jabber.org/protocol/feature-neg\x1fht'
+            b'tp://jabber.org/protocol/geoloc\x1fhttp://jabber.org/protocol/ge'
+            b'oloc+notify\x1fhttp://jabber.org/protocol/ibb\x1fhttp://jabber.o'
+            b'rg/protocol/iqibb\x1fhttp://jabber.org/protocol/mood\x1fhttp://j'
+            b'abber.org/protocol/mood+notify\x1fhttp://jabber.org/protocol/ros'
+            b'terx\x1fhttp://jabber.org/protocol/si\x1fhttp://jabber.org/proto'
+            b'col/si/profile/file-transfer\x1fhttp://jabber.org/protocol/tune'
+            b'\x1fhttp://www.facebook.com/xmpp/messages\x1fhttp://www.xmpp.org'
+            b'/extensions/xep-0084.html#ns-metadata+notify\x1fjabber:iq:avatar'
+            b'\x1fjabber:iq:browse\x1fjabber:iq:dtcp\x1fjabber:iq:filexfer\x1f'
+            b'jabber:iq:ibb\x1fjabber:iq:inband\x1fjabber:iq:jidlink\x1fjabber'
+            b':iq:last\x1fjabber:iq:oob\x1fjabber:iq:privacy\x1fjabber:iq:rost'
+            b'er\x1fjabber:iq:time\x1fjabber:iq:version\x1fjabber:x:data\x1fja'
+            b'bber:x:event\x1fjabber:x:oob\x1furn:xmpp:avatar:metadata+notify'
+            b'\x1furn:xmpp:ping\x1furn:xmpp:receipts\x1furn:xmpp:time\x1f\x1c'
+        )
+
+
+class Test_process_identities(unittest.TestCase):
+    def test_on_small_testcase(self):
+        self.assertEqual(
+            caps390._process_identities(TEST_SMALL.identities),
+            b'client\x1fmobile\x1f\x1fBombusMod\x1f\x1e\x1c'
+        )
+
+    def test_on_large_testcase(self):
+        self.assertEqual(
+            caps390._process_identities(TEST_LARGE.identities),
+            b'client\x1fpc\x1fen\x1fTkabber\x1f\x1eclient\x1fpc\x1fru\x1f\xd0'
+            b'\xa2\xd0\xba\xd0\xb0\xd0\xb1\xd0\xb1\xd0\xb5\xd1\x80\x1f\x1e\x1c'
+        )
+
+
+class Test_process_extensions(unittest.TestCase):
+    def test_on_small_testcase(self):
+        self.assertEqual(
+            caps390._process_extensions(TEST_SMALL.exts),
+            b'\x1c'
+        )
+
+    def test_on_large_testcase(self):
+        self.assertEqual(
+            caps390._process_extensions(TEST_LARGE.exts),
+            b'FORM_TYPE\x1furn:xmpp:dataforms:softwareinfo\x1f\x1eos\x1fWindow'
+            b's\x1f\x1eos_version\x1fXP\x1f\x1esoftware\x1fTkabber\x1f\x1esoft'
+            b'ware_version\x1f0.11.1-svn-20111216-mod (Tcl/Tk 8.6b2)\x1f\x1e'
+            b'\x1d\x1c'
+        )
+
+
+class Test_get_hash_input(unittest.TestCase):
+    def test_on_small_testcase(self):
+        self.assertEqual(
+            caps390._get_hash_input(TEST_SMALL),
+            b'http://jabber.org/protocol/bytestreams\x1fhttp://jabber.org/prot'
+            b'ocol/chatstates\x1fhttp://jabber.org/protocol/disco#info\x1fhttp'
+            b'://jabber.org/protocol/disco#items\x1fhttp://jabber.org/protocol'
+            b'/ibb\x1fhttp://jabber.org/protocol/rosterx\x1fhttp://jabber.org/'
+            b'protocol/si\x1fhttp://jabber.org/protocol/si/profile/file-transf'
+            b'er\x1fjabber:iq:last\x1fjabber:iq:privacy\x1fjabber:iq:roster'
+            b'\x1fjabber:iq:time\x1fjabber:iq:version\x1fjabber:x:oob\x1furn:x'
+            b'mpp:ping\x1furn:xmpp:receipts\x1furn:xmpp:time\x1f\x1cclient\x1f'
+            b'mobile\x1f\x1fBombusMod\x1f\x1e\x1c\x1c'
+        )
+
+    def test_on_large_testcase(self):
+        self.assertEqual(
+            caps390._get_hash_input(TEST_LARGE),
+            b'games:board\x1fhttp://jabber.org/protocol/activity\x1fhttp://jab'
+            b'ber.org/protocol/activity+notify\x1fhttp://jabber.org/protocol/b'
+            b'ytestreams\x1fhttp://jabber.org/protocol/chatstates\x1fhttp://ja'
+            b'bber.org/protocol/commands\x1fhttp://jabber.org/protocol/disco#i'
+            b'nfo\x1fhttp://jabber.org/protocol/disco#items\x1fhttp://jabber.o'
+            b'rg/protocol/evil\x1fhttp://jabber.org/protocol/feature-neg\x1fht'
+            b'tp://jabber.org/protocol/geoloc\x1fhttp://jabber.org/protocol/ge'
+            b'oloc+notify\x1fhttp://jabber.org/protocol/ibb\x1fhttp://jabber.o'
+            b'rg/protocol/iqibb\x1fhttp://jabber.org/protocol/mood\x1fhttp://j'
+            b'abber.org/protocol/mood+notify\x1fhttp://jabber.org/protocol/ros'
+            b'terx\x1fhttp://jabber.org/protocol/si\x1fhttp://jabber.org/proto'
+            b'col/si/profile/file-transfer\x1fhttp://jabber.org/protocol/tune'
+            b'\x1fhttp://www.facebook.com/xmpp/messages\x1fhttp://www.xmpp.org'
+            b'/extensions/xep-0084.html#ns-metadata+notify\x1fjabber:iq:avatar'
+            b'\x1fjabber:iq:browse\x1fjabber:iq:dtcp\x1fjabber:iq:filexfer\x1f'
+            b'jabber:iq:ibb\x1fjabber:iq:inband\x1fjabber:iq:jidlink\x1fjabber'
+            b':iq:last\x1fjabber:iq:oob\x1fjabber:iq:privacy\x1fjabber:iq:rost'
+            b'er\x1fjabber:iq:time\x1fjabber:iq:version\x1fjabber:x:data\x1fja'
+            b'bber:x:event\x1fjabber:x:oob\x1furn:xmpp:avatar:metadata+notify'
+            b'\x1furn:xmpp:ping\x1furn:xmpp:receipts\x1furn:xmpp:time\x1f\x1cc'
+            b'lient\x1fpc\x1fen\x1fTkabber\x1f\x1eclient\x1fpc\x1fru\x1f\xd0'
+            b'\xa2\xd0\xba\xd0\xb0\xd0\xb1\xd0\xb1\xd0\xb5\xd1\x80\x1f\x1e\x1c'
+            b'FORM_TYPE\x1furn:xmpp:dataforms:softwareinfo\x1f\x1eos\x1fWindow'
+            b's\x1f\x1eos_version\x1fXP\x1f\x1esoftware\x1fTkabber\x1f\x1esoft'
+            b'ware_version\x1f0.11.1-svn-20111216-mod (Tcl/Tk 8.6b2)\x1f\x1e'
+            b'\x1d\x1c'
+        )
+
+
+class Test_calculate_hash(unittest.TestCase):
+    def test_uses_and_hash_from_algo(self):
+        with contextlib.ExitStack() as stack:
+            hash_from_algo = stack.enter_context(
+                unittest.mock.patch("aioxmpp.hashes.hash_from_algo")
+            )
+
+            _get_hash_input = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._get_hash_input"
+                )
+            )
+
+            result = caps390._calculate_hash(
+                unittest.mock.sentinel.algo,
+                unittest.mock.sentinel.hash_input,
+            )
+
+        hash_from_algo.assert_called_once_with(unittest.mock.sentinel.algo)
+        _get_hash_input.assert_not_called()
+
+        hash_from_algo().update.assert_called_once_with(
+            unittest.mock.sentinel.hash_input
+        )
+        hash_from_algo().digest.assert_called_once_with()
+
+        self.assertEqual(
+            result,
+            hash_from_algo().digest(),
+        )
+
+
+class TestKey(unittest.TestCase):
+    def test_init_default(self):
+        with self.assertRaises(TypeError):
+            caps390.Key()
+
+    def test_init_args(self):
+        k = caps390.Key("algo", b"digest")
+
+        self.assertEqual(
+            k.algo,
+            "algo",
+        )
+        self.assertEqual(
+            k.digest,
+            b"digest",
+        )
+
+    def test_init_kwargs(self):
+        k = caps390.Key(algo="somealgo", digest=b"somedigest")
+
+        self.assertEqual(
+            k.algo,
+            "somealgo",
+        )
+        self.assertEqual(
+            k.digest,
+            b"somedigest",
+        )
+
+    def test_hashable(self):
+        k1 = caps390.Key("algo", b"digest")
+        k2 = caps390.Key("algo", b"digest")
+
+        self.assertEqual(hash(k1), hash(k2))
+
+    def test_equality(self):
+        k1 = caps390.Key("algo", b"digest")
+        k2 = caps390.Key("algo", b"digest")
+        k3 = caps390.Key("somealgo", b"otherdigest")
+
+        self.assertTrue(k1 == k2)
+        self.assertFalse(k1 != k2)
+        self.assertFalse(k1 == k3)
+        self.assertTrue(k1 != k3)
+
+        self.assertTrue(k2 == k1)
+        self.assertFalse(k2 != k1)
+        self.assertFalse(k2 == k3)
+        self.assertTrue(k2 != k3)
+
+        self.assertFalse(k3 == k1)
+        self.assertTrue(k3 != k1)
+        self.assertFalse(k3 == k2)
+        self.assertTrue(k3 != k2)
+
+    def test_node(self):
+        k1 = caps390.Key("algo", b"digest")
+
+        self.assertEqual(
+            k1.node,
+            "urn:xmpp:caps#algo.ZGlnZXN0"
+        )
+
+        k1 = caps390.Key("somealgo", b"otherdigest")
+
+        self.assertEqual(
+            k1.node,
+            "urn:xmpp:caps#somealgo.b3RoZXJkaWdlc3Q="
+        )
+
+    def test_path(self):
+        k1 = caps390.Key("algo", b"digest")
+
+        self.assertEqual(
+            k1.path,
+            pathlib.Path("caps2") / "algo" / "mr" / "uw" / "ozltoq.xml",
+        )
+
+        k1 = caps390.Key("somealgo", b"otherdigest")
+
+        self.assertEqual(
+            k1.path,
+            pathlib.Path("caps2") / "somealgo" / "n5" / "2g" /
+            "qzlsmruwozltoq.xml",
+        )
+
+    def test_path_urlencodes_algo(self):
+        quote = unittest.mock.Mock(wraps=urllib.parse.quote)
+        k = caps390.Key("/.$?", b"digest")
+
+        with unittest.mock.patch("urllib.parse.quote", new=quote):
+            path = k.path
+
+        quote.assert_called_once_with("/.$?", safe="")
+
+        self.assertEqual(
+            path,
+            pathlib.Path("caps2") / "%2F.%24%3F" / "mr" / "uw" / "ozltoq.xml",
+        )
+
+    def test_verify_consults__calculate_hash(self):
+        k = caps390.Key(
+            unittest.mock.sentinel.key_algo,
+            unittest.mock.sentinel.key_digest,
+        )
+
+        info = unittest.mock.Mock(
+            spec=aioxmpp.disco.xso.InfoQuery
+        )
+
+        with contextlib.ExitStack() as stack:
+            _calculate_hash = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._calculate_hash"
+                )
+            )
+            _calculate_hash.return_value = unittest.mock.sentinel.key_digest
+
+            _get_hash_input = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._get_hash_input"
+                )
+            )
+
+            self.assertTrue(
+                k.verify(info)
+            )
+
+            _get_hash_input.assert_called_once_with(
+                info,
+            )
+
+            _calculate_hash.assert_called_once_with(
+                unittest.mock.sentinel.key_algo,
+                _get_hash_input(),
+            )
+
+    def test_verify_can_use_precalculated_hash_input(self):
+        k = caps390.Key(
+            unittest.mock.sentinel.key_algo,
+            unittest.mock.sentinel.key_digest,
+        )
+
+        hash_input = unittest.mock.Mock(
+            spec=bytes
+        )
+
+        with contextlib.ExitStack() as stack:
+            _calculate_hash = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._calculate_hash"
+                )
+            )
+            _calculate_hash.return_value = unittest.mock.sentinel.key_digest
+
+            _get_hash_input = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._get_hash_input"
+                )
+            )
+
+            self.assertTrue(
+                k.verify(hash_input)
+            )
+
+            _get_hash_input.assert_not_called()
+
+            _calculate_hash.assert_called_once_with(
+                unittest.mock.sentinel.key_algo,
+                hash_input,
+            )
+
+    def test_verify_detects_mismatch_with_precalculated_hash_input(self):
+        k = caps390.Key(
+            unittest.mock.sentinel.key_algo,
+            unittest.mock.sentinel.key_digest,
+        )
+
+        hash_input = unittest.mock.Mock(
+            spec=bytes
+        )
+
+        with contextlib.ExitStack() as stack:
+            _calculate_hash = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._calculate_hash"
+                )
+            )
+            _calculate_hash.return_value = unittest.mock.sentinel.other_digest
+
+            _get_hash_input = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._get_hash_input"
+                )
+            )
+
+            self.assertFalse(
+                k.verify(hash_input)
+            )
+
+            _get_hash_input.assert_not_called()
+
+            _calculate_hash.assert_called_once_with(
+                unittest.mock.sentinel.key_algo,
+                hash_input,
+            )
+
+    def test_verify_returns_false_if_digest_mismatches(self):
+        k = caps390.Key(
+            unittest.mock.sentinel.key_algo,
+            unittest.mock.sentinel.key_digest,
+        )
+
+        info = unittest.mock.Mock(
+            spec=aioxmpp.disco.xso.InfoQuery
+        )
+
+        with contextlib.ExitStack() as stack:
+            _calculate_hash = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._calculate_hash"
+                )
+            )
+            _calculate_hash.return_value = unittest.mock.sentinel.other_digest
+
+            _get_hash_input = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._get_hash_input"
+                )
+            )
+
+            self.assertFalse(
+                k.verify(info)
+            )
+
+            _get_hash_input.assert_called_once_with(
+                info,
+            )
+
+            _calculate_hash.assert_called_once_with(
+                unittest.mock.sentinel.key_algo,
+                _get_hash_input(),
+            )
+
+    def test_verify_small_input(self):
+        k = caps390.Key(
+            "sha-256",
+            caps390._calculate_hash(
+                "sha-256",
+                caps390._get_hash_input(TEST_SMALL),
+            ),
+        )
+
+        self.assertTrue(
+            k.verify(TEST_SMALL)
+        )
+
+        self.assertFalse(
+            k.verify(TEST_LARGE)
+        )
+
+    def test_verify_small_input_precalculated(self):
+        hash_input_small = caps390._get_hash_input(TEST_SMALL)
+        hash_input_large = caps390._get_hash_input(TEST_LARGE)
+
+        k = caps390.Key(
+            "sha-256",
+            caps390._calculate_hash(
+                "sha-256",
+                hash_input_small,
+            ),
+        )
+
+        self.assertTrue(
+            k.verify(hash_input_small)
+        )
+
+        self.assertFalse(
+            k.verify(hash_input_large)
+        )
+
+    def test_verify_large_input(self):
+        k = caps390.Key(
+            "sha-256",
+            caps390._calculate_hash(
+                "sha-256",
+                caps390._get_hash_input(TEST_LARGE),
+            ),
+        )
+
+        self.assertTrue(
+            k.verify(TEST_LARGE)
+        )
+
+        self.assertFalse(
+            k.verify(TEST_SMALL)
+        )
+
+    def test_verify_large_input_precalculated(self):
+        hash_input_small = caps390._get_hash_input(TEST_SMALL)
+        hash_input_large = caps390._get_hash_input(TEST_LARGE)
+
+        k = caps390.Key(
+            "sha-256",
+            caps390._calculate_hash(
+                "sha-256",
+                hash_input_large,
+            ),
+        )
+
+        self.assertTrue(
+            k.verify(hash_input_large)
+        )
+
+        self.assertFalse(
+            k.verify(hash_input_small)
+        )
+
+
+class TestImplementation(unittest.TestCase):
+    def setUp(self):
+        self.algorithms = [
+            unittest.mock.sentinel.algo1,
+            unittest.mock.sentinel.algo2
+        ]
+        self.i = caps390.Implementation(self.algorithms)
+
+    def test_extract_keys_returns_empty_if_caps_is_None(self):
+        presence = unittest.mock.Mock(["xep0390_caps"])
+        presence.xep0390_caps = None
+
+        self.assertSetEqual(
+            set(self.i.extract_keys(presence)),
+            set(),
+        )
+
+    def test_extract_keys_creates_Key_objects_from_digests(self):
+        presence = unittest.mock.Mock(["xep0390_caps"])
+        presence.xep0390_caps.digests = {
+            unittest.mock.sentinel.palgo1: unittest.mock.sentinel.pdigest1,
+            unittest.mock.sentinel.palgo2: unittest.mock.sentinel.pdigest2,
+        }
+
+        self.assertSetEqual(
+            set(self.i.extract_keys(presence)),
+            {
+                caps390.Key(unittest.mock.sentinel.palgo1,
+                            unittest.mock.sentinel.pdigest1),
+                caps390.Key(unittest.mock.sentinel.palgo2,
+                            unittest.mock.sentinel.pdigest2),
+            }
+        )
+
+    def test_put_keys_inserts_keys_into_presence(self):
+        keys = [
+            caps390.Key(unittest.mock.sentinel.palgo1,
+                        unittest.mock.sentinel.pdigest1),
+            caps390.Key(unittest.mock.sentinel.palgo2,
+                        unittest.mock.sentinel.pdigest2),
+        ]
+
+        presence = unittest.mock.Mock(["xep0390_caps"])
+        presence.xep0390_caps = None
+
+        self.i.put_keys(keys, presence)
+
+        self.assertIsInstance(
+            presence.xep0390_caps,
+            caps_xso.Caps390,
+        )
+
+        self.assertDictEqual(
+            presence.xep0390_caps.digests,
+            {
+                unittest.mock.sentinel.palgo1: unittest.mock.sentinel.pdigest1,
+                unittest.mock.sentinel.palgo2: unittest.mock.sentinel.pdigest2,
+            }
+        )
+
+    def test_calculate_keys_efficiently_builds_hashes_for_given_algorithms(self):  # NOQA
+        def generate_digests(algo, _):
+            assert isinstance(algo, type(unittest.mock.sentinel.foo))
+            return getattr(unittest.mock.sentinel, "{}_digest".format(
+                algo.name
+            ))
+
+        with contextlib.ExitStack() as stack:
+            _calculate_hash = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._calculate_hash"
+                )
+            )
+            _calculate_hash.side_effect = generate_digests
+
+            _get_hash_input = stack.enter_context(
+                unittest.mock.patch(
+                    "aioxmpp.entitycaps.caps390._get_hash_input"
+                )
+            )
+            _get_hash_input.return_value = unittest.mock.sentinel.hash_input
+
+            result = set(self.i.calculate_keys(unittest.mock.sentinel.info))
+
+        _get_hash_input.assert_called_once_with(
+            unittest.mock.sentinel.info
+        )
+
+        self.assertCountEqual(
+            _calculate_hash.mock_calls,
+            [
+                unittest.mock.call(algo, unittest.mock.sentinel.hash_input)
+                for algo in self.algorithms
+            ]
+        )
+
+        self.assertSetEqual(
+            result,
+            {
+                caps390.Key(unittest.mock.sentinel.algo1,
+                            unittest.mock.sentinel.algo1_digest),
+                caps390.Key(unittest.mock.sentinel.algo2,
+                            unittest.mock.sentinel.algo2_digest),
+            }
+        )

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -53,8 +53,6 @@ class TestEntityCapabilities(TestCase):
                 ]
             )
         )
-        self.source.summon(aioxmpp.EntityCapsService).update_delay = 0
-        self.sink.summon(aioxmpp.EntityCapsService).update_delay = 0
 
     @blocking_timed
     @asyncio.coroutine
@@ -73,8 +71,6 @@ class TestEntityCapabilities(TestCase):
         self.sink.summon(aioxmpp.PresenceClient).on_available.connect(
             on_available
         )
-
-        yield from asyncio.sleep(0.11)
 
         presence = aioxmpp.Presence(
             type_=aioxmpp.PresenceType.AVAILABLE,

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -53,6 +53,8 @@ class TestEntityCapabilities(TestCase):
                 ]
             )
         )
+        self.source.summon(aioxmpp.EntityCapsService).update_delay = 0
+        self.sink.summon(aioxmpp.EntityCapsService).update_delay = 0
 
     @blocking_timed
     @asyncio.coroutine
@@ -71,6 +73,8 @@ class TestEntityCapabilities(TestCase):
         self.sink.summon(aioxmpp.PresenceClient).on_available.connect(
             on_available
         )
+
+        yield from asyncio.sleep(0.11)
 
         presence = aioxmpp.Presence(
             type_=aioxmpp.PresenceType.AVAILABLE,

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -1092,19 +1092,6 @@ class TestService(unittest.TestCase):
         self.assertIs(result, unittest.mock.sentinel.query_result)
 
     def test_update_hash(self):
-        iter_features_result = iter([
-            "http://jabber.org/protocol/caps",
-            "http://jabber.org/protocol/disco#items",
-            "http://jabber.org/protocol/disco#info",
-        ])
-
-        self.disco_server.iter_features.return_value = iter_features_result
-
-        self.disco_server.iter_identities.return_value = iter([
-            ("client", "pc", None, None),
-            ("client", "pc", structs.LanguageTag.fromstr("en"), "foo"),
-        ])
-
         base = unittest.mock.Mock()
 
         self.impl115.calculate_keys.return_value = iter([
@@ -1123,50 +1110,33 @@ class TestService(unittest.TestCase):
                 )
             )
 
-            stack.enter_context(unittest.mock.patch(
-                "aioxmpp.disco.xso.InfoQuery",
-                new=base.InfoQuery
-            ))
-
             self.s.update_hash()
 
         hash_query.assert_not_called()
 
-        base.InfoQuery.assert_called_with(
-            identities=[
-                disco.xso.Identity(category="client",
-                                   type_="pc"),
-                disco.xso.Identity(category="client",
-                                   type_="pc",
-                                   lang=structs.LanguageTag.fromstr("en"),
-                                   name="foo"),
-            ],
-            features=iter_features_result
-        )
+        self.disco_server.as_info_xso.assert_called_once_with()
 
         self.impl115.calculate_keys.assert_called_once_with(
-            base.InfoQuery()
+            self.disco_server.as_info_xso(),
         )
 
         self.impl390.calculate_keys.assert_called_once_with(
-            base.InfoQuery()
+            self.disco_server.as_info_xso(),
         )
 
-        calls = list(self.disco_server.mock_calls)
+        calls = list(self.disco_server.mount_node.mock_calls)
         self.assertCountEqual(
             calls,
             [
-                unittest.mock.call.iter_identities(),
-                unittest.mock.call.iter_features(),
-                unittest.mock.call.mount_node(
+                unittest.mock.call(
                     base.key1.node,
                     self.disco_server,
                 ),
-                unittest.mock.call.mount_node(
+                unittest.mock.call(
                     base.key2.node,
                     self.disco_server,
                 ),
-                unittest.mock.call.mount_node(
+                unittest.mock.call(
                     base.key3.node,
                     self.disco_server,
                 ),
@@ -1177,19 +1147,6 @@ class TestService(unittest.TestCase):
         self.s.xep115_support = False
         self.disco_server.reset_mock()
 
-        iter_features_result = iter([
-            "http://jabber.org/protocol/caps",
-            "http://jabber.org/protocol/disco#items",
-            "http://jabber.org/protocol/disco#info",
-        ])
-
-        self.disco_server.iter_features.return_value = iter_features_result
-
-        self.disco_server.iter_identities.return_value = iter([
-            ("client", "pc", None, None),
-            ("client", "pc", structs.LanguageTag.fromstr("en"), "foo"),
-        ])
-
         base = unittest.mock.Mock()
 
         self.impl115.calculate_keys.return_value = iter([
@@ -1208,44 +1165,27 @@ class TestService(unittest.TestCase):
                 )
             )
 
-            stack.enter_context(unittest.mock.patch(
-                "aioxmpp.disco.xso.InfoQuery",
-                new=base.InfoQuery
-            ))
-
             self.s.update_hash()
 
         hash_query.assert_not_called()
 
-        base.InfoQuery.assert_called_with(
-            identities=[
-                disco.xso.Identity(category="client",
-                                   type_="pc"),
-                disco.xso.Identity(category="client",
-                                   type_="pc",
-                                   lang=structs.LanguageTag.fromstr("en"),
-                                   name="foo"),
-            ],
-            features=iter_features_result
-        )
+        self.disco_server.as_info_xso.assert_called_once_with()
 
         self.impl115.calculate_keys.assert_not_called()
 
         self.impl390.calculate_keys.assert_called_once_with(
-            base.InfoQuery()
+            self.disco_server.as_info_xso(),
         )
 
-        calls = list(self.disco_server.mock_calls)
+        calls = list(self.disco_server.mount_node.mock_calls)
         self.assertCountEqual(
             calls,
             [
-                unittest.mock.call.iter_identities(),
-                unittest.mock.call.iter_features(),
-                unittest.mock.call.mount_node(
+                unittest.mock.call(
                     base.key2.node,
                     self.disco_server,
                 ),
-                unittest.mock.call.mount_node(
+                unittest.mock.call(
                     base.key3.node,
                     self.disco_server,
                 ),
@@ -1256,19 +1196,6 @@ class TestService(unittest.TestCase):
         self.s.xep390_support = False
         self.disco_server.reset_mock()
 
-        iter_features_result = iter([
-            "http://jabber.org/protocol/caps",
-            "http://jabber.org/protocol/disco#items",
-            "http://jabber.org/protocol/disco#info",
-        ])
-
-        self.disco_server.iter_features.return_value = iter_features_result
-
-        self.disco_server.iter_identities.return_value = iter([
-            ("client", "pc", None, None),
-            ("client", "pc", structs.LanguageTag.fromstr("en"), "foo"),
-        ])
-
         base = unittest.mock.Mock()
 
         self.impl115.calculate_keys.return_value = iter([
@@ -1287,40 +1214,23 @@ class TestService(unittest.TestCase):
                 )
             )
 
-            stack.enter_context(unittest.mock.patch(
-                "aioxmpp.disco.xso.InfoQuery",
-                new=base.InfoQuery
-            ))
-
             self.s.update_hash()
 
         hash_query.assert_not_called()
 
-        base.InfoQuery.assert_called_with(
-            identities=[
-                disco.xso.Identity(category="client",
-                                   type_="pc"),
-                disco.xso.Identity(category="client",
-                                   type_="pc",
-                                   lang=structs.LanguageTag.fromstr("en"),
-                                   name="foo"),
-            ],
-            features=iter_features_result
-        )
+        self.disco_server.as_info_xso.assert_called_once_with()
 
         self.impl115.calculate_keys.assert_called_once_with(
-            base.InfoQuery()
+            self.disco_server.as_info_xso()
         )
 
         self.impl390.calculate_keys.assert_not_called()
 
-        calls = list(self.disco_server.mock_calls)
+        calls = list(self.disco_server.mount_node.mock_calls)
         self.assertCountEqual(
             calls,
             [
-                unittest.mock.call.iter_identities(),
-                unittest.mock.call.iter_features(),
-                unittest.mock.call.mount_node(
+                unittest.mock.call(
                     base.key1.node,
                     self.disco_server,
                 ),

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -1772,7 +1772,15 @@ class TestService(unittest.TestCase):
             ],
         )
 
+    def test_update_delay(self):
+        self.assertEqual(
+            self.s.update_delay,
+            0.1,
+        )
+
     def test__info_changed_calls_update_hash_later(self):
+        self.s.update_delay = unittest.mock.sentinel.update_delay
+
         with contextlib.ExitStack() as stack:
             get_event_loop = stack.enter_context(unittest.mock.patch(
                 "asyncio.get_event_loop"
@@ -1782,7 +1790,7 @@ class TestService(unittest.TestCase):
 
         get_event_loop.assert_called_with()
         get_event_loop().call_later.assert_called_once_with(
-            0.1,
+            unittest.mock.sentinel.update_delay,
             self.s.update_hash,
         )
 

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -447,6 +447,7 @@ class TestService(unittest.TestCase):
         self.disco_server = unittest.mock.Mock()
         self.disco_server.on_info_changed.context_connect = \
             unittest.mock.MagicMock()
+        self.disco_server.iter_items.return_value = []
 
         self.impl115 = unittest.mock.Mock()
         self.impl115.extract_keys.return_value = []
@@ -1110,18 +1111,26 @@ class TestService(unittest.TestCase):
                 )
             )
 
+            clone = stack.enter_context(
+                unittest.mock.patch.object(
+                    disco.StaticNode,
+                    "clone",
+                )
+            )
+
             self.s.update_hash()
 
         hash_query.assert_not_called()
 
-        self.disco_server.as_info_xso.assert_called_once_with()
+        clone.assert_called_once_with(self.disco_server)
+        clone().as_info_xso.assert_called_once_with()
 
         self.impl115.calculate_keys.assert_called_once_with(
-            self.disco_server.as_info_xso(),
+            clone().as_info_xso()
         )
 
         self.impl390.calculate_keys.assert_called_once_with(
-            self.disco_server.as_info_xso(),
+            clone().as_info_xso()
         )
 
         calls = list(self.disco_server.mount_node.mock_calls)
@@ -1130,15 +1139,15 @@ class TestService(unittest.TestCase):
             [
                 unittest.mock.call(
                     base.key1.node,
-                    self.disco_server,
+                    clone(),
                 ),
                 unittest.mock.call(
                     base.key2.node,
-                    self.disco_server,
+                    clone(),
                 ),
                 unittest.mock.call(
                     base.key3.node,
-                    self.disco_server,
+                    clone(),
                 ),
             ]
         )
@@ -1165,16 +1174,24 @@ class TestService(unittest.TestCase):
                 )
             )
 
+            clone = stack.enter_context(
+                unittest.mock.patch.object(
+                    disco.StaticNode,
+                    "clone",
+                )
+            )
+
             self.s.update_hash()
 
         hash_query.assert_not_called()
 
-        self.disco_server.as_info_xso.assert_called_once_with()
+        clone.assert_called_once_with(self.disco_server)
+        clone().as_info_xso.assert_called_once_with()
 
         self.impl115.calculate_keys.assert_not_called()
 
         self.impl390.calculate_keys.assert_called_once_with(
-            self.disco_server.as_info_xso(),
+            clone().as_info_xso()
         )
 
         calls = list(self.disco_server.mount_node.mock_calls)
@@ -1183,11 +1200,11 @@ class TestService(unittest.TestCase):
             [
                 unittest.mock.call(
                     base.key2.node,
-                    self.disco_server,
+                    clone(),
                 ),
                 unittest.mock.call(
                     base.key3.node,
-                    self.disco_server,
+                    clone(),
                 ),
             ]
         )
@@ -1214,14 +1231,22 @@ class TestService(unittest.TestCase):
                 )
             )
 
+            clone = stack.enter_context(
+                unittest.mock.patch.object(
+                    disco.StaticNode,
+                    "clone",
+                )
+            )
+
             self.s.update_hash()
 
         hash_query.assert_not_called()
 
-        self.disco_server.as_info_xso.assert_called_once_with()
+        clone.assert_called_once_with(self.disco_server)
+        clone().as_info_xso.assert_called_once_with()
 
         self.impl115.calculate_keys.assert_called_once_with(
-            self.disco_server.as_info_xso()
+            clone().as_info_xso()
         )
 
         self.impl390.calculate_keys.assert_not_called()
@@ -1232,7 +1257,7 @@ class TestService(unittest.TestCase):
             [
                 unittest.mock.call(
                     base.key1.node,
-                    self.disco_server,
+                    clone(),
                 ),
             ]
         )
@@ -1324,7 +1349,16 @@ class TestService(unittest.TestCase):
         ])
 
         self.disco_server.mount_node.reset_mock()
-        self.s.update_hash()
+
+        with contextlib.ExitStack() as stack:
+            clone = stack.enter_context(
+                unittest.mock.patch.object(
+                    disco.StaticNode,
+                    "clone",
+                )
+            )
+
+            self.s.update_hash()
 
         self.assertCountEqual(
             self.disco_server.unmount_node.mock_calls,
@@ -1338,9 +1372,9 @@ class TestService(unittest.TestCase):
         self.assertCountEqual(
             self.disco_server.mount_node.mock_calls,
             [
-                unittest.mock.call(base.key4.node, self.disco_server),
-                unittest.mock.call(base.key2.node, self.disco_server),
-                unittest.mock.call(base.key5.node, self.disco_server),
+                unittest.mock.call(base.key4.node, clone()),
+                unittest.mock.call(base.key2.node, clone()),
+                unittest.mock.call(base.key5.node, clone()),
             ]
         )
 

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -22,6 +22,7 @@
 import asyncio
 import contextlib
 import io
+import itertools
 import unittest
 import unittest.mock
 import urllib.parse
@@ -867,7 +868,6 @@ class TestService(unittest.TestCase):
     def test_query_and_cache_checks_hash(self):
         self.maxDiff = None
 
-        ver = TEST_DB_ENTRY_VER
         response = TEST_DB_ENTRY
 
         base = unittest.mock.Mock()
@@ -1772,7 +1772,7 @@ class TestService(unittest.TestCase):
             ],
         )
 
-    def test__info_changed_calls_update_hash_soon(self):
+    def test__info_changed_calls_update_hash_later(self):
         with contextlib.ExitStack() as stack:
             get_event_loop = stack.enter_context(unittest.mock.patch(
                 "asyncio.get_event_loop"
@@ -1781,8 +1781,33 @@ class TestService(unittest.TestCase):
             self.s._info_changed()
 
         get_event_loop.assert_called_with()
-        get_event_loop().call_soon.assert_called_with(
-            self.s.update_hash
+        get_event_loop().call_later.assert_called_once_with(
+            0.1,
+            self.s.update_hash,
+        )
+
+    def test__info_changed_cancels_previous_delayed_if_it_exists(self):
+        delayed = unittest.mock.Mock()
+
+        def generate_results():
+            for i in itertools.count():
+                yield getattr(delayed, "i{}".format(i))
+
+        with contextlib.ExitStack() as stack:
+            get_event_loop = stack.enter_context(unittest.mock.patch(
+                "asyncio.get_event_loop"
+            ))
+            get_event_loop().call_later.side_effect = generate_results()
+
+            self.s._info_changed()
+
+            self.s._info_changed()
+
+        delayed.i0.cancel.assert_called_once_with()
+
+        get_event_loop().call_later.assert_called_with(
+            0.1,
+            self.s.update_hash,
         )
 
     def test_handle_outbound_presence_inserts_keys(self):

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -1772,15 +1772,7 @@ class TestService(unittest.TestCase):
             ],
         )
 
-    def test_update_delay(self):
-        self.assertEqual(
-            self.s.update_delay,
-            0.1,
-        )
-
     def test__info_changed_calls_update_hash_later(self):
-        self.s.update_delay = unittest.mock.sentinel.update_delay
-
         with contextlib.ExitStack() as stack:
             get_event_loop = stack.enter_context(unittest.mock.patch(
                 "asyncio.get_event_loop"
@@ -1790,7 +1782,7 @@ class TestService(unittest.TestCase):
 
         get_event_loop.assert_called_with()
         get_event_loop().call_later.assert_called_once_with(
-            unittest.mock.sentinel.update_delay,
+            0.1,
             self.s.update_hash,
         )
 

--- a/tests/entitycaps/test_xso.py
+++ b/tests/entitycaps/test_xso.py
@@ -21,6 +21,7 @@
 ########################################################################
 import unittest
 
+import aioxmpp.hashes
 import aioxmpp.entitycaps.xso as entitycaps_xso
 import aioxmpp.stanza as stanza
 import aioxmpp.xso as xso
@@ -33,6 +34,12 @@ class TestNamespaces(unittest.TestCase):
         self.assertEqual(
             namespaces.xep0115_caps,
             "http://jabber.org/protocol/caps"
+        )
+
+    def test_ecaps2(self):
+        self.assertEqual(
+            namespaces.xep0390_caps,
+            "urn:xmpp:caps"
         )
 
 
@@ -139,3 +146,35 @@ class TestCaps115(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                                     "positional argument"):
             entitycaps_xso.Caps115()
+
+
+class TestCaps390(unittest.TestCase):
+    def test_is_xso(self):
+        self.assertTrue(issubclass(
+            entitycaps_xso.Caps390,
+            xso.XSO,
+        ))
+
+    def test_is_hashes_parent(self):
+        self.assertTrue(issubclass(
+            entitycaps_xso.Caps390,
+            aioxmpp.hashes.HashesParent,
+        ))
+
+    def test_tag(self):
+        self.assertEqual(
+            entitycaps_xso.Caps390.TAG,
+            (namespaces.xep0390_caps, "c")
+        )
+
+    def test_attr_on_Presence(self):
+        self.assertIsInstance(
+            stanza.Presence.xep0390_caps,
+            xso.Child,
+        )
+        self.assertSetEqual(
+            {
+                entitycaps_xso.Caps390
+            },
+            set(stanza.Presence.xep0390_caps._classes)
+        )

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -1,0 +1,333 @@
+########################################################################
+# File name: test_hashes.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import hashlib
+import unittest
+import unittest.mock
+
+import aioxmpp.hashes as hashes
+import aioxmpp.xso
+
+from aioxmpp.utils import namespaces
+
+
+class TestNamespaces(unittest.TestCase):
+    def test_namespace(self):
+        self.assertEqual(
+            namespaces.xep0300_hashes2,
+            "urn:xmpp:hashes:2",
+        )
+
+
+class TestHash(unittest.TestCase):
+    def test_is_xso(self):
+        self.assertTrue(issubclass(
+            hashes.Hash,
+            aioxmpp.xso.XSO
+        ))
+
+    def test_tag(self):
+        self.assertEqual(
+            hashes.Hash.TAG,
+            (namespaces.xep0300_hashes2, "hash"),
+        )
+
+    def test_init_default(self):
+        with self.assertRaises(TypeError):
+            hashes.Hash()
+
+    def test_init(self):
+        h = hashes.Hash("algo", b"digest")
+        self.assertEqual(h.algo, "algo")
+        self.assertEqual(h.digest, b"digest")
+
+    def test_get_impl_uses_hash_from_algo(self):
+        h = hashes.Hash("some algo", b"foo")
+        with unittest.mock.patch(
+                "aioxmpp.hashes.hash_from_algo") as hash_from_algo:
+            impl = h.get_impl()
+            hash_from_algo.assert_called_once_with(
+                h.algo,
+            )
+            self.assertEqual(impl, hash_from_algo())
+
+
+class TestHashType(unittest.TestCase):
+    def test_is_abstract_type(self):
+        self.assertTrue(issubclass(
+            hashes.HashType,
+            aioxmpp.xso.AbstractType,
+        ))
+
+    def test_formatted_type_is_Hash(self):
+        self.assertIs(
+            hashes.HashType.get_formatted_type(),
+            hashes.Hash,
+        )
+
+    def test_format(self):
+        t = hashes.HashType()
+        h = t.format(("sha-1", b"foobar"))
+        self.assertIsInstance(h, hashes.Hash)
+        self.assertEqual(h.algo, "sha-1")
+        self.assertEqual(h.digest, b"foobar")
+
+    def test_parse(self):
+        t = hashes.HashType()
+        h = hashes.Hash("fnord", b"baz")
+        pair = t.parse(h)
+        self.assertSequenceEqual(
+            pair,
+            (
+                "fnord",
+                b"baz",
+            )
+        )
+
+
+class TestHashesParent(unittest.TestCase):
+    def test_is_xso(self):
+        self.assertTrue(issubclass(
+            hashes.HashesParent,
+            aioxmpp.xso.XSO,
+        ))
+
+    def test_has_no_tag(self):
+        self.assertFalse(
+            hasattr(hashes.HashesParent, "TAG")
+        )
+
+    def test_digests(self):
+        self.assertIsInstance(
+            hashes.HashesParent.digests,
+            aioxmpp.xso.ChildValueMap
+        )
+        self.assertIsInstance(
+            hashes.HashesParent.digests.type_,
+            hashes.HashType,
+        )
+
+
+class Testhash_from_algo(unittest.TestCase):
+    def test_all_supported(self):
+        for algo_name, (enabled,
+                        (fun_name,
+                         fun_args,
+                         fun_kwargs)) in hashes._HASH_ALGO_MAPPING:
+            if not enabled:
+                continue
+
+            with unittest.mock.patch(
+                    "hashlib.{}".format(fun_name),
+                    create=True) as hash_impl:
+                result = hashes.hash_from_algo(algo_name)
+
+            hash_impl.assert_called_once_with(
+                *fun_args,
+                **fun_kwargs
+            )
+
+            self.assertEqual(
+                result,
+                hash_impl(),
+            )
+
+    def test_raise_ValueError_for_MUST_NOT_hashes(self):
+        with self.assertRaisesRegexp(
+                ValueError,
+                "support of md2 in XMPP is forbidden"):
+            hashes.hash_from_algo("md2")
+
+        with self.assertRaisesRegexp(
+                ValueError,
+                "support of md4 in XMPP is forbidden"):
+            hashes.hash_from_algo("md4")
+
+        with self.assertRaisesRegexp(
+                ValueError,
+                "support of md5 in XMPP is forbidden"):
+            hashes.hash_from_algo("md5")
+
+    def test_raises_NotImplementedError_if_function_not_supported(self):
+        _sha1 = hashlib.sha1
+        with self.assertRaisesRegexp(
+                NotImplementedError,
+                "sha-1 not supported by hashlib") as ctx:
+            del hashlib.sha1
+            try:
+                hashes.hash_from_algo("sha-1")
+            finally:
+                hashlib.sha1 = _sha1
+
+        self.assertIsInstance(ctx.exception.__cause__, AttributeError)
+
+    def test_raises_NotImplementedError_if_function_not_defined(self):
+        with self.assertRaisesRegexp(
+                NotImplementedError,
+                "hash algorithm 'foobar' unknown"):
+            hashes.hash_from_algo("foobar")
+
+
+class Testis_algo_supported(unittest.TestCase):
+    def test_all_supported(self):
+        for algo_name, (enabled,
+                        (fun_name,
+                         fun_args,
+                         fun_kwargs)) in hashes._HASH_ALGO_MAPPING:
+            if not enabled:
+                self.assertFalse(
+                    hashes.is_algo_supported(algo_name)
+                )
+            else:
+                with unittest.mock.patch(
+                        "hashlib.{}".format(fun_name),
+                        create=True) as hash_impl:
+                    self.assertTrue(hashes.is_algo_supported(algo_name))
+
+                hash_impl.assert_not_called()
+
+    def test_return_false_for_MUST_NOT_hashes(self):
+        self.assertFalse(hashes.is_algo_supported("md2"))
+        self.assertFalse(hashes.is_algo_supported("md4"))
+        self.assertFalse(hashes.is_algo_supported("md5"))
+
+    def test_return_false_if_function_not_implemented(self):
+        try:
+            _sha3_256 = hashlib.sha3_256
+        except AttributeError:
+            self.assertFalse(hashes.is_algo_supported("sha3-256"))
+            return
+
+        self.assertTrue(hashes.is_algo_supported("sha3-256"))
+        del hashlib.sha3_256
+
+        try:
+            self.assertFalse(hashes.is_algo_supported("sha3-256"))
+        finally:
+            hashlib.sha3_256 = _sha3_256
+
+    def test_return_false_if_function_not_defined(self):
+        self.assertFalse(hashes.is_algo_supported("foobar"))
+
+
+class Testalgo_from_hashlib(unittest.TestCase):
+    def test_all_supported(self):
+        for algo_name, (enabled,
+                        (fun_name,
+                         fun_args,
+                         fun_kwargs)) in hashes._HASH_ALGO_MAPPING:
+            if not enabled:
+                continue
+
+            try:
+                impl = hashes.hash_from_algo(algo_name)
+            except NotImplementedError:
+                continue
+
+            self.assertEqual(
+                algo_name,
+                hashes.algo_of_hash(impl)
+            )
+
+    def test_raise_ValueError_for_MUST_NOT_hashes(self):
+        with self.assertRaisesRegexp(
+                ValueError,
+                "support of md5 in XMPP is forbidden"):
+            hashes.algo_of_hash(hashlib.md5())
+
+    def test_sha1(self):
+        m = unittest.mock.Mock()
+        m.name = "sha1"
+
+        self.assertEqual(
+            "sha-1",
+            hashes.algo_of_hash(m),
+        )
+
+    def test_sha2(self):
+        for size in ["224", "256", "384", "512"]:
+            m = unittest.mock.Mock()
+            m.name = "sha{}".format(size)
+
+            self.assertEqual(
+                "sha-{}".format(size),
+                hashes.algo_of_hash(m),
+            )
+
+    def test_sha3(self):
+        for size in ["256", "512"]:
+            m = unittest.mock.Mock()
+            m.name = "sha3_{}".format(size)
+
+            self.assertEqual(
+                "sha3-{}".format(size),
+                hashes.algo_of_hash(m),
+            )
+
+    def test_blake2b(self):
+        versions = [
+            (32, "blake2b-256"),
+            (64, "blake2b-512"),
+        ]
+
+        for digest_size, algo in versions:
+            m = unittest.mock.Mock()
+            m.digest_size = digest_size
+            m.name = "blake2b"
+
+            self.assertEqual(
+                algo,
+                hashes.algo_of_hash(m),
+            )
+
+    def test_raise_ValueError_on_unknown(self):
+        m = unittest.mock.Mock()
+        with self.assertRaisesRegexp(
+                ValueError,
+                "unknown hash implementation: <Mock id=.+>"):
+            hashes.algo_of_hash(m)
+
+
+class Testdefault_hash_algorithms(unittest.TestCase):
+    def test_selection(self):
+        selected = set(hashes.default_hash_algorithms)
+        self.assertIn(
+            "sha-256",
+            selected,
+        )
+
+        try:
+            hashes.hash_from_algo("sha3-256")
+        except NotImplementedError:
+            self.assertNotIn("sha3-256", selected)
+        else:
+            self.assertIn("sha3-256", selected)
+
+        try:
+            hashes.hash_from_algo("blake2b-256")
+        except NotImplementedError:
+            self.assertNotIn("blake2b-256", selected)
+        else:
+            self.assertIn("blake2b-256", selected)
+
+    def test_all_selected_can_be_instantiated(self):
+        for algo in hashes.default_hash_algorithms:
+            hashes.hash_from_algo(algo)


### PR DESCRIPTION
This depends on #97!

This implements support for emitting and processing XEP-0390 capabilities, as well as the possibility to turn emission and processing for XEP-0115 and XEP-0390 on and off respectively (they both default to "on").

The following features are still missing and will be implemented in an upcoming PR:

* ~~Keeping the last 3 capability hash sets available for querying (including those from XEP-0115)~~
* Inbound and outbound rate limits