### PR TITLE
Rework conversation join/new events

### DIFF
--- a/aioxmpp/avatar/service.py
+++ b/aioxmpp/avatar/service.py
@@ -202,7 +202,7 @@ class AbstractAvatarDescriptor:
     If :attr:`has_image_data_in_pubsub` is true, the image can be
     retrieved by the following coroutine:
 
-    .. autocoroutine:: get_image_bytes
+    .. automethod:: get_image_bytes
     """
 
     def __init__(self, remote_jid, mime_type, id_, nbytes, width=None,

--- a/aioxmpp/im/__init__.py
+++ b/aioxmpp/im/__init__.py
@@ -103,6 +103,12 @@ Conversations
 
 .. autoclass:: AbstractConversationMember
 
+
+Conversation Service
+--------------------
+
+.. autoclass:: AbstractConversationService
+
 """
 
 from .conversation import (  # NOQA

--- a/aioxmpp/im/conversation.py
+++ b/aioxmpp/im/conversation.py
@@ -386,6 +386,37 @@ class AbstractConversation(metaclass=abc.ABCMeta):
         :param new_topic: The new topic of the conversation.
         :type new_topic: :class:`.LanguageMap`
 
+    .. signal:: on_enter(**kwargs)
+
+        The conversation was entered.
+
+        This event is emitted up to once for a :class:`AbstractConversation`.
+
+        One of :meth:`on_enter` and :meth:`on_failure` is emitted exactly
+        once for each :class:`AbstractConversation` instance.
+
+        .. versionadded:: 0.10
+
+    .. signal:: on_failure(exc, **kwargs)
+
+        The conversation could not be entered.
+
+        :param exc: The exception which caused the operation to fail.
+        :type exc: :class:`Exception`
+
+        Often, `exc` will be a :class:`aioxmpp.errors.XMPPError` indicating
+        an error emitted from an involved server, such as permission problems,
+        conflicts or non-existant peers.
+
+        This signal can only be emitted instead of :meth:`on_enter` and not
+        after the room has been entered. If the conversation is terminated
+        due to a remote cause at a later point, :meth:`on_exit` is used.
+
+        One of :meth:`on_enter` and :meth:`on_failure` is emitted exactly
+        once for each :class:`AbstractConversation` instance.
+
+        .. versionadded:: 0.10
+
     .. signal:: on_join(member, **kwargs)
 
        A new member has joined the conversation.
@@ -461,6 +492,11 @@ class AbstractConversation(metaclass=abc.ABCMeta):
     on_join = aioxmpp.callbacks.Signal()
     on_leave = aioxmpp.callbacks.Signal()
     on_exit = aioxmpp.callbacks.Signal()
+    on_failed = aioxmpp.callbacks.Signal()
+    on_nick_changed = aioxmpp.callbacks.Signal()
+    on_enter = aioxmpp.callbacks.Signal()
+    on_failure = aioxmpp.callbacks.Signal()
+    on_topic_changed = aioxmpp.callbacks.Signal()
 
     def __init__(self, service, parent=None, **kwargs):
         super().__init__(**kwargs)

--- a/aioxmpp/im/conversation.py
+++ b/aioxmpp/im/conversation.py
@@ -843,17 +843,7 @@ class AbstractConversationService(metaclass=abc.ABCMeta):
 
         .. versionadded:: 0.10
 
-    .. signal:: on_conversation_left(conversation)
-
-        Fires when a conversation is left.
-
-        :param conversation: The left conversation.
-        :type conversation: :class:`AbstractConversation`
-
-        The conversation is to be considered defunct afterwards.
-
     """
 
     on_conversation_new = aioxmpp.callbacks.Signal()
     on_spontaneous_conversation = aioxmpp.callbacks.Signal()
-    on_conversation_left = aioxmpp.callbacks.Signal()

--- a/aioxmpp/im/conversation.py
+++ b/aioxmpp/im/conversation.py
@@ -805,5 +805,55 @@ class AbstractConversation(metaclass=abc.ABCMeta):
 
 
 class AbstractConversationService(metaclass=abc.ABCMeta):
+    """
+    Abstract base class for
+    :term:`Conversation Services <Conversation Service>`.
+
+    Useful implementations:
+
+    .. autosummary::
+
+        aioxmpp.im.p2p.Service
+        aioxmpp.muc.MUCClient
+
+    Signals:
+
+    .. signal:: on_conversation_new(conversation)
+
+        Fires when a new conversation is created in the service.
+
+        :param conversation: The new conversation.
+        :type conversation: :class:`AbstractConversation`
+
+        .. seealso::
+
+            :meth:`.ConversationService.on_conversation_added`
+                is a signal shared among all :term:`Conversation
+                Implementations <Conversation Implementation>` which gets
+                emitted whenever a new conversation is added. If you need all
+                conversations, that is the signal to listen for.
+
+    .. signal:: on_spontaneous_conversation(conversation)
+
+        Like :meth:`on_conversation_new`, but is only emitted for conversations
+        which are created without local interaction.
+
+        :param conversation: The new conversation.
+        :type conversation: :class:`AbstractConversation`
+
+        .. versionadded:: 0.10
+
+    .. signal:: on_conversation_left(conversation)
+
+        Fires when a conversation is left.
+
+        :param conversation: The left conversation.
+        :type conversation: :class:`AbstractConversation`
+
+        The conversation is to be considered defunct afterwards.
+
+    """
+
     on_conversation_new = aioxmpp.callbacks.Signal()
+    on_spontaneous_conversation = aioxmpp.callbacks.Signal()
     on_conversation_left = aioxmpp.callbacks.Signal()

--- a/aioxmpp/im/conversation.py
+++ b/aioxmpp/im/conversation.py
@@ -386,7 +386,7 @@ class AbstractConversation(metaclass=abc.ABCMeta):
         :param new_topic: The new topic of the conversation.
         :type new_topic: :class:`.LanguageMap`
 
-    .. signal:: on_enter(**kwargs)
+    .. signal:: on_enter()
 
         The conversation was entered.
 
@@ -395,9 +395,26 @@ class AbstractConversation(metaclass=abc.ABCMeta):
         One of :meth:`on_enter` and :meth:`on_failure` is emitted exactly
         once for each :class:`AbstractConversation` instance.
 
+        .. seealso::
+
+            :func:`aioxmpp.callbacks.first_signal` can be used nicely to await
+            the completion of entering a conversation::
+
+                conv = ... # let this be your conversation
+                await first_signal(conv.on_enter, conv.on_failure)
+                # await first_signal() will either return None (success) or
+                # raise the exception passed to :meth:`on_failure`.
+
+        .. note::
+
+            This and :meth:`on_failure` are the only signals which **must not**
+            receive keyword arguments, so that they continue to work with
+            :attr:`.AdHocSignal.AUTO_FUTURE` and
+            :func:`~.callbacks.first_signal`.
+
         .. versionadded:: 0.10
 
-    .. signal:: on_failure(exc, **kwargs)
+    .. signal:: on_failure(exc)
 
         The conversation could not be entered.
 
@@ -414,6 +431,13 @@ class AbstractConversation(metaclass=abc.ABCMeta):
 
         One of :meth:`on_enter` and :meth:`on_failure` is emitted exactly
         once for each :class:`AbstractConversation` instance.
+
+        .. note::
+
+            This and :meth:`on_failure` are the only signals which **must not**
+            receive keyword arguments, so that they continue to work with
+            :attr:`.AdHocSignal.AUTO_FUTURE` and
+            :func:`~.callbacks.first_signal`.
 
         .. versionadded:: 0.10
 
@@ -815,6 +839,14 @@ class AbstractConversationService(metaclass=abc.ABCMeta):
 
         aioxmpp.im.p2p.Service
         aioxmpp.muc.MUCClient
+
+    In general, conversation services should provide a method (*not* a coroutine
+    method) to start a conversation using the service. That method should return
+    the fresh :class:`~.AbstractConversation` object immediately and start
+    possibly needed background tasks to actually initiate the conversation. The
+    caller should use the :meth:`~.AbstractConversation.on_enter` and
+    :meth:`~.AbstractConversation.on_failure` signals to be notified of the
+    result of the join operation.
 
     Signals:
 

--- a/aioxmpp/im/p2p.py
+++ b/aioxmpp/im/p2p.py
@@ -146,6 +146,7 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
         result = Conversation(self, peer_jid, parent=None)
         self._conversationmap[peer_jid] = result
         self.on_conversation_new(result)
+        result.on_enter()
         return result
 
     @aioxmpp.service.depfilter(IMDispatcher, "message_filter")

--- a/aioxmpp/im/p2p.py
+++ b/aioxmpp/im/p2p.py
@@ -112,6 +112,11 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
     """
     Manage one-to-one conversations.
 
+    .. seealso::
+
+        :class:`~.AbstractConversationService`
+            for useful common signals
+
     This service manages one-to-one conversations, including private
     conversations running in the framework of a multi-user chat. In those
     cases, the respective multi-user chat conversation service requests a

--- a/aioxmpp/im/p2p.py
+++ b/aioxmpp/im/p2p.py
@@ -206,4 +206,3 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
 
     def _conversation_left(self, conv):
         del self._conversationmap[conv.peer_jid]
-        self.on_conversation_left(conv)

--- a/aioxmpp/im/p2p.py
+++ b/aioxmpp/im/p2p.py
@@ -181,7 +181,6 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
 
         return msg
 
-    @asyncio.coroutine
     def get_conversation(self, peer_jid, *, current_jid=None):
         """
         Get or create a new one-to-one conversation with a peer.
@@ -196,6 +195,10 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
 
         `peer_jid` must be a full or bare JID. See the :class:`Service`
         documentation for details.
+
+        .. versionchanged:: 0.10
+
+            In 0.9, this was a coroutine. Sorry.
         """
 
         try:

--- a/aioxmpp/im/p2p.py
+++ b/aioxmpp/im/p2p.py
@@ -147,9 +147,11 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
             self.dependencies[ConversationService]._add_conversation
         )
 
-    def _make_conversation(self, peer_jid):
+    def _make_conversation(self, peer_jid, spontaneous):
         result = Conversation(self, peer_jid, parent=None)
         self._conversationmap[peer_jid] = result
+        if spontaneous:
+            self.on_spontaneous_conversation(result)
         self.on_conversation_new(result)
         result.on_enter()
         return result
@@ -172,7 +174,7 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
                 conversation_jid = peer.bare()
                 if msg.xep0045_muc_user is not None:
                     conversation_jid = peer
-                existing = self._make_conversation(conversation_jid)
+                existing = self._make_conversation(conversation_jid, True)
 
             existing._handle_message(msg, peer, sent, source)
             return None
@@ -200,7 +202,7 @@ class Service(AbstractConversationService, aioxmpp.service.Service):
             return self._conversationmap[peer_jid]
         except KeyError:
             pass
-        return self._make_conversation(peer_jid)
+        return self._make_conversation(peer_jid, False)
 
     def _conversation_left(self, conv):
         del self._conversationmap[conv.peer_jid]

--- a/aioxmpp/im/service.py
+++ b/aioxmpp/im/service.py
@@ -93,11 +93,11 @@ class ConversationService(aioxmpp.service.Service):
         from the list automatically. There is no need to remove a conversation
         from the list explicitly.
         """
-        self.on_conversation_added(conversation)
-        conversation.on_exit.connect(
-            functools.partial(
-                self._handle_conversation_exit,
-                conversation
-            ),
+        handler = functools.partial(
+            self._handle_conversation_exit,
+            conversation
         )
+        conversation.on_exit.connect(handler)
+        conversation.on_failure.connect(handler)
         self._conversations.append(conversation)
+        self.on_conversation_added(conversation)

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1359,7 +1359,12 @@ class MUCClient(aioxmpp.service.Service):
                           self._pending_mucs,
                           self._joined_mucs)
 
-    def _pending_join_done(self, mucjid, fut):
+    def _pending_join_done(self, mucjid, room, fut):
+        try:
+            fut.result()
+        except Exception as exc:
+            room.on_failure(exc)
+
         if fut.cancelled():
             try:
                 del self._pending_mucs[mucjid]
@@ -1572,7 +1577,8 @@ class MUCClient(aioxmpp.service.Service):
         fut = asyncio.Future()
         fut.add_done_callback(functools.partial(
             self._pending_join_done,
-            mucjid
+            mucjid,
+            room,
         ))
         self._pending_mucs[mucjid] = room, fut, nick, history
 

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -481,25 +481,13 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
        details on who triggered the change in role and for what reason.
 
     """
-
-    on_message = aioxmpp.callbacks.Signal()
-
     # this occupant state events
-    on_enter = aioxmpp.callbacks.Signal()
     on_muc_suspend = aioxmpp.callbacks.Signal()
     on_muc_resume = aioxmpp.callbacks.Signal()
-    on_exit = aioxmpp.callbacks.Signal()
 
     # other occupant state events
-    on_join = aioxmpp.callbacks.Signal()
-    on_leave = aioxmpp.callbacks.Signal()
-    on_presence_changed = aioxmpp.callbacks.Signal()
     on_muc_affiliation_changed = aioxmpp.callbacks.Signal()
-    on_nick_changed = aioxmpp.callbacks.Signal()
     on_muc_role_changed = aioxmpp.callbacks.Signal()
-
-    # room state events
-    on_topic_changed = aioxmpp.callbacks.Signal()
 
     def __init__(self, service, mucjid):
         super().__init__(service)

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1506,7 +1506,8 @@ class MUCClient(aioxmpp.service.Service):
         signal is emitted immediately with the new :class:`Room`.
 
         It is recommended to attach the desired signals to the :class:`Room`
-        before yielding next (e.g. in a non-deferred event handler to the :meth:`~.ConversationService.on_conversation_added` signal), to avoid
+        before yielding next (e.g. in a non-deferred event handler to the
+        :meth:`~.ConversationService.on_conversation_added` signal), to avoid
         races with the server. It is guaranteed that no signals are emitted
         before the next yield, and thus, it is safe to attach the signals right
         after :meth:`join` returned. (This is also the reason why :meth:`join`

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1240,9 +1240,15 @@ def _connect_to_signal(signal, func):
     return signal, signal.connect(func)
 
 
-class MUCClient(aioxmpp.service.Service):
+class MUCClient(aioxmpp.im.conversation.AbstractConversationService,
+                aioxmpp.service.Service):
     """
     :term:`Conversation Implementation` for Multi-User Chats (:xep:`45`).
+
+    .. seealso::
+
+        :class:`~.AbstractConversationService`
+            for useful common signals
 
     This service provides access to Multi-User Chats using the
     conversation interface defined by :mod:`aioxmpp.im`.
@@ -1274,6 +1280,11 @@ class MUCClient(aioxmpp.service.Service):
 
         This class was completely remodeled in 0.9 to conform with the
         :class:`aioxmpp.im` interface.
+
+    .. versionchanged:: 0.10
+
+        This class now conforms to the :class:`~.AbstractConversationService`
+        interface.
 
     """
 
@@ -1586,6 +1597,7 @@ class MUCClient(aioxmpp.service.Service):
         if self.client.established:
             self._send_join_presence(mucjid, history, nick, password)
 
+        self.on_conversation_new(room)
         self.dependencies[
             aioxmpp.im.service.ConversationService
         ]._add_conversation(room)

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -118,7 +118,7 @@ def make_listener(instance):
 
     The children are named exactly like the signals.
     """
-    result = unittest.mock.Mock()
+    result = unittest.mock.Mock([])
     names = {
         name
         for type_ in type(instance).__mro__
@@ -128,7 +128,8 @@ def make_listener(instance):
         signal = getattr(instance, name)
         if not isinstance(signal, callbacks.AdHocSignal):
             continue
-        cb = getattr(result, name)
+        cb = unittest.mock.Mock()
+        setattr(result, name, cb)
         cb.return_value = None
         signal.connect(cb)
     return result

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -134,7 +134,6 @@ def make_listener(instance):
     return result
 
 
-
 class FilterMock(unittest.mock.Mock):
     def __init__(self):
         super().__init__([

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -119,12 +119,18 @@ def make_listener(instance):
     The children are named exactly like the signals.
     """
     result = unittest.mock.Mock()
-    for name, obj in type(instance).__dict__.items():
-        if not isinstance(obj, callbacks.Signal):
+    names = {
+        name
+        for type_ in type(instance).__mro__
+        for name in type_.__dict__
+    }
+    for name in names:
+        signal = getattr(instance, name)
+        if not isinstance(signal, callbacks.AdHocSignal):
             continue
         cb = getattr(result, name)
         cb.return_value = None
-        getattr(instance, name).connect(cb)
+        signal.connect(cb)
     return result
 
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -55,6 +55,10 @@ Version 0.10
 
 * Implement :func:`aioxmpp.callbacks.first_signal`.
 
+* Specify :meth:`aioxmpp.im.conversation.AbstractConversation.on_enter` and
+  :meth:`~aioxmpp.im.conversation.AbstractConversation.on_failure` events and
+  implement emission of those for the existing conversation implementations.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -59,6 +59,15 @@ Version 0.10
   :meth:`~aioxmpp.im.conversation.AbstractConversation.on_failure` events and
   implement emission of those for the existing conversation implementations.
 
+* Specify that :term:`Conversation Services <Conversation Service>` must
+  provide a non-coroutine method to start a conversation. Asynchronous parts
+  have to happen in the background. To await the completion of the
+  initialisation of the conversation, use
+  :func:`aioxmpp.callbacks.first_signal` as described in
+  :meth:`aioxmpp.im.conversation.AbstractConversation.on_enter`.
+
+* Make :meth:`aioxmpp.im.p2p.Service.get_conversation` a normal method.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/tests/im/test_p2p.py
+++ b/tests/im/test_p2p.py
@@ -194,7 +194,7 @@ class TestService(unittest.TestCase):
                 "aioxmpp.im.p2p.Conversation"
             ))
 
-            c = run_coroutine(self.s.get_conversation(PEER_JID))
+            c = self.s.get_conversation(PEER_JID)
 
         self.cc.stream.register_message_callback.assert_not_called()
 
@@ -215,7 +215,7 @@ class TestService(unittest.TestCase):
                 "aioxmpp.im.p2p.Conversation"
             ))
 
-            c = run_coroutine(self.s.get_conversation(PEER_JID))
+            c = self.s.get_conversation(PEER_JID)
 
         self.listener.on_conversation_added.assert_called_once_with(c)
 
@@ -231,7 +231,7 @@ class TestService(unittest.TestCase):
                 "aioxmpp.im.p2p.Conversation"
             ))
 
-            c = run_coroutine(self.s.get_conversation(PEER_JID))
+            c = self.s.get_conversation(PEER_JID)
 
         self.listener.on_conversation_added.assert_called_once_with(c)
 
@@ -243,7 +243,7 @@ class TestService(unittest.TestCase):
                 "aioxmpp.im.p2p.Conversation"
             ))
 
-            run_coroutine(self.s.get_conversation(PEER_JID))
+            self.s.get_conversation(PEER_JID)
 
         self.listener.on_spontaneous_conversation.assert_not_called()
 
@@ -253,8 +253,8 @@ class TestService(unittest.TestCase):
                 "aioxmpp.im.p2p.Conversation"
             ))
 
-            c1 = run_coroutine(self.s.get_conversation(PEER_JID))
-            c2 = run_coroutine(self.s.get_conversation(PEER_JID))
+            c1 = self.s.get_conversation(PEER_JID)
+            c2 = self.s.get_conversation(PEER_JID)
 
         Conversation.assert_called_once_with(
             self.s,
@@ -275,10 +275,10 @@ class TestService(unittest.TestCase):
             ))
             Conversation.side_effect = generate_mocks()
 
-            c1 = run_coroutine(self.s.get_conversation(PEER_JID))
+            c1 = self.s.get_conversation(PEER_JID)
             c1.peer_jid = PEER_JID
             self.s._conversation_left(c1)
-            c2 = run_coroutine(self.s.get_conversation(PEER_JID))
+            c2 = self.s.get_conversation(PEER_JID)
 
         self.assertIsNot(c1, c2)
 
@@ -293,11 +293,11 @@ class TestService(unittest.TestCase):
             ))
             Conversation.side_effect = generate_mocks()
 
-            c1 = run_coroutine(self.s.get_conversation(PEER_JID))
+            c1 = self.s.get_conversation(PEER_JID)
             self.listener.on_conversation_new.assert_called_once_with(c1)
             c1.peer_jid = PEER_JID
             self.s._conversation_left(c1)
-            c2 = run_coroutine(self.s.get_conversation(PEER_JID))
+            c2 = self.s.get_conversation(PEER_JID)
             self.listener.on_conversation_new.assert_called_with(c2)
 
         self.assertIsNot(c1, c2)
@@ -347,7 +347,7 @@ class TestService(unittest.TestCase):
                 parent=None
             )
 
-            c = run_coroutine(self.s.get_conversation(PEER_JID))
+            c = self.s.get_conversation(PEER_JID)
             Conversation.assert_called_once_with(
                 self.s,
                 msg.from_.bare(),
@@ -395,9 +395,9 @@ class TestService(unittest.TestCase):
                 parent=None
             )
 
-            c = run_coroutine(self.s.get_conversation(
+            c = self.s.get_conversation(
                 PEER_JID.replace(localpart="fnord")
-            ))
+            )
             Conversation.assert_called_once_with(
                 self.s,
                 PEER_JID.replace(localpart="fnord"),
@@ -446,9 +446,9 @@ class TestService(unittest.TestCase):
                 parent=None
             )
 
-            c = run_coroutine(self.s.get_conversation(
+            c = self.s.get_conversation(
                 PEER_JID.replace(localpart="fnord", resource="foo")
-            ))
+            )
             Conversation.assert_called_once_with(
                 self.s,
                 PEER_JID.replace(localpart="fnord", resource="foo"),
@@ -496,7 +496,7 @@ class TestService(unittest.TestCase):
                 parent=None
             )
 
-            c = run_coroutine(self.s.get_conversation(PEER_JID))
+            c = self.s.get_conversation(PEER_JID)
             Conversation.assert_called_once_with(
                 self.s,
                 msg.from_.bare(),
@@ -657,11 +657,11 @@ class TestE2E(TestCase):
     @blocking_timed
     @asyncio.coroutine
     def test_converse_with_preexisting(self):
-        c1 = yield from self.firstwitch.summon(p2p.Service).get_conversation(
+        c1 = self.firstwitch.summon(p2p.Service).get_conversation(
             self.secondwitch.local_jid.bare()
         )
 
-        c2 = yield from self.secondwitch.summon(p2p.Service).get_conversation(
+        c2 = self.secondwitch.summon(p2p.Service).get_conversation(
             self.firstwitch.local_jid.bare()
         )
 

--- a/tests/im/test_p2p.py
+++ b/tests/im/test_p2p.py
@@ -167,7 +167,8 @@ class TestService(unittest.TestCase):
         self.listener = make_listener(self.s)
 
         for ev in ["on_conversation_added"]:
-            listener = getattr(self.listener, ev)
+            listener = unittest.mock.Mock()
+            setattr(self.listener, ev, listener)
             signal = getattr(deps[im_service.ConversationService], ev)
             listener.return_value = None
             signal.connect(listener)

--- a/tests/im/test_p2p.py
+++ b/tests/im/test_p2p.py
@@ -296,7 +296,6 @@ class TestService(unittest.TestCase):
             self.listener.on_conversation_new.assert_called_once_with(c1)
             c1.peer_jid = PEER_JID
             self.s._conversation_left(c1)
-            self.listener.on_conversation_left.assert_called_once_with(c1)
             c2 = run_coroutine(self.s.get_conversation(PEER_JID))
             self.listener.on_conversation_new.assert_called_with(c2)
 

--- a/tests/muc/test_e2e.py
+++ b/tests/muc/test_e2e.py
@@ -471,7 +471,7 @@ class TestMuc(TestCase):
         secondwitch_p2p = self.secondwitch.summon(
             aioxmpp.im.p2p.Service,
         )
-        secondconv = yield from secondwitch_p2p.get_conversation(
+        secondconv = secondwitch_p2p.get_conversation(
             self.secondroom.members[1].conversation_jid
         )
 

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -2925,6 +2925,12 @@ class TestService(unittest.TestCase):
             service.Service
         ))
 
+    def test_is_conversation_service(self):
+        self.assertTrue(issubclass(
+            muc_service.MUCClient,
+            im_conversation.AbstractConversationService,
+        ))
+
     def setUp(self):
         self.cc = make_connected_client()
         self.im_dispatcher = im_dispatcher.IMDispatcher(self.cc)
@@ -2939,6 +2945,7 @@ class TestService(unittest.TestCase):
             im_service.ConversationService: self.im_service,
             aioxmpp.tracking.BasicTrackingService: self.tracking_service,
         })
+        self.listener = make_listener(self.s)
 
     def test_depends_on_IMDispatcher(self):
         self.assertIn(
@@ -3116,6 +3123,7 @@ class TestService(unittest.TestCase):
         room, future = self.s.join(TEST_MUC_JID, "thirdwitch")
 
         self.im_service._add_conversation.assert_called_once_with(room)
+        self.listener.on_conversation_new.assert_called_once_with(room)
 
         self.assertIs(
             self.s.get_muc(TEST_MUC_JID),

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -1991,14 +1991,14 @@ class TestRoom(unittest.TestCase):
         self.assertEqual(stanza.show, aioxmpp.PresenceShow.NONE)
 
         self.jmuc.on_exit(muc_leave_mode=object(),
-                            muc_actor=object(),
-                            muc_reason=object())
+                          muc_actor=object(),
+                          muc_reason=object())
 
         self.assertIsNone(run_coroutine(fut))
 
         self.jmuc.on_exit(muc_leave_mode=object(),
-                            muc_actor=object(),
-                            muc_reason=object())
+                          muc_actor=object(),
+                          muc_reason=object())
 
     def test_members(self):
         presence = aioxmpp.stanza.Presence(
@@ -3342,7 +3342,8 @@ class TestService(unittest.TestCase):
             future.exception(),
         )
 
-    def test_on_failure_is_emitted_on_stream_destruction_without_autorejoin(self):
+    def test_on_failure_is_emitted_on_stream_destruction_without_autorejoin(
+            self):
         room, future = self.s.join(TEST_MUC_JID, "thirdwitch",
                                    autorejoin=False)
         listener = make_listener(room)

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -1119,3 +1119,14 @@ class Testmake_listener(unittest.TestCase):
 
         b.on_b("foo")
         listener.on_b.assert_called_once_with("foo")
+
+    def test_has_no_non_listener_attributes(self):
+        class Foo:
+            on_a = callbacks.Signal()
+
+        f = Foo()
+        listener = make_listener(f)
+
+        self.assertFalse(hasattr(listener, "foobar"))
+        with self.assertRaises(AttributeError):
+            listener.foobar


### PR DESCRIPTION
So I had those in the pipeline for some time now. They came into existance during development on MLXC.

The spirit is the following:

Conversation construction is a bit tricky, because normally we’d want to call a method on the respective Conversation Service (e.g. join()) and store the result away somewhere. This is the easy part. Things get funny with "spontaneous" conversations like the one-on-one implementation has (e.g. when a contact spontaneously starts messaging you): in that case, you have to rely on some event from the conversation service.

Before, there was no such event. There was, of course, the ``on_conversation_new`` event, but this is not usable: one cannot distinguish between spontaneous and non-spontaneous (locally triggered) conversations. Thus one would have to use that event for everything, which breaks the flow when using join() and awaiting the result future.

So here we have a new event on conversation services which is emitted when spontaneous conversations get started.

The other change is that ``on_enter``, ``on_failure`` and ``on_exit`` on AbstractConversation can now be used to track the full life-cycle of a conversation:

1. if joining/setting up of conversation fails, ``on_failure`` is emitted; processing stops here, the conversation is dead.
2. otherwise, ``on_enter`` is emitted.
3. ``on_exit`` is emitted when the conversation is torn down.

All of these events are emitted only after the ``on_conversation_new``/``on_spontaneous_conversation`` events have been emitted.