### PR TITLE
Synchronous callbacks for IQ handlers

### DIFF
--- a/aioxmpp/adhoc/service.py
+++ b/aioxmpp/adhoc/service.py
@@ -362,7 +362,7 @@ class AdHocServer(aioxmpp.service.Service, aioxmpp.disco.Node):
 
         When a request for the command is received, `handler` is invoked. The
         semantics of `handler` are the same as for
-        :meth:`~.StanzaStream.register_iq_request_coro`. It must produce a
+        :meth:`~.StanzaStream.register_iq_request_handler`. It must produce a
         valid :class:`~.adhoc.xso.Command` response payload.
 
         If `is_allowed` is not :data:`None`, it is invoked whenever a command

--- a/aioxmpp/callbacks.py
+++ b/aioxmpp/callbacks.py
@@ -152,6 +152,10 @@ class AsyncTagListener(TagListener):
 
 
 class OneshotTagListener(TagListener):
+    def __init__(self, ondata, onerror=None, **kwargs):
+        super().__init__(ondata, onerror=onerror, **kwargs)
+        self._cancelled = False
+
     def data(self, data):
         super().data(data)
         return True
@@ -159,6 +163,12 @@ class OneshotTagListener(TagListener):
     def error(self, exc):
         super().error(exc)
         return True
+
+    def cancel(self):
+        self._cancelled = True
+
+    def is_valid(self):
+        return not self._cancelled and super().is_valid()
 
 
 class OneshotAsyncTagListener(OneshotTagListener, AsyncTagListener):

--- a/aioxmpp/service.py
+++ b/aioxmpp/service.py
@@ -973,7 +973,7 @@ def iq_handler(type_, payload_cls):
 
     .. seealso::
 
-       :meth:`~.StanzaStream.register_iq_request_coro`
+       :meth:`~.StanzaStream.register_iq_request_handler`
           for more details on the `type_` and `payload_cls` arguments
 
     """

--- a/aioxmpp/service.py
+++ b/aioxmpp/service.py
@@ -963,25 +963,26 @@ def _apply_connect_attrsignal(instance, stream, func, descriptor, signal_name,
 
 def iq_handler(type_, payload_cls):
     """
-    Register the decorated coroutine function as IQ request handler.
+    Register the decorated function or coroutine function as IQ request
+    handler.
 
     :param type_: IQ type to listen for
     :type type_: :class:`~.IQType`
     :param payload_cls: Payload XSO class to listen for
     :type payload_cls: :class:`~.XSO` subclass
-    :raise TypeError: if the decorated object is not a coroutine function
+
+    If the decorated function is not a coroutine function, it must return an
+    awaitable instead.
 
     .. seealso::
 
        :meth:`~.StanzaStream.register_iq_request_handler`
-          for more details on the `type_` and `payload_cls` arguments
+          for more details on the `type_` and `payload_cls` arguments, as well
+          as behaviour expected from the decorated function.
 
     """
 
     def decorator(f):
-        if not asyncio.iscoroutinefunction(f):
-            raise TypeError("a coroutine function is required")
-
         add_handler_spec(
             f,
             HandlerSpec(

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -461,7 +461,7 @@ class StanzaStream:
 
     .. automethod:: register_iq_request_coro
 
-    .. automethod:: unregister_iq_request_handler
+    .. automethod:: unregister_iq_request_coro
 
     .. automethod:: register_iq_response_future
 

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -2403,15 +2403,6 @@ class StanzaStream:
         `timeout` seconds, :class:`TimeoutError` (not
         :class:`asyncio.TimeoutError`!) is raised.
 
-        .. warning::
-
-           Setting a timeout is recommended for IQ requests. If the IQ is sent
-           directly to the clients server for processing (i.e. if the
-           :attr:`~.IQ.to` attribute is :data:`None`), malformed responses
-           are discarded instead of raising :class:`.errors.ErroneusStanza`.
-           This is due to limitations in the :mod:`aioxmpp.xso` code, which are
-           to be fixed at some point.
-
         .. versionadded:: 0.8
         """
         stanza.autoset_id()

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -60,6 +60,12 @@ Version 0.10
   to coroutines, a callback function can exploit the strong ordering guarantee
   of the XMPP XML Stream.
 
+* Support for passing a callback function to
+  :meth:`aioxmpp.stream.StanzaStream.send` which is invoked on responses to an
+  IQ request sent through :meth:`~aioxmpp.stream.StanzaStream.send`. In contrast
+  to awaiting the result of :meth:`~aioxmpp.stream.StanzaStream.send`, the
+  callback can exploit the strong ordering guarantee of the XMPP XML Stream.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -66,6 +66,15 @@ Version 0.10
   to awaiting the result of :meth:`~aioxmpp.stream.StanzaStream.send`, the
   callback can exploit the strong ordering guarantee of the XMPP XML Stream.
 
+* *Deprecation*: The name
+  :meth:`aioxmpp.stream.StanzaStream.register_iq_request_coro` is deprecated
+  in favour of :meth:`~aioxmpp.stream.StanzaStream.register_iq_request_handler`.
+  The old alias persists, but will be removed with the release of 1.0. Using
+  the old alias emits a warning.
+
+  Likewise, :meth:`~aioxmpp.stream.StanzaStream.unregister_iq_request_coro` was
+  renamed to :meth:`~aioxmpp.stream.StanzaStream.unregister_iq_request_handler`.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -55,6 +55,11 @@ Version 0.10
 
 * Implement :func:`aioxmpp.callbacks.first_signal`.
 
+* Support for passing a function returning an awaitable as callback to
+  :meth:`aioxmpp.stream.StanzaStream.register_iq_request_coro`. In contrast
+  to coroutines, a callback function can exploit the strong ordering guarantee
+  of the XMPP XML Stream.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -75,6 +75,9 @@ Version 0.10
   Likewise, :meth:`~aioxmpp.stream.StanzaStream.unregister_iq_request_coro` was
   renamed to :meth:`~aioxmpp.stream.StanzaStream.unregister_iq_request_handler`.
 
+* The :func:`aioxmpp.service.iq_handler` decorator function now allows normal
+  functions to be decorated (in addition to coroutine functions).
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/user-guide/quickstart.rst
+++ b/docs/user-guide/quickstart.rst
@@ -228,7 +228,7 @@ IQ request handlers, instead of normal functions::
   async def request_handler(request):
       print(request)
 
-  client.stream.register_iq_request_coro(
+  client.stream.register_iq_request_handler(
       aioxmpp.IQType.GET,
       aioxmpp.disco.xso.InfoQuery,
       request_handler,
@@ -241,7 +241,7 @@ exception will be converted to a proper ``"error"`` IQ response.
 
 Relevant documentation:
 
-* :meth:`~aioxmpp.stream.StanzaStream.register_iq_request_coro`
+* :meth:`~aioxmpp.stream.StanzaStream.register_iq_request_handler`
 * :class:`aioxmpp.IQ`
 * :class:`aioxmpp.errors.XMPPError`
 
@@ -428,7 +428,7 @@ with``)::
       result.os = "MFHBμKOS (My Fancy HomeBrew Micro Kernel Operating System)"
       return result
 
-  client.stream.register_iq_request_coro(
+  client.stream.register_iq_request_handler(
       aioxmpp.IQType.GET,
       Query,
       handler,
@@ -451,7 +451,7 @@ for the ``"result"`` IQ or raise an exception (which would be converted to an
 
 Relevant documentation:
 
-* :meth:`aioxmpp.stream.StanzaStream.register_iq_request_coro`
+* :meth:`aioxmpp.stream.StanzaStream.register_iq_request_handler`
 * :meth:`aioxmpp.IQ.as_payload_class`
 
 

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -614,12 +614,12 @@ class TestDiscoServer(unittest.TestCase):
 
         self.assertCountEqual(
             [
-                unittest.mock.call.stream.register_iq_request_coro(
+                unittest.mock.call.stream.register_iq_request_handler(
                     structs.IQType.GET,
                     disco_xso.InfoQuery,
                     s.handle_info_request
                 ),
-                unittest.mock.call.stream.register_iq_request_coro(
+                unittest.mock.call.stream.register_iq_request_handler(
                     structs.IQType.GET,
                     disco_xso.ItemsQuery,
                     s.handle_items_request
@@ -632,11 +632,11 @@ class TestDiscoServer(unittest.TestCase):
         run_coroutine(self.s.shutdown())
         self.assertCountEqual(
             [
-                unittest.mock.call.stream.unregister_iq_request_coro(
+                unittest.mock.call.stream.unregister_iq_request_handler(
                     structs.IQType.GET,
                     disco_xso.InfoQuery
                 ),
-                unittest.mock.call.stream.unregister_iq_request_coro(
+                unittest.mock.call.stream.unregister_iq_request_handler(
                     structs.IQType.GET,
                     disco_xso.ItemsQuery
                 ),

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -151,7 +151,7 @@ class TestEntityCapabilities(TestCase):
             )
         )
 
-        self.source.stream.register_iq_request_coro(
+        self.source.stream.register_iq_request_handler(
             aioxmpp.IQType.GET,
             disco.xso.InfoQuery,
             fake_disco_handler,
@@ -239,7 +239,7 @@ class TestEntityCapabilities(TestCase):
             )
         )
 
-        self.source.stream.register_iq_request_coro(
+        self.source.stream.register_iq_request_handler(
             aioxmpp.IQType.GET,
             disco.xso.InfoQuery,
             fake_disco_handler,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -237,6 +237,25 @@ class TestTagDispatcher(unittest.TestCase):
             mock.mock_calls
         )
 
+    def test_unicast_to_cancelled_oneshot(self):
+        mock = unittest.mock.Mock()
+        obj = object()
+
+        l = OneshotTagListener(mock)
+
+        nh = TagDispatcher()
+        nh.add_listener("tag", l)
+
+        l.cancel()
+
+        with self.assertRaises(KeyError):
+            nh.unicast("tag", obj)
+
+        self.assertSequenceEqual(
+            [],
+            mock.mock_calls
+        )
+
     def test_unicast_removes_for_true_result(self):
         mock = unittest.mock.Mock()
         mock.return_value = True
@@ -268,6 +287,28 @@ class TestTagDispatcher(unittest.TestCase):
             [
                 unittest.mock.call(obj)
             ],
+            error.mock_calls
+        )
+        self.assertFalse(data.mock_calls)
+
+    def test_broadcast_error_to_cancelled_oneshot(self):
+        data = unittest.mock.Mock()
+        error = unittest.mock.Mock()
+        obj = object()
+
+        l = OneshotTagListener(data, error)
+
+        nh = TagDispatcher()
+        nh.add_listener("tag", l)
+
+        l.cancel()
+
+        nh.broadcast_error(obj)
+        with self.assertRaises(KeyError):
+            nh.unicast("tag", obj)
+
+        self.assertSequenceEqual(
+            [],
             error.mock_calls
         )
         self.assertFalse(data.mock_calls)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1339,19 +1339,14 @@ class Testiq_handler(unittest.TestCase):
             coro._aioxmpp_service_handlers,
         )
 
-    def test_requires_coroutine(self):
+    def test_accepts_normal_function(self):
         with unittest.mock.patch(
                 "asyncio.iscoroutinefunction") as iscoroutinefunction:
             iscoroutinefunction.return_value = False
 
-            with self.assertRaisesRegex(
-                    TypeError,
-                    "a coroutine function is required"):
-                self.decorator(unittest.mock.sentinel.coro)
+            self.decorator(unittest.mock.sentinel.coro)
 
-        iscoroutinefunction.assert_called_with(
-            unittest.mock.sentinel.coro,
-        )
+        iscoroutinefunction.assert_not_called()
 
     def test_works_with_is_iq_handler(self):
         @asyncio.coroutine

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -417,13 +417,13 @@ class TestStanzaStream(StanzaStreamTestBase):
 
     @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
                      "not applying to this version of aioxmpp")
-    def test_register_iq_request_coro_casts_enum_and_warn(self):
+    def test_register_iq_request_handler_casts_enum_and_warn(self):
         self.stream._ALLOW_ENUM_COERCION = True
         with self.assertWarnsRegex(
                 DeprecationWarning,
                 r"passing a non-enum value as type_ is deprecated and will "
                 "be invalid as of aioxmpp 1.0") as ctx:
-            self.stream.register_iq_request_coro(
+            self.stream.register_iq_request_handler(
                 "get",
                 FancyTestIQ,
                 unittest.mock.sentinel.coro,
@@ -437,31 +437,31 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaisesRegex(
                 ValueError,
                 r"only one listener is allowed per tag"):
-            self.stream.register_iq_request_coro(
+            self.stream.register_iq_request_handler(
                 structs.IQType.GET,
                 FancyTestIQ,
                 unittest.mock.sentinel.coro,
             )
 
-    def test_register_iq_request_coro_raises_on_string_type(self):
+    def test_register_iq_request_handler_raises_on_string_type(self):
         if aioxmpp.version_info < (1, 0, 0):
             self.stream._ALLOW_ENUM_COERCION = False
 
         with self.assertRaisesRegex(
                 TypeError,
                 r"type_ must be IQType, got .*"):
-            self.stream.register_iq_request_coro(
+            self.stream.register_iq_request_handler(
                 "get",
                 FancyTestIQ,
                 unittest.mock.sentinel.coro,
             )
 
-    def test_register_iq_request_coro_does_not_warn_on_enum(self):
+    def test_register_iq_request_handler_does_not_warn_on_enum(self):
         self.stream._ALLOW_ENUM_COERCION = True
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.stream.register_iq_request_coro(
+            self.stream.register_iq_request_handler(
                 structs.IQType.GET,
                 FancyTestIQ,
                 unittest.mock.sentinel.coro,
@@ -469,12 +469,12 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.assertFalse(w)
 
-    def test_register_iq_request_coro_rejects_duplicate_registration(self):
+    def test_register_iq_request_handler_rejects_duplicate_registration(self):
         @asyncio.coroutine
         def handle_request(stanza):
             pass
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -484,15 +484,15 @@ class TestStanzaStream(StanzaStreamTestBase):
             pass
 
         with self.assertRaises(ValueError):
-            self.stream.register_iq_request_coro(
+            self.stream.register_iq_request_handler(
                 structs.IQType.GET,
                 FancyTestIQ,
                 handle_request)
 
     @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
                      "not applying to this version of aioxmpp")
-    def test_unregister_iq_request_coro_casts_enum_and_warn(self):
-        self.stream.register_iq_request_coro(
+    def test_unregister_iq_request_handler_casts_enum_and_warn(self):
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             unittest.mock.sentinel.coro,
@@ -503,7 +503,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 DeprecationWarning,
                 r"passing a non-enum value as type_ is deprecated and will "
                 "be invalid as of aioxmpp 1.0") as ctx:
-            self.stream.unregister_iq_request_coro(
+            self.stream.unregister_iq_request_handler(
                 "get",
                 FancyTestIQ,
             )
@@ -514,13 +514,13 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
 
         with self.assertRaises(KeyError):
-            self.stream.unregister_iq_request_coro(
+            self.stream.unregister_iq_request_handler(
                 structs.IQType.GET,
                 FancyTestIQ,
             )
 
-    def test_unregister_iq_request_coro_raises_on_string_type(self):
-        self.stream.register_iq_request_coro(
+    def test_unregister_iq_request_handler_raises_on_string_type(self):
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             unittest.mock.sentinel.coro,
@@ -532,13 +532,13 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaisesRegex(
                 TypeError,
                 r"type_ must be IQType, got .*"):
-            self.stream.unregister_iq_request_coro(
+            self.stream.unregister_iq_request_handler(
                 "get",
                 FancyTestIQ,
             )
 
-    def test_unregister_iq_request_coro_does_not_warn_on_enum(self):
-        self.stream.register_iq_request_coro(
+    def test_unregister_iq_request_handler_does_not_warn_on_enum(self):
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             unittest.mock.sentinel.coro,
@@ -548,17 +548,17 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.stream.unregister_iq_request_coro(
+            self.stream.unregister_iq_request_handler(
                 structs.IQType.GET,
                 FancyTestIQ,
             )
 
         self.assertFalse(w)
 
-    def test_register_iq_request_coro_raises_on_response_IQType(self):
+    def test_register_iq_request_handler_raises_on_response_IQType(self):
         for member in structs.IQType:
             if member.is_request:
-                self.stream.register_iq_request_coro(
+                self.stream.register_iq_request_handler(
                     member,
                     FancyTestIQ,
                     unittest.mock.sentinel.coro,
@@ -567,7 +567,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 with self.assertRaisesRegex(
                         ValueError,
                         r".* is not a request IQType"):
-                    self.stream.register_iq_request_coro(
+                    self.stream.register_iq_request_handler(
                         member,
                         FancyTestIQ,
                         unittest.mock.sentinel.coro,
@@ -585,7 +585,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             response_payload = FancyTestIQ()
             return response_payload
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -614,7 +614,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             fut.set_result(response_payload)
             return fut
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -659,7 +659,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         def handle_request(stanza):
             raise Exception("foo")
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -687,7 +687,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         def handle_request(stanza):
             raise Exception("foo")
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -719,7 +719,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 text="foobarbaz",
             )
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -754,7 +754,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 text="foobarbaz",
             )
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
@@ -777,13 +777,13 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.stop()
 
-    def test_unregister_iq_request_coro_raises_if_none_was_registered(self):
+    def test_unregister_iq_request_handler_raises_if_none_was_registered(self):
         with self.assertRaises(KeyError):
-            self.stream.unregister_iq_request_coro(
+            self.stream.unregister_iq_request_handler(
                 structs.IQType.GET,
                 FancyTestIQ)
 
-    def test_unregister_iq_request_coro(self):
+    def test_unregister_iq_request_handler(self):
         iq = make_test_iq()
         iq.autoset_id()
 
@@ -794,11 +794,11 @@ class TestStanzaStream(StanzaStreamTestBase):
             nonlocal recvd
             recvd = stanza
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             handle_request)
-        self.stream.unregister_iq_request_coro(
+        self.stream.unregister_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ)
 
@@ -1491,7 +1491,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 exc = inner_exc
                 raise
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             coro,
@@ -1525,7 +1525,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 exc = inner_exc
                 raise
 
-        self.stream.register_iq_request_coro(
+        self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
             coro,
@@ -3580,6 +3580,66 @@ class TestStanzaStream(StanzaStreamTestBase):
             result,
             reply.payload,
         )
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "not applying to this version of aioxmpp")
+    def test_register_iq_request_coro_warns_and_forwards_to_handler(self):
+        with contextlib.ExitStack() as stack:
+            handler = stack.enter_context(unittest.mock.patch.object(
+                self.stream,
+                "register_iq_request_handler",
+            ))
+
+            stack.enter_context(
+                self.assertWarnsRegex(
+                    DeprecationWarning,
+                    r"register_iq_request_coro is a deprecated alias to "
+                    r"register_iq_request_handler and will be removed in "
+                    r"aioxmpp 1.0")
+            )
+
+            result = self.stream.register_iq_request_coro(
+                unittest.mock.sentinel.type_,
+                unittest.mock.sentinel.payload_class,
+                unittest.mock.sentinel.coro,
+            )
+
+        handler.assert_called_once_with(
+            unittest.mock.sentinel.type_,
+            unittest.mock.sentinel.payload_class,
+            unittest.mock.sentinel.coro,
+        )
+
+        self.assertEqual(result, handler())
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "not applying to this version of aioxmpp")
+    def test_unregister_iq_request_coro_warns_and_forwards_to_handler(self):
+        with contextlib.ExitStack() as stack:
+            handler = stack.enter_context(unittest.mock.patch.object(
+                self.stream,
+                "unregister_iq_request_handler",
+            ))
+
+            stack.enter_context(
+                self.assertWarnsRegex(
+                    DeprecationWarning,
+                    r"unregister_iq_request_coro is a deprecated alias to "
+                    r"unregister_iq_request_handler and will be removed in "
+                    r"aioxmpp 1.0")
+            )
+
+            result = self.stream.unregister_iq_request_coro(
+                unittest.mock.sentinel.type_,
+                unittest.mock.sentinel.payload_class,
+            )
+
+        handler.assert_called_once_with(
+            unittest.mock.sentinel.type_,
+            unittest.mock.sentinel.payload_class,
+        )
+
+        self.assertEqual(result, handler())
 
 
 class TestStanzaStreamSM(StanzaStreamTestBase):
@@ -5650,7 +5710,7 @@ class Testiq_handler(unittest.TestCase):
     def test_enter_registers_coroutine(self):
         self.cm.__enter__()
 
-        self.stream.register_iq_request_coro.assert_called_with(
+        self.stream.register_iq_request_handler.assert_called_with(
             unittest.mock.sentinel.iqtype,
             unittest.mock.sentinel.payload,
             unittest.mock.sentinel.coro,
@@ -5662,7 +5722,7 @@ class Testiq_handler(unittest.TestCase):
 
         self.cm.__exit__(None, None, None)
 
-        self.stream.unregister_iq_request_coro.assert_called_with(
+        self.stream.unregister_iq_request_handler.assert_called_with(
             unittest.mock.sentinel.iqtype,
             unittest.mock.sentinel.payload,
         )
@@ -5679,7 +5739,7 @@ class Testiq_handler(unittest.TestCase):
 
         result = self.cm.__exit__(*info)
 
-        self.stream.unregister_iq_request_coro.assert_called_with(
+        self.stream.unregister_iq_request_handler.assert_called_with(
             unittest.mock.sentinel.iqtype,
             unittest.mock.sentinel.payload,
         )

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -957,7 +957,7 @@ class Testmake_connected_client(unittest.TestCase):
         )
 
         self.assertTrue(hasattr(cc.stream, "register_iq_response_future"))
-        self.assertTrue(hasattr(cc.stream, "register_iq_request_coro"))
+        self.assertTrue(hasattr(cc.stream, "register_iq_request_handler"))
         self.assertTrue(hasattr(cc.stream, "register_message_callback"))
         self.assertTrue(hasattr(cc.stream, "register_iq_response_callback"))
         self.assertTrue(hasattr(cc.stream, "register_presence_callback"))


### PR DESCRIPTION
Essentially what is written in #143:

* Rename ``{un,}register_iq_request{coro => handler}`` and support plain functions returning awaitables as handlers.
* Allow a callback returning an awaitable (or None) when ``send()``-ing IQ requests. The callback is invoked.
* Tack nice warnings and notes on things to explain the reasoning and warn against excessive use of these features.
* Adapt downstream tooling (like the ``iq_handler`` decorator).

Implements/fixes #143.