### PR TITLE
Support for defaulting when an attribute / child text fails to parse

### DIFF
--- a/aioxmpp/stanza.py
+++ b/aioxmpp/stanza.py
@@ -788,6 +788,7 @@ class Presence(StanzaBase):
             accept_unknown=False,
         ),
         default=structs.PresenceShow.NONE,
+        erroneous_as_absent=True,
     )
 
     status = xso.ChildTextMap(Status)

--- a/aioxmpp/stanza.py
+++ b/aioxmpp/stanza.py
@@ -641,6 +641,7 @@ class Message(StanzaBase):
             accept_unknown=False,
         ),
         default=structs.MessageType.NORMAL,
+        erroneous_as_absent=True,
     )
 
     body = xso.ChildTextMap(Body)

--- a/aioxmpp/xso/__init__.py
+++ b/aioxmpp/xso/__init__.py
@@ -107,7 +107,7 @@ similar. They are described in detail on the :class:`Attr` class and not
 repeated that detailed on the other classes. Refer to the documentation of the
 :class:`Attr` class in those cases.
 
-.. autoclass:: Attr(name, *[, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, missing=None][, default])
+.. autoclass:: Attr(name, *[, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, missing=None][, default][, erroneous_as_absent=False])
 
 .. autoclass:: LangAttr(*[, validator=None][, validate=ValidateMode.FROM_RECV][, default=None])
 
@@ -117,9 +117,9 @@ repeated that detailed on the other classes. Refer to the documentation of the
 
 .. autoclass:: ChildFlag(tag, *[, text_policy=UnknownTextPolicy.FAIL][, child_policy=UnknownChildPolicy.FAIL][, attr_policy=UnknownAttrPolicy.FAIL])
 
-.. autoclass:: ChildText(tag, *[, child_policy=UnknownChildPolicy.FAIL][, attr_policy=UnknownAttrPolicy.FAIL][, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, default])
+.. autoclass:: ChildText(tag, *[, child_policy=UnknownChildPolicy.FAIL][, attr_policy=UnknownAttrPolicy.FAIL][, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, default][, erroneous_as_absent=False])
 
-.. autoclass:: Text(*[, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, default])
+.. autoclass:: Text(*[, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, default][, erroneous_as_absent=False])
 
 Non-scalar descriptors
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -175,6 +175,10 @@ Version 0.10
   :class:`~aioxmpp.xso.Text` and :class:`~aioxmpp.xso.ChildText`. See the
   documentation of :class:`~aioxmpp.xso.Attr` for details.
 
+* Treat absent ``@type`` XML attribute on message stanzas as
+  :class:`aioxmpp.MessageType.NORMAL`, as specified in :rfc:`6121`,
+  section 5.2.2.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -179,6 +179,13 @@ Version 0.10
   :class:`aioxmpp.MessageType.NORMAL`, as specified in :rfc:`6121`,
   section 5.2.2.
 
+* Treat empty ``<show/>`` XML child on presence stanzas like absent
+  ``<show/>``. This is not legal as per :rfc:`6120`, but apparently there are
+  some broken implementations out there.
+
+  Not having this workaround leads to being unable to receive presence stanzas
+  from those entities, which is rather unfortunate.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -171,6 +171,10 @@ Version 0.10
 * **Breaking change**: Assignment to :class:`aioxmpp.xso.Collector`
   descriptors is now forbidden.
 
+* New `erroneous_as_absent` argument to :class:`aioxmpp.xso.Attr`,
+  :class:`~aioxmpp.xso.Text` and :class:`~aioxmpp.xso.ChildText`. See the
+  documentation of :class:`~aioxmpp.xso.Attr` for details.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/tests/test_stanza.py
+++ b/tests/test_stanza.py
@@ -20,6 +20,7 @@
 #
 ########################################################################
 import contextlib
+import io
 import itertools
 import unittest
 import unittest.mock
@@ -28,6 +29,7 @@ import aioxmpp.xso as xso
 import aioxmpp.stanza as stanza
 import aioxmpp.structs as structs
 import aioxmpp.errors as errors
+import aioxmpp.xml
 
 from aioxmpp.utils import namespaces
 
@@ -379,6 +381,16 @@ class TestMessage(unittest.TestCase):
             "<message from=<incomplete> to=<incomplete> "
             "id=<incomplete> type=<incomplete>>"
         )
+
+    def test_random_type_is_equal_to_normal(self):
+        buf = io.BytesIO(b"<message xmlns='jabber:client' type='fnord'/>")
+        s = aioxmpp.xml.read_single_xso(buf, stanza.Message)
+        self.assertIs(s.type_, structs.MessageType.NORMAL)
+
+    def test_absent_type_is_normal(self):
+        buf = io.BytesIO(b"<message xmlns='jabber:client'/>")
+        s = aioxmpp.xml.read_single_xso(buf, stanza.Message)
+        self.assertIs(s.type_, structs.MessageType.NORMAL)
 
 
 class TestStatus(unittest.TestCase):

--- a/tests/test_stanza.py
+++ b/tests/test_stanza.py
@@ -636,6 +636,16 @@ class TestPresence(unittest.TestCase):
             "id=<incomplete> type=<incomplete>>"
         )
 
+    def test_empty_show_is_equivalent_to_no_show(self):
+        buf = io.BytesIO(b"<presence xmlns='jabber:client'><show/></presence>")
+        s = aioxmpp.xml.read_single_xso(buf, stanza.Presence)
+        self.assertIs(s.show, structs.PresenceShow.NONE)
+
+    def test_absent_show(self):
+        buf = io.BytesIO(b"<presence xmlns='jabber:client'/>")
+        s = aioxmpp.xml.read_single_xso(buf, stanza.Presence)
+        self.assertIs(s.show, structs.PresenceShow.NONE)
+
 
 class TestError(unittest.TestCase):
     def test_declare_ns(self):


### PR DESCRIPTION
Fixes #140, #148.

This introduces a new keyword argument on the text parsing XSO types, ``erroneous_as_absent``. This affects ``Attr``, ``ChildText`` and ``Text``. It defaults to false (the previous behaviour). If set to true, ValueError and TypeError when invoking ``type_.parse`` are ignored and the default value (if any) is used. If no default is set, the attribute behaves as if it was unset.