### PR TITLE
service: fix is_{dep,attr}signal_handler with defer=True

### DIFF
--- a/aioxmpp/service.py
+++ b/aioxmpp/service.py
@@ -927,6 +927,12 @@ def _apply_connect_depsignal(instance, stream, func, dependency, signal_name,
     if mode is None:
         return signal.context_connect(func)
     else:
+        try:
+            mode_func, args = mode
+        except TypeError:
+            pass
+        else:
+            mode = mode_func(*args)
         return signal.context_connect(func, mode)
 
 
@@ -946,6 +952,12 @@ def _apply_connect_attrsignal(instance, stream, func, descriptor, signal_name,
     if mode is None:
         return signal.context_connect(func)
     else:
+        try:
+            mode_func, args = mode
+        except TypeError:
+            pass
+        else:
+            mode = mode_func(*args)
         return signal.context_connect(func, mode)
 
 
@@ -1124,14 +1136,14 @@ def _signal_connect_mode(signal, f, defer):
     else:
         if asyncio.iscoroutinefunction(f):
             if defer:
-                mode = aioxmpp.callbacks.AdHocSignal.SPAWN_WITH_LOOP(None)
+                mode = aioxmpp.callbacks.AdHocSignal.SPAWN_WITH_LOOP, (None,)
             else:
                 raise TypeError(
                     "cannot use coroutine function with this signal"
                     " without defer"
                 )
         elif defer:
-            mode = aioxmpp.callbacks.AdHocSignal.ASYNC_WITH_LOOP(None)
+            mode = aioxmpp.callbacks.AdHocSignal.ASYNC_WITH_LOOP, (None,)
         else:
             mode = aioxmpp.callbacks.AdHocSignal.STRONG
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -40,6 +40,9 @@ Version 0.10
 * Fix (harmless) traceback in logs which could occur when using
   :meth:`aioxmpp.muc.Room.send_message_tracked`.
 
+* Fix :func:`aioxmpp.service.is_depsignal_handler` and
+  :func:`~aioxmpp.service.is_attrsignal_handler` when used with ``defer=True``.
+
 .. _api-changelog-0.9:
 
 Version 0.9


### PR DESCRIPTION
As discovered by @sebastianriese while working on #125.