### PR TITLE
Improve the AbstractConversation API regarding tracking

### DIFF
--- a/aioxmpp/im/conversation.py
+++ b/aioxmpp/im/conversation.py
@@ -267,7 +267,7 @@ class AbstractConversation(metaclass=abc.ABCMeta):
 
     Signals:
 
-    .. signal:: on_message(msg, member, source, **kwargs)
+    .. signal:: on_message(msg, member, source, tracker=None, **kwargs)
 
        A message occured in the conversation.
 
@@ -277,6 +277,8 @@ class AbstractConversation(metaclass=abc.ABCMeta):
        :type member: :class:`.AbstractConversationMember`
        :param source: How the message was acquired
        :type source: :class:`~.MessageSource`
+       :param tracker: A message tracker which tracks an outbound message.
+       :type trakcre: :class:`aioxmpp.tracking.MessageTracker`
 
        This signal is emitted on the following events:
 
@@ -305,6 +307,13 @@ class AbstractConversation(metaclass=abc.ABCMeta):
        as :meth:`on_state_changed` signals) are dispatched to this event. This
        may include messages not understood and/or which carry no textual
        payload.
+
+       `tracker` is set only for messages sent by the local member. If a
+       message is sent from the client without tracking, `tracker` is
+       :data:`None`; otherwise, the `tracker` is always set, even for messages
+       sent by other clients. It depends on the conversation implementation as
+       well as timing in which state a tracker is at the time the event is
+       emitted.
 
     .. signal:: on_state_changed(member, new_state, msg, **kwargs)
 

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -698,10 +698,19 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             )
 
         elif message.body:
+            if occupant is not None and occupant == self._this_occupant:
+                tracker = aioxmpp.tracking.MessageTracker()
+                tracker._set_state(
+                    aioxmpp.tracking.MessageState.DELIVERED_TO_RECIPIENT
+                )
+                tracker.close()
+            else:
+                tracker = None
             self.on_message(
                 message,
                 occupant,
                 source,
+                tracker=tracker,
             )
 
     def _diff_presence(self, stanza, info, existing):
@@ -1004,6 +1013,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             msg,
             self._this_occupant,
             aioxmpp.im.dispatcher.MessageSource.STREAM,
+            tracker=tracker,
         )
         return token, tracker
 

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1000,6 +1000,11 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             tracker,
         ))
         token = tracking_svc.send_tracked(msg, tracker)
+        self.on_message(
+            msg,
+            self._this_occupant,
+            aioxmpp.im.dispatcher.MessageSource.STREAM,
+        )
         return token, tracker
 
     @asyncio.coroutine

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1409,7 +1409,7 @@ class MUCClient(aioxmpp.service.Service):
                 return
         muc._inbound_muc_user_presence(stanza)
 
-    def _inbound_muc_presence(self, stanza):
+    def _inbound_presence_error(self, stanza):
         mucjid = stanza.from_.bare()
         try:
             pending, fut, *_ = self._pending_mucs.pop(mucjid)
@@ -1428,8 +1428,8 @@ class MUCClient(aioxmpp.service.Service):
         if stanza.xep0045_muc_user is not None:
             self._inbound_muc_user_presence(stanza)
             return None
-        if stanza.xep0045_muc is not None:
-            self._inbound_muc_presence(stanza)
+        if stanza.type_ == aioxmpp.structs.PresenceType.ERROR:
+            self._inbound_presence_error(stanza)
             return None
         return stanza
 

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -918,7 +918,6 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
         self._tracking_by_id.pop(id_key, None)
         self._tracking_by_body.pop(body_key, None)
 
