### PR TITLE
Limit size of DiscoClient caches and defer EntityCapsService lookups

### DIFF
--- a/aioxmpp/cache.py
+++ b/aioxmpp/cache.py
@@ -1,0 +1,99 @@
+"""
+:mod:`~aioxmpp.cache` --- Utilities for implementing caches
+###########################################################
+
+.. versionadded:: 0.9
+
+    This module was added in version 0.9.
+
+.. autoclass:: LRUDict
+
+"""
+
+import collections.abc
+
+
+class LRUDict(collections.abc.MutableMapping):
+    """
+    Size-restricted dictionary with Least Recently Used expiry policy.
+
+    .. versionadded:: 0.9
+
+    The :class:`LRUDict` supports normal dictionary-style access and implements
+    :class:`collections.abc.MutableMapping`.
+
+    When the :attr:`maxsize` is exceeded, as many entries as needed to get
+    below the :attr:`maxsize` are removed from the dict. Least recently used
+    entries are purged first. Setting an entry does *not* count as use!
+
+    .. autoattribute:: maxsize
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__data = {}
+        self.__data_used = {}
+        self.__maxsize = 1
+        self.__ctr = 0
+
+    def _purge_old(self, n):
+        keys_in_age_order = sorted(
+            self.__data_used.items(),
+            key=lambda x: x[1]
+        )
+        keys_to_delete = keys_in_age_order[:n]
+        for key, _ in keys_to_delete:
+            del self.__data[key]
+            del self.__data_used[key]
+        keys_to_keep = keys_in_age_order[n:]
+        # avoid the counter becoming large
+        self.__ctr = len(keys_to_keep)
+        for i, (key, _) in enumerate(keys_to_keep):
+            self.__data_used[key] = i
+
+    @property
+    def maxsize(self):
+        """
+        Maximum size of the cache. Changing this property purges overhanging
+        entries immediately.
+
+        If set to :data:`None`, no limit on the number of entries is imposed.
+        Do **not** use a limit of :data:`None` for data where the `key` is
+        under control of a remote entity.
+
+        Use cases for :data:`None` are those where you only need the explicit
+        expiry feature, but not the LRU feature.
+        """
+        return self.__maxsize
+
+    @maxsize.setter
+    def maxsize(self, value):
+        if value is not None and value <= 0:
+            raise ValueError("maxsize must be positive integer or None")
+        self.__maxsize = value
+        if self.__maxsize is not None and len(self.__data) > self.__maxsize:
+            self._purge_old(len(self.__data) - self.__maxsize)
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __iter__(self):
+        return iter(self.__data)
+
+    def __setitem__(self, key, value):
+        if self.__maxsize is not None and len(self.__data) >= self.__maxsize:
+            self._purge_old(len(self.__data) - (self.__maxsize-1))
+        self.__data[key] = value
+        self.__data_used[key] = self.__ctr
+
+    def __getitem__(self, key):
+        result = self.__data[key]
+        counter = self.__ctr
+        counter += 1
+        self.__ctr = counter
+        self.__data_used[key] = counter
+        return result
+
+    def __delitem__(self, key):
+        del self.__data[key]
+        del self.__data_used[key]

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -568,10 +568,18 @@ class DiscoClient(service.Service):
     @asyncio.coroutine
     def query_info(self, jid, *, node=None, require_fresh=False, timeout=None):
         """
-        Query the features and identities of the specified entity. The entity
-        is identified by the `jid` and the optional `node`.
+        Query the features and identities of the specified entity.
 
-        Return the :class:`.xso.InfoQuery` instance returned by the peer.
+        :param jid: The entity to query.
+        :type jid: :class:`aioxmpp.JID`
+        :param node: The node to query.
+        :type node: :class:`str` or :data:`None`
+        :param require_fresh: Boolean flag to discard previous caches.
+        :type require_fresh: :class:`bool`
+        :param timeout: Optional timeout for the response.
+        :type timeout: :class:`float`
+        :rtype: :class:`.xso.InfoQuery`
+        :return: Service discovery information of the `node` at `jid`.
 
         The requests are cached. This means that only one request is ever fired
         for a given target (identified by the `jid` and the `node`). The
@@ -652,8 +660,18 @@ class DiscoClient(service.Service):
     def query_items(self, jid, *,
                     node=None, require_fresh=False, timeout=None):
         """
-        Send an items query to the given `jid`, querying for the items at the
-        `node`. Return the :class:`~.xso.ItemsQuery` result.
+        Query the items of the specified entity.
+
+        :param jid: The entity to query.
+        :type jid: :class:`aioxmpp.JID`
+        :param node: The node to query.
+        :type node: :class:`str` or :data:`None`
+        :param require_fresh: Boolean flag to discard previous caches.
+        :type require_fresh: :class:`bool`
+        :param timeout: Optional timeout for the response.
+        :type timeout: :class:`float`
+        :rtype: :class:`.xso.ItemsQuery`
+        :return: Service discovery items of the `node` at `jid`.
 
         The arguments have the same semantics as with :meth:`query_info`, as
         does the caching and error handling.

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -26,7 +26,6 @@ import functools
 import logging
 import os
 import tempfile
-import urllib.parse
 
 import aioxmpp.callbacks
 import aioxmpp.disco as disco

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -441,8 +441,10 @@ class EntityCapsService(aioxmpp.service.Service):
             keys.extend(self.__115.extract_keys(presence))
 
         if keys:
-            lookup_task = asyncio.async(
-                self.lookup_info(presence.from_, keys)
+            lookup_task = aioxmpp.utils.LazyTask(
+                self.lookup_info,
+                presence.from_,
+                keys,
             )
             self.disco_client.set_info_future(
                 presence.from_,

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -373,7 +373,9 @@ class EntityCapsService(aioxmpp.service.Service):
         data = yield from self.disco_client.query_info(
             jid,
             node=key.node,
-            require_fresh=True)
+            require_fresh=True,
+            no_cache=True,  # the caps node is never queried by apps
+        )
 
         try:
             if key.verify(data):

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -143,6 +143,9 @@ Version 0.9
   for its internal caches to prevent memory exhaustion in long running
   applications and/or with malicious peers.
 
+* :meth:`aioxmpp.DiscoClient.query_info` now supports a `no_cache` argument
+  which prevents caching of the request and response.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -139,6 +139,10 @@ Version 0.9
 
 * :mod:`aioxmpp.pep`
 
+* :class:`aioxmpp.DiscoClient` now uses :class:`aioxmpp.cache.LRUDict`
+  for its internal caches to prevent memory exhaustion in long running
+  applications and/or with malicious peers.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/internal/cache.rst
+++ b/docs/api/internal/cache.rst
@@ -1,0 +1,1 @@
+.. automodule:: aioxmpp.cache

--- a/docs/api/internal/index.rst
+++ b/docs/api/internal/index.rst
@@ -12,6 +12,7 @@ Internal tools
 .. toctree::
    :maxdepth: 2
 
+   cache
    e2etest
    network
    protocol

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -1192,6 +1192,56 @@ class TestDiscoClient(unittest.TestCase):
             len(send_and_decode.mock_calls)
         )
 
+    def test_query_info_does_not_cache_if_no_cache_is_false(self):
+        to = structs.JID.fromstr("user@foo.example/res1")
+        response = {}
+
+        with unittest.mock.patch.object(
+                self.s,
+                "send_and_decode_info_query",
+                new=CoroutineMock()) as send_and_decode:
+            send_and_decode.return_value = response
+
+            result1 = run_coroutine(
+                self.s.query_info(to, node="foobar", no_cache=True)
+            )
+            result2 = run_coroutine(
+                self.s.query_info(to, node="foobar")
+            )
+
+            self.assertIs(result1, response)
+            self.assertIs(result2, response)
+
+        self.assertEqual(
+            2,
+            len(send_and_decode.mock_calls)
+        )
+
+    def test_query_info_with_no_cache_uses_cached_result(self):
+        to = structs.JID.fromstr("user@foo.example/res1")
+        response = {}
+
+        with unittest.mock.patch.object(
+                self.s,
+                "send_and_decode_info_query",
+                new=CoroutineMock()) as send_and_decode:
+            send_and_decode.return_value = response
+
+            result1 = run_coroutine(
+                self.s.query_info(to, node="foobar")
+            )
+            result2 = run_coroutine(
+                self.s.query_info(to, node="foobar", no_cache=True)
+            )
+
+            self.assertIs(result1, response)
+            self.assertIs(result2, response)
+
+        self.assertEqual(
+            1,
+            len(send_and_decode.mock_calls)
+        )
+
     def test_query_info_reraises_and_aliases_exception(self):
         to = structs.JID.fromstr("user@foo.example/res1")
 

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -197,13 +197,6 @@ class TestEntityCapabilities(TestCase):
             "http://test#{}".format(info_hash)
         )
 
-        disco_client = self.sink.summon(aioxmpp.DiscoClient)
-        info_node = yield from disco_client.query_info(
-            self.source.local_jid,
-            node="http://test#{}".format(info_hash),
-        )
-        self.assertEqual(info_node.features, info.features)
-
         self.assertFalse(disco_called_again)
 
     @blocking_timed
@@ -288,12 +281,5 @@ class TestEntityCapabilities(TestCase):
             disco_iq.payload.node,
             "urn:xmpp:caps#sha-256.{}".format(info_hash_b64)
         )
-
-        disco_client = self.sink.summon(aioxmpp.DiscoClient)
-        info_node = yield from disco_client.query_info(
-            self.source.local_jid,
-            node="urn:xmpp:caps#sha-256.{}".format(info_hash_b64),
-        )
-        self.assertEqual(info_node.features, info.features)
 
         self.assertFalse(disco_called_again)

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -658,8 +658,8 @@ class TestService(unittest.TestCase):
         ])
 
         with contextlib.ExitStack() as stack:
-            async = stack.enter_context(
-                unittest.mock.patch("asyncio.async")
+            LazyTask = stack.enter_context(
+                unittest.mock.patch("aioxmpp.utils.LazyTask")
             )
 
             lookup_info = stack.enter_context(
@@ -670,21 +670,18 @@ class TestService(unittest.TestCase):
 
         self.impl115.extract_keys.assert_called_once_with(presence)
 
-        lookup_info.assert_called_once_with(
+        LazyTask.assert_called_once_with(
+            lookup_info,
             presence.from_,
             [
                 unittest.mock.sentinel.key1,
             ]
         )
 
-        async.assert_called_once_with(
-            lookup_info()
-        )
-
         self.disco_client.set_info_future.assert_called_with(
             presence.from_,
             None,
-            async(),
+            LazyTask(),
         )
 
         self.assertEqual(result, presence)
@@ -697,8 +694,8 @@ class TestService(unittest.TestCase):
         ])
 
         with contextlib.ExitStack() as stack:
-            async = stack.enter_context(
-                unittest.mock.patch("asyncio.async")
+            LazyTask = stack.enter_context(
+                unittest.mock.patch("aioxmpp.utils.LazyTask")
             )
 
             lookup_info = stack.enter_context(
@@ -709,21 +706,18 @@ class TestService(unittest.TestCase):
 
         self.impl390.extract_keys.assert_called_once_with(presence)
 
-        lookup_info.assert_called_once_with(
+        LazyTask.assert_called_once_with(
+            lookup_info,
             presence.from_,
             [
                 unittest.mock.sentinel.key1,
             ]
         )
 
-        async.assert_called_once_with(
-            lookup_info()
-        )
-
         self.disco_client.set_info_future.assert_called_with(
             presence.from_,
             None,
-            async(),
+            LazyTask(),
         )
 
         self.assertEqual(result, presence)
@@ -741,8 +735,8 @@ class TestService(unittest.TestCase):
         ])
 
         with contextlib.ExitStack() as stack:
-            async = stack.enter_context(
-                unittest.mock.patch("asyncio.async")
+            LazyTask = stack.enter_context(
+                unittest.mock.patch("aioxmpp.utils.LazyTask")
             )
 
             lookup_info = stack.enter_context(
@@ -753,7 +747,8 @@ class TestService(unittest.TestCase):
 
         self.impl390.extract_keys.assert_called_once_with(presence)
 
-        lookup_info.assert_called_once_with(
+        LazyTask.assert_called_once_with(
+            lookup_info,
             presence.from_,
             [
                 unittest.mock.sentinel.key2,
@@ -762,14 +757,10 @@ class TestService(unittest.TestCase):
             ]
         )
 
-        async.assert_called_once_with(
-            lookup_info()
-        )
-
         self.disco_client.set_info_future.assert_called_with(
             presence.from_,
             None,
-            async(),
+            LazyTask(),
         )
 
         self.assertEqual(result, presence)
@@ -789,8 +780,8 @@ class TestService(unittest.TestCase):
         ])
 
         with contextlib.ExitStack() as stack:
-            async = stack.enter_context(
-                unittest.mock.patch("asyncio.async")
+            LazyTask = stack.enter_context(
+                unittest.mock.patch("aioxmpp.utils.LazyTask")
             )
 
             lookup_info = stack.enter_context(
@@ -802,7 +793,8 @@ class TestService(unittest.TestCase):
         self.impl115.extract_keys.assert_not_called()
         self.impl390.extract_keys.assert_called_once_with(presence)
 
-        lookup_info.assert_called_once_with(
+        LazyTask.assert_called_once_with(
+            lookup_info,
             presence.from_,
             [
                 unittest.mock.sentinel.key2,
@@ -810,14 +802,10 @@ class TestService(unittest.TestCase):
             ]
         )
 
-        async.assert_called_once_with(
-            lookup_info()
-        )
-
         self.disco_client.set_info_future.assert_called_with(
             presence.from_,
             None,
-            async(),
+            LazyTask(),
         )
 
         self.assertEqual(result, presence)
@@ -837,8 +825,8 @@ class TestService(unittest.TestCase):
         ])
 
         with contextlib.ExitStack() as stack:
-            async = stack.enter_context(
-                unittest.mock.patch("asyncio.async")
+            LazyTask = stack.enter_context(
+                unittest.mock.patch("aioxmpp.utils.LazyTask")
             )
 
             lookup_info = stack.enter_context(
@@ -850,21 +838,18 @@ class TestService(unittest.TestCase):
         self.impl115.extract_keys.assert_called_once_with(presence)
         self.impl390.extract_keys.assert_not_called()
 
-        lookup_info.assert_called_once_with(
+        LazyTask.assert_called_once_with(
+            lookup_info,
             presence.from_,
             [
                 unittest.mock.sentinel.key1,
             ]
         )
 
-        async.assert_called_once_with(
-            lookup_info()
-        )
-
         self.disco_client.set_info_future.assert_called_with(
             presence.from_,
             None,
-            async(),
+            LazyTask(),
         )
 
         self.assertEqual(result, presence)

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -885,7 +885,8 @@ class TestService(unittest.TestCase):
                 unittest.mock.call.disco.query_info(
                     TEST_FROM,
                     node=base.key.node,
-                    require_fresh=True
+                    require_fresh=True,
+                    no_cache=True,
                 ),
                 unittest.mock.call.key.verify(response),
                 unittest.mock.call.add_cache_entry(
@@ -932,7 +933,8 @@ class TestService(unittest.TestCase):
                 unittest.mock.call.disco.query_info(
                     TEST_FROM,
                     node=base.key.node,
-                    require_fresh=True
+                    require_fresh=True,
+                    no_cache=True,
                 ),
                 unittest.mock.call.key.verify(response),
                 unittest.mock.call.fut.set_exception(unittest.mock.ANY)
@@ -976,7 +978,8 @@ class TestService(unittest.TestCase):
                 unittest.mock.call.disco.query_info(
                     TEST_FROM,
                     node=base.key.node,
-                    require_fresh=True
+                    require_fresh=True,
+                    no_cache=True,
                 ),
                 unittest.mock.call.key.verify(response),
                 unittest.mock.call.fut.set_exception(exc)

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -26,7 +26,6 @@ import pathlib
 import tempfile
 import unittest
 import unittest.mock
-import urllib.parse
 
 import aioxmpp.disco as disco
 import aioxmpp.service as service
@@ -1916,12 +1915,6 @@ class Testwriteback(unittest.TestCase):
                 new=base.unlink
             ))
 
-            base.quote = unittest.mock.Mock(wraps=urllib.parse.quote)
-            stack.enter_context(unittest.mock.patch(
-                "urllib.parse.quote",
-                new=base.quote,
-            ))
-
             stack.enter_context(unittest.mock.patch(
                 "aioxmpp.xml.XMPPXMLGenerator",
                 new=base.XMPPXMLGenerator
@@ -1991,12 +1984,6 @@ class Testwriteback(unittest.TestCase):
             stack.enter_context(unittest.mock.patch(
                 "os.unlink",
                 new=base.unlink
-            ))
-
-            base.quote = unittest.mock.Mock(wraps=urllib.parse.quote)
-            stack.enter_context(unittest.mock.patch(
-                "urllib.parse.quote",
-                new=base.quote,
             ))
 
             stack.enter_context(unittest.mock.patch(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,226 @@
+import collections.abc
+import unittest
+
+import aioxmpp.cache as cache
+
+
+class TestLRUDict(unittest.TestCase):
+    def setUp(self):
+        self.d = cache.LRUDict()
+
+    def tearDown(self):
+        del self.d
+
+    def test_is_mutable_mapping(self):
+        self.assertIsInstance(
+            self.d,
+            collections.abc.MutableMapping,
+        )
+
+    def test_default_maxsize(self):
+        self.assertEqual(
+            self.d.maxsize,
+            1,
+        )
+
+    def test_store_and_retrieve(self):
+        key = object()
+        value = object()
+        self.d[key] = value
+
+        result = self.d[key]
+        self.assertEqual(result, value)
+
+    def test_raise_KeyError_for_unknown_key(self):
+        key = object()
+
+        with self.assertRaises(KeyError):
+            self.d[key]
+
+        value = object()
+        self.d[key] = value
+
+        with self.assertRaises(KeyError):
+            self.d[object()]
+
+    def test_store_multiple(self):
+        size = 3
+        self.d.maxsize = size
+        keys = [object() for i in range(size)]
+        values = [object() for i in range(size)]
+
+        for i, (k, v) in enumerate(zip(keys, values)):
+            self.assertEqual(
+                len(self.d),
+                i,
+            )
+
+            self.d[k] = v
+            self.assertEqual(
+                self.d[k],
+                v,
+            )
+
+            self.assertEqual(
+                len(self.d),
+                i+1,
+            )
+
+        for k, v in zip(keys, values):
+            self.assertEqual(
+                self.d[k],
+                v,
+            )
+
+    def test_iter_iterates_over_keys(self):
+        size = 3
+        self.d.maxsize = size
+        keys = [object() for i in range(size)]
+        values = [object() for i in range(size)]
+
+        for k, v in zip(keys, values):
+            self.d[k] = v
+            self.assertEqual(
+                self.d[k],
+                v,
+            )
+
+        self.assertSetEqual(
+            set(self.d),
+            set(keys),
+        )
+
+    def test_maxsize_can_be_written(self):
+        self.d.maxsize = 4
+        self.assertEqual(self.d.maxsize, 4)
+
+    def test_maxsize_rejects_non_positive_integers(self):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            self.d.maxsize = 0
+
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            self.d.maxsize = -1
+
+    def test_maxsize_accepts_None(self):
+        self.d.maxsize = None
+        self.assertIsNone(self.d.maxsize)
+
+    def test_fetch_does_not_create_ghost_keys(self):
+        with self.assertRaises(KeyError):
+            self.d[object()]
+        self.d[object()] = object()
+
+        # "ghost key": if one part of the data structure (the "last used") is
+        # updated before the check for existance of the key is made
+        # in this case, the second store would raise because there is a key
+        # in the "last used" data structure which isn’t in the main data
+        # structure
+        self.d[object()] = object()
+
+    def test_lru_purge_when_decreasing_maxsize(self):
+        size = 4
+        self.d.maxsize = size
+        keys = [object() for i in range(size)]
+        values = [object() for i in range(size)]
+
+        for k, v in zip(keys, values):
+            self.d[k] = v
+            self.assertEqual(
+                self.d[k],
+                v,
+            )
+
+        # keys have now been fetached in insertion order
+        # reducing maxsize by one should remove first key, but not the others
+
+        self.d.maxsize = size-1
+
+        with self.assertRaises(KeyError):
+            self.d[keys[0]]
+
+        # we now fetch the second key, so that the third is purged instead of
+        # the second when we reduce maxsize again
+
+        self.d[keys[1]]
+
+        self.d.maxsize = size-2
+
+        with self.assertRaises(KeyError):
+            self.d[keys[2]]
+
+        self.assertEqual(
+            self.d[keys[1]],
+            values[1]
+        )
+
+        # reducing the size to 1 should leave only the third key
+
+        self.d.maxsize = 1
+
+        self.assertEqual(
+            self.d[keys[1]],
+            values[1]
+        )
+
+        for i in [0, 2, 3]:
+            with self.assertRaises(KeyError):
+                self.d[keys[i]]
+
+    def test_lru_purge_when_storing(self):
+        size = 4
+        self.d.maxsize = size
+        keys = [object() for i in range(size+2)]
+        values = [object() for i in range(size+2)]
+
+        for k, v in zip(keys[:size], values[:size]):
+            self.d[k] = v
+            self.assertEqual(
+                self.d[k],
+                v,
+            )
+
+        # keys have now been fetached in insertion order
+        # reducing maxsize by one should remove first key, but not the others
+
+        self.d[keys[size]] = values[size]
+
+        with self.assertRaises(KeyError):
+            self.d[keys[0]]
+
+        # we now fetch the second key, so that the third is purged instead of
+        # the second when we reduce maxsize again
+
+        self.d[keys[2]]
+
+        self.d[keys[size+1]] = values[size+1]
+
+        with self.assertRaises(KeyError):
+            self.d[keys[1]]
+
+        self.assertEqual(
+            self.d[keys[2]],
+            values[2]
+        )
+
+        for i in [0, 1]:
+            with self.assertRaises(KeyError, msg=i):
+                self.d[keys[i]]
+
+        for i in [2, 3, 4, 5]:
+            self.assertEqual(
+                self.d[keys[i]],
+                values[i],
+            )
+
+    def test_expire_removes_from_cache(self):
+        key = object()
+        value = object()
+        self.d[key] = value
+
+        del self.d[key]
+
+        with self.assertRaises(KeyError):
+            self.d[key]
+
+        self.d[object()] = value
+        self.d[object()] = value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -257,3 +257,96 @@ class Testmkdir_exist_ok(unittest.TestCase):
                 unittest.mock.call.is_dir()
             ]
         )
+
+
+class TestLazyTask(unittest.TestCase):
+    def setUp(self):
+        self.coro = CoroutineMock()
+
+    def test_yield_from_able(self):
+        self.coro.return_value = unittest.mock.sentinel.result
+
+        @asyncio.coroutine
+        def user(fut):
+            return (yield from fut)
+
+        fut = utils.LazyTask(self.coro)
+
+        result = run_coroutine(user(fut))
+
+        self.assertEqual(result, unittest.mock.sentinel.result)
+
+    def test_run_coroutine_able(self):
+        self.coro.return_value = unittest.mock.sentinel.result
+
+        fut = utils.LazyTask(self.coro)
+
+        result = run_coroutine(fut)
+
+        self.assertEqual(result, unittest.mock.sentinel.result)
+
+    def test_async_able(self):
+        self.coro.return_value = unittest.mock.sentinel.result
+
+        fut = utils.LazyTask(self.coro)
+
+        result = run_coroutine(asyncio.async(fut))
+
+        self.assertEqual(result, unittest.mock.sentinel.result)
+
+    def test_runs_only_once_even_if_awaited_concurrently(self):
+        self.coro.return_value = unittest.mock.sentinel.result
+
+        fut = utils.LazyTask(self.coro)
+
+        result2 = run_coroutine(asyncio.async(fut))
+        result1 = run_coroutine(fut)
+
+        self.assertEqual(result1, result2)
+        self.assertEqual(result1, unittest.mock.sentinel.result)
+
+        self.coro.assert_called_once_with()
+
+    def test_add_done_callback_spawns_task(self):
+        fut = utils.LazyTask(self.coro)
+        cb = unittest.mock.Mock()
+
+        with unittest.mock.patch("asyncio.async") as async_:
+            fut.add_done_callback(cb)
+            async_.assert_called_once_with(unittest.mock.ANY)
+
+    def test_add_done_callback_works(self):
+        fut = utils.LazyTask(self.coro)
+        cb = unittest.mock.Mock()
+
+        fut.add_done_callback(cb)
+
+        run_coroutine(fut)
+
+        cb.assert_called_once_with(fut)
+
+    def test_is_future(self):
+        self.assertTrue(issubclass(
+            utils.LazyTask,
+            asyncio.Future,
+        ))
+
+    def test_passes_args(self):
+        self.coro.return_value = unittest.mock.sentinel.result
+
+        fut = utils.LazyTask(
+            self.coro,
+            unittest.mock.sentinel.a1,
+            unittest.mock.sentinel.a2,
+            unittest.mock.sentinel.a3,
+        )
+
+        result = run_coroutine(fut)
+
+        self.assertEqual(result, unittest.mock.sentinel.result)
+
+        self.coro.assert_called_once_with(
+            unittest.mock.sentinel.a1,
+            unittest.mock.sentinel.a2,
+            unittest.mock.sentinel.a3,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,7 +309,7 @@ class TestLazyTask(unittest.TestCase):
 
     def test_add_done_callback_spawns_task(self):
         fut = utils.LazyTask(self.coro)
-        cb = unittest.mock.Mock()
+        cb = unittest.mock.Mock(["__call__"])
 
         with unittest.mock.patch("asyncio.async") as async_:
             fut.add_done_callback(cb)
@@ -317,7 +317,7 @@ class TestLazyTask(unittest.TestCase):
 
     def test_add_done_callback_works(self):
         fut = utils.LazyTask(self.coro)
-        cb = unittest.mock.Mock()
+        cb = unittest.mock.Mock(["__call__"])
 
         fut.add_done_callback(cb)
 


### PR DESCRIPTION
Fixes #100 and reduces overall footprint of entitycaps.

Key changes:

* ``EntityCapsService`` now uses ``LazyTask`` (also new in this PR) instead of ``asyncio.async`` for its lookups. ``LazyTask`` essentially spawns the task only when the first attempt to await the task is made. This reduces the traffic during (re-)connects while still having the benefits of entity capabilities: at the point the query is made, the most recent caps are looked up in the cache and only on a miss the query is fired.
* ``DiscoClient`` now uses ``LRUDict`` (new in this PR) for its caches. This means that excess entries are removed with a least-recently-used policy. This prevents the ``DiscoClient`` cache from filling all the memory with ``LazyTask`` objects (formely just ``asyncio.Task`` objects) from EntityCapsService in a long-running application or with malicious peers.

The disadvantage is that the ``disco#info`` is not eagerly prefetched. This has the following effects:

* Higher latency when a cache miss happens when requesting the ``disco#info`` for the first time (this is only true if the "first time" is reasonably after the caps of the peer were received)
* Error response instead of successful response when a cache miss happens when requesting the ``disco#info`` for the first time when the peer is already offline.

I consider those effects to be not relevant enough to stop this change: neither of this is the main goal of entity capabilities.