### PR TITLE
Add attribute to control the maximum lifetime of a Stream Management session at the server

### DIFF
--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -486,11 +486,12 @@ class Client:
 
     .. autoattribute:: running
 
-    .. attribute:: negotiation_timeout = timedelta(seconds=60)
+    .. attribute:: negotiation_timeout
+        :annotation: = timedelta(seconds=60)
 
-       The timeout applied to the connection process and the individual steps
-       of negotiating the stream. See the `negotiation_timeout` argument to
-       :func:`connect_xmlstream`.
+        The timeout applied to the connection process and the individual steps
+        of negotiating the stream. See the `negotiation_timeout` argument to
+        :func:`connect_xmlstream`.
 
     .. attribute:: override_peer
 

--- a/aioxmpp/nonza.py
+++ b/aioxmpp/nonza.py
@@ -617,6 +617,12 @@ class SMEnabled(SMXSO):
        A hostname-port pair which defines to which host the client shall
        connect to resume the stream.
 
+    .. attribute:: max_
+
+        Maximum time, as integer in seconds, for which the stream will be
+        resumable after the connection dropped. Only relevant if
+        :attr:`resume` is true.
+
     """
     TAG = (namespaces.stream_management, "enabled")
 
@@ -625,15 +631,22 @@ class SMEnabled(SMXSO):
         type_=xso.Bool(),
         default=False
     )
+
     id_ = xso.Attr("id", default=None)
+
     location = xso.Attr(
         "location",
         type_=xso.ConnectionLocation(),
-        default=None)
+        default=None
+    )
+
     max_ = xso.Attr(
         "max",
         type_=xso.Integer(),
-        default=None)
+        default=None,
+        validate=xso.ValidateMode.ALWAYS,
+        validator=xso.NumericRange(min_=0),
+    )
 
     def __init__(self,
                  resume=False,

--- a/aioxmpp/nonza.py
+++ b/aioxmpp/nonza.py
@@ -559,6 +559,14 @@ class SMEnable(SMXSO):
        Set this to :data:`True` to request the capability of resuming the
        stream later.
 
+    .. attribute:: max_
+
+        Maximum time, as integer in seconds, for which the stream should be
+        resumable after the connection dropped. Only relevant if
+        :attr:`resume` is true and may be overridden by the server.
+
+        .. versionadded:: 0.9
+
     """
 
     TAG = (namespaces.stream_management, "enable")
@@ -569,15 +577,25 @@ class SMEnable(SMXSO):
         default=False
     )
 
-    def __init__(self, resume=False):
+    max_ = xso.Attr(
+        "max",
+        type_=xso.Integer(),
+        default=None,
+        validate=xso.ValidateMode.ALWAYS,
+        validator=xso.NumericRange(min_=0),
+    )
+
+    def __init__(self, resume=False, max_=None):
         super().__init__()
         self.resume = resume
+        self.max_ = max_
 
     def __repr__(self):
-        return "<{}.{} resume={} at 0x{:x}>".format(
+        return "<{}.{} resume={} max={} at 0x{:x}>".format(
             type(self).__module__,
             type(self).__qualname__,
             self.resume,
+            self.max_,
             id(self),
         )
 

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -1924,8 +1924,14 @@ class StanzaStream:
     @asyncio.coroutine
     def start_sm(self, request_resumption=True):
         """
-        Start stream management (version 3). This negotiates stream management
-        with the server.
+        Start stream management (version 3).
+
+        :param request_resumption: Request that the stream shall be resumable.
+        :type request_resumption: :class:`bool`
+        :raises aioxmpp.errors.StreamNegotiationFailure: if the server rejects
+            the attempt to enable stream management.
+
+        This method attempts to starts stream management on the stream.
 
         If the server rejects the attempt to enable stream management, a
         :class:`.errors.StreamNegotiationFailure` is raised. The stream is
@@ -1940,14 +1946,14 @@ class StanzaStream:
 
         If an XML stream error occurs during the negotiation, the result
         depends on a few factors. In any case, the stream is not running
-        afterwards. If the :class:`SMEnabled` response was not received before
-        the XML stream died, SM is also disabled and the exception which caused
-        the stream to die is re-raised (this is due to the implementation of
-        :func:`~.protocol.send_and_wait_for`). If the :class:`SMEnabled`
-        response was received and annonuced support for resumption, SM is
-        enabled. Otherwise, it is disabled. No exception is raised if
-        :class:`SMEnabled` was received, as this method has no way to determine
-        that the stream failed.
+        afterwards. If the :class:`.nonza.SMEnabled` response was not received
+        before the XML stream died, SM is also disabled and the exception which
+        caused the stream to die is re-raised (this is due to the
+        implementation of :func:`~.protocol.send_and_wait_for`). If the
+        :class:`.nonza.SMEnabled` response was received and annonuced support
+        for resumption, SM is enabled. Otherwise, it is disabled. No exception
+        is raised if :class:`.nonza.SMEnabled` was received, as this method has
+        no way to determine that the stream failed.
 
         If negotiation succeeds, this coroutine initializes a new stream
         management session. The stream management state attributes become

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -306,7 +306,8 @@ class _PropBase(metaclass=PropBaseMeta):
         instance._xso_contents[self] = value
 
     def __set__(self, instance, value):
-        if     (self.validate.from_code and
+        if     (self.default != value and
+                self.validate.from_code and
                 self.validator and
                 not self.validator.validate(value)):
             raise ValueError("invalid value")
@@ -316,7 +317,8 @@ class _PropBase(metaclass=PropBaseMeta):
         self.__set__(instance, value)
 
     def _set_from_recv(self, instance, value):
-        if     (self.validate.from_recv and
+        if     (self.default != value and
+                self.validate.from_recv and
                 self.validator and
                 not self.validator.validate(value)):
             raise ValueError("invalid value")

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -146,6 +146,9 @@ Version 0.9
 * :meth:`aioxmpp.DiscoClient.query_info` now supports a `no_cache` argument
   which prevents caching of the request and response.
 
+* The `default` of XSO descriptors has incorrectly been passed through the
+  validator, despite the documentation saying otherwise. This has been fixed.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -149,6 +149,10 @@ Version 0.9
 * The `default` of XSO descriptors has incorrectly been passed through the
   validator, despite the documentation saying otherwise. This has been fixed.
 
+* :attr:`aioxmpp.Client.resumption_timeout`: Support for specifying the
+  lifetime of a Stream  Management (:xep:`198`) session and disabling stream
+  resumption altogether.
+
 .. _api-changelog-0.8:
 
 Version 0.8

--- a/docs/user-guide/pitfalls.rst
+++ b/docs/user-guide/pitfalls.rst
@@ -59,6 +59,25 @@ the case that an error occured.
    such as Connection Reset by Peer break such a stream would defeat the
    purpose of Stream Management.
 
+
+.. note::
+
+    As of version 0.9, you can disable the resumption capaibility of Stream
+    Management using the :attr:`.Client.resumption_timeout` attribute. However,
+    that alone is no guarantee that sessions die quickly; it still depends a
+    lot on the way in which the network connection got interrupted and whether
+    or not the server is sending data to the (disconnected) client.
+
+    There are other timeouts, such as the ones from TCP, at play here which
+    need to be tweaked properly on the server-side. How to do so is out of
+    scope for aioxmpp.
+
+    (If you happen to find a client-side way, e.g. in another XMPP library, to
+    achieve the behaviour of letting the session die quickly in case of a
+    hard disconnect (e.g. a pulled cable), let me know. I’m quite convinced
+    that this is impossible, so I’d like to be proven wrong.)
+
+
 I am trying to connect to a bare IP and I get a DNS error
 =========================================================
 

--- a/tests/test_nonza.py
+++ b/tests/test_nonza.py
@@ -778,10 +778,15 @@ class TestSMEnable(unittest.TestCase):
     def test_default_init(self):
         obj = nonza.SMEnable()
         self.assertFalse(obj.resume)
+        self.assertIsNone(obj.max_)
 
     def test_init(self):
-        obj = nonza.SMEnable(resume=True)
+        obj = nonza.SMEnable(resume=True, max_=123)
         self.assertTrue(obj.resume)
+        self.assertEqual(
+            obj.max_,
+            123,
+        )
 
     def test_resume(self):
         self.assertIsInstance(
@@ -799,6 +804,40 @@ class TestSMEnable(unittest.TestCase):
         self.assertIs(
             nonza.SMEnable.resume.default,
             False
+        )
+
+    def test_max_(self):
+        self.assertIsInstance(
+            nonza.SMEnable.max_,
+            xso.Attr
+        )
+        self.assertEqual(
+            (None, "max"),
+            nonza.SMEnable.max_.tag
+        )
+        self.assertIsInstance(
+            nonza.SMEnable.max_.type_,
+            xso.Integer
+        )
+        self.assertIs(
+            nonza.SMEnable.max_.default,
+            None
+        )
+        self.assertEqual(
+            nonza.SMEnable.max_.validate,
+            xso.ValidateMode.ALWAYS,
+        )
+        self.assertIsInstance(
+            nonza.SMEnable.max_.validator,
+            xso.NumericRange,
+        )
+        self.assertEqual(
+            nonza.SMEnable.max_.validator.min_,
+            0
+        )
+        self.assertEqual(
+            nonza.SMEnable.max_.validator.max_,
+            None,
         )
 
 

--- a/tests/test_nonza.py
+++ b/tests/test_nonza.py
@@ -921,6 +921,22 @@ class TestSMEnabled(unittest.TestCase):
             nonza.SMEnabled.max_.default,
             None
         )
+        self.assertEqual(
+            nonza.SMEnabled.max_.validate,
+            xso.ValidateMode.ALWAYS,
+        )
+        self.assertIsInstance(
+            nonza.SMEnabled.max_.validator,
+            xso.NumericRange,
+        )
+        self.assertEqual(
+            nonza.SMEnabled.max_.validator.min_,
+            0
+        )
+        self.assertEqual(
+            nonza.SMEnabled.max_.validator.max_,
+            None,
+        )
 
     def test_resume(self):
         self.assertIsInstance(

--- a/tests/xso/test_model.py
+++ b/tests/xso/test_model.py
@@ -2423,6 +2423,18 @@ class Test_PropBase(unittest.TestCase):
             ],
             validator.mock_calls)
 
+    def test_validator_recv_ignores_default(self):
+        validator = unittest.mock.MagicMock()
+        instance = make_instance_mock()
+
+        prop = xso_model._PropBase(
+            default=self.default,
+            validator=validator,
+            validate=xso.ValidateMode.FROM_RECV)
+
+        prop._set_from_recv(instance, self.default)
+        validator.validate.assert_not_called()
+
     def test_validator_code(self):
         validator = unittest.mock.MagicMock()
         instance = make_instance_mock()
@@ -2461,6 +2473,18 @@ class Test_PropBase(unittest.TestCase):
                 unittest.mock.call.validate("baz"),
             ],
             validator.mock_calls)
+
+    def test_validator_code_ignores_default(self):
+        validator = unittest.mock.MagicMock()
+        instance = make_instance_mock()
+
+        prop = xso_model._PropBase(
+            default=self.default,
+            validator=validator,
+            validate=xso.ValidateMode.FROM_CODE)
+
+        prop._set_from_code(instance, self.default)
+        validator.validate.assert_not_called()
 
     def test_validator_always(self):
         validator = unittest.mock.MagicMock()
@@ -2566,12 +2590,7 @@ class Test_TypedPropBase(unittest.TestCase):
 
         prop._set_from_code(instance, "bar")
 
-        self.assertSequenceEqual(
-            [
-                unittest.mock.call.coerce("bar"),
-            ],
-            type_.mock_calls
-        )
+        type_.coerce.assert_called_once_with("bar")
 
         self.assertDictEqual(
             {
@@ -2684,11 +2703,7 @@ class TestText(XMLTestCase):
         prop = xso.Text(type_=type_)
         prop.__set__(instance, "foo")
 
-        self.assertSequenceEqual(
-            [
-                unittest.mock.call.coerce("foo"),
-            ],
-            type_.mock_calls)
+        type_.coerce.assert_called_once_with("foo")
 
     def test_to_sax_unset(self):
         instance = make_instance_mock()
@@ -2834,12 +2849,7 @@ class TestChild(XMLTestCase):
         obj = self.ClsA()
         obj.test_child = unittest.mock.MagicMock()
         self.ClsA.test_child.to_sax(obj, dest)
-        self.assertSequenceEqual(
-            [
-                unittest.mock.call.unparse_to_sax(dest)
-            ],
-            obj.test_child.mock_calls
-        )
+        obj.test_child.unparse_to_sax.assert_called_once_with(dest)
 
     def test_to_sax_unset(self):
         dest = unittest.mock.MagicMock()
@@ -3327,6 +3337,15 @@ class TestAttr(XMLTestCase):
             ],
             validator.mock_calls)
 
+    def test_validator_ignores_default(self):
+        validator = unittest.mock.MagicMock()
+        instance = make_instance_mock()
+
+        prop = xso.Attr("foo", validator=validator, default=None,
+                        validate=xso_model.ValidateMode.ALWAYS)
+        prop.__set__(instance, None)
+        validator.validate.assert_not_called()
+
     def test_coerces(self):
         type_ = unittest.mock.MagicMock()
         instance = make_instance_mock()
@@ -3334,12 +3353,7 @@ class TestAttr(XMLTestCase):
         prop = xso.Attr("foo", type_=type_)
         prop.__set__(instance, "bar")
 
-        self.assertSequenceEqual(
-            [
-                unittest.mock.call.coerce("bar"),
-            ],
-            type_.mock_calls
-        )
+        type_.coerce.assert_called_once_with("bar")
 
     def test_missing(self):
         ctx = xso_model.Context()
@@ -3434,11 +3448,8 @@ class TestChildText(XMLTestCase):
 
         drive_from_events(prop.from_events, instance, subtree, self.ctx)
 
-        self.assertSequenceEqual(
-            [
-                unittest.mock.call.parse("foo"),
-            ],
-            type_mock.mock_calls)
+        type_mock.parse.assert_called_once_with("foo")
+
         self.assertDictEqual(
             {
                 prop: type_mock.parse("foo"),
@@ -3660,12 +3671,7 @@ class TestChildText(XMLTestCase):
         prop = xso.ChildText("body", type_=type_)
         prop.__set__(instance, "bar")
 
-        self.assertSequenceEqual(
-            [
-                unittest.mock.call.coerce("bar"),
-            ],
-            type_.mock_calls
-        )
+        type_.coerce.assert_called_once_with("bar")
 
     def test_validate_contents_rejects_unset_and_undefaulted(self):
         instance = make_instance_mock()


### PR DESCRIPTION
Fixes #114.

In addition fixes a bug uncovered in XSO while adding validators to the SMEnable{,d} nonzas: The validators were run on default values despite the opposite being documented.