-    @asyncio.coroutine
     def send_message_tracked(self, msg):
         """
         Send a message to the MUC with tracking.
@@ -1000,7 +999,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             self._tracker_closed,
             tracker,
         ))
-        token = yield from tracking_svc.send_tracked(msg, tracker)
+        token = tracking_svc.send_tracked(msg, tracker)
         return token, tracker
 
     @asyncio.coroutine

--- a/aioxmpp/tracking.py
+++ b/aioxmpp/tracking.py
@@ -393,11 +393,15 @@ class BasicTrackingService(aioxmpp.service.Service):
         try:
             fut.result()
         except asyncio.CancelledError:
-            pass
+            return
         except:
-            tracker._set_state(MessageState.ABORTED)
+            next_state = MessageState.ABORTED
         else:
-            tracker._set_state(MessageState.DELIVERED_TO_SERVER)
+            next_state = MessageState.DELIVERED_TO_SERVER
+        try:
+            tracker._set_state(next_state)
+        except ValueError:
+            pass
 
     def send_tracked(self, stanza, tracker):
         """

--- a/aioxmpp/tracking.py
+++ b/aioxmpp/tracking.py
@@ -55,8 +55,9 @@ implement the management of additional information:
 
 Option (1) has the appeal that users (applications) do not have to worry about
 properly releasing the tracking objects. However, it has the downside that
-applications have to keep the :class:`MessageeTracker` instance around. Remember
-that connecting to callbacks of an object is *not* enough to keep it alive.
+applications have to keep the :class:`MessageeTracker` instance around.
+Remember that connecting to callbacks of an object is *not* enough to keep it
+alive.
 
 Option (2) is somewhat like file objects work: in theory, you have to close
 them explicitly and manually: if you do not, there is no guarantee when the

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -22,6 +22,9 @@ Version 0.10
   is deprecated and you should upgrade your code to use one of the two named
   classes explicitly.
 
+* Make :meth:`aioxmpp.muc.Room.send_message_tracked` a normal method instead
+  of a coroutine (it was never intended to be a coroutine).
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -33,6 +33,9 @@ Version 0.10
   a :class:`aioxmpp.tracking.MessageTracker` for sent messages (including
   those sent by other resources of the account in the same conversation).
 
+* Fix (harmless) traceback in logs which could occur when using
+  :meth:`aioxmpp.muc.Room.send_message_tracked`.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -25,6 +25,9 @@ Version 0.10
 * Make :meth:`aioxmpp.muc.Room.send_message_tracked` a normal method instead
   of a coroutine (it was never intended to be a coroutine).
 
+* Emit :meth:`aioxmpp.im.conversation.AbstractConversation.on_message` for
+  MUC messages sent via :meth:`~aioxmpp.muc.Room.send_message_tracked`.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,6 +28,11 @@ Version 0.10
 * Emit :meth:`aioxmpp.im.conversation.AbstractConversation.on_message` for
   MUC messages sent via :meth:`~aioxmpp.muc.Room.send_message_tracked`.
 
+* Add ``tracker`` argument to
+  :meth:`aioxmpp.im.conversation.AbstractConversation.on_message`. It carries
+  a :class:`aioxmpp.tracking.MessageTracker` for sent messages (including
+  those sent by other resources of the account in the same conversation).
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/tests/muc/test_e2e.py
+++ b/tests/muc/test_e2e.py
@@ -396,7 +396,7 @@ class TestMuc(TestCase):
 
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body[None] = "foo"
-        _, tracker = yield from self.firstroom.send_message_tracked(msg)
+        token, tracker = self.firstroom.send_message_tracked(msg)
         tracker.on_state_changed.connect(onstatechange)
         yield from sent_future
 

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -3107,41 +3107,6 @@ class TestService(unittest.TestCase):
 
         handler.assert_not_called()
 
-    def test__handle_presence_catches_presence_with_muc(self):
-        presence = aioxmpp.stanza.Presence()
-        presence.xep0045_muc = muc_xso.GenericExt()
-        with unittest.mock.patch.object(
-                self.s,
-                "_inbound_muc_presence") as handler:
-            handler.return_value = 123
-            self.assertIsNone(
-                self.s._handle_presence(
-                    presence,
-                    presence.from_,
-                    False,
-                )
-            )
-
-        handler.assert_called_with(presence)
-
-    def test__handle_presence_ignores_presence_with_muc_if_sent(self):
-        presence = aioxmpp.stanza.Presence()
-        presence.xep0045_muc = muc_xso.GenericExt()
-        with unittest.mock.patch.object(
-                self.s,
-                "_inbound_muc_presence") as handler:
-            handler.return_value = 123
-            self.assertIs(
-                presence,
-                self.s._handle_presence(
-                    presence,
-                    presence.from_,
-                    True,
-                )
-            )
-
-        handler.assert_not_called()
-
     def test_join_without_password_or_history(self):
         with self.assertRaises(KeyError):
             self.s.get_muc(TEST_MUC_JID)
@@ -3338,7 +3303,6 @@ class TestService(unittest.TestCase):
         response = aioxmpp.stanza.Presence(
             from_=TEST_MUC_JID,
             type_=aioxmpp.structs.PresenceType.ERROR)
-        response.xep0045_muc = muc_xso.GenericExt()
         response.error = aioxmpp.stanza.Error()
         self.s._handle_presence(
             response,

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -291,7 +291,6 @@ class TestRoom(unittest.TestCase):
         self.base.service.dependencies[
             aioxmpp.tracking.BasicTrackingService
         ] = self.base.tracking_service
-        self.base.tracking_service.send_tracked = CoroutineMock()
 
         self.jmuc = muc_service.Room(self.base.service, self.mucjid)
 
@@ -2214,9 +2213,7 @@ class TestRoom(unittest.TestCase):
             self.base.tracking_service.send_tracked.return_value = \
                 unittest.mock.sentinel.token
 
-            result = run_coroutine(
-                self.jmuc.send_message_tracked(msg)
-            )
+            result = self.jmuc.send_message_tracked(msg)
 
         self.assertIsNotNone(msg.id_)
 
@@ -2276,9 +2273,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,
@@ -2326,9 +2321,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,
@@ -2376,9 +2369,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,
@@ -2430,9 +2421,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,
@@ -2484,9 +2473,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,
@@ -2548,9 +2535,7 @@ class TestRoom(unittest.TestCase):
             {aioxmpp.structs.LanguageTag.fromstr("de"): "ein Text"}
         )
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,
@@ -2630,13 +2615,9 @@ class TestRoom(unittest.TestCase):
         msg2 = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg2.body.update({None: "some text"})
 
-        _, tracker1 = run_coroutine(
-            self.jmuc.send_message_tracked(msg1)
-        )
+        _, tracker1 = self.jmuc.send_message_tracked(msg1)
 
-        _, tracker2 = run_coroutine(
-            self.jmuc.send_message_tracked(msg2)
-        )
+        _, tracker2 = self.jmuc.send_message_tracked(msg2)
 
         self.assertEqual(
             tracker1.state,
@@ -2718,9 +2699,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
         tracker._set_state(aioxmpp.tracking.MessageState.SEEN_BY_RECIPIENT)
 
         reflected = aioxmpp.Message(
@@ -2757,9 +2736,7 @@ class TestRoom(unittest.TestCase):
         msg = aioxmpp.Message(aioxmpp.MessageType.NORMAL)
         msg.body.update({None: "some text"})
 
-        _, tracker = run_coroutine(
-            self.jmuc.send_message_tracked(msg)
-        )
+        _, tracker = self.jmuc.send_message_tracked(msg)
 
         self.assertEqual(
             tracker.state,


### PR DESCRIPTION
* Generate trackers for sent messages we receive via Carbons
* Fix missing emission of ``on_message`` from MUC ``send_message_tracked``.
* Fix a traceback which can happen in real-life when using MUC.
* ``send_message_tracked`` of MUC was a coroutine, even though that was not intended by AbstractConversation