### PR TITLE
Make insertion O(1) for aioxmpp.cache.LRUDict

### DIFF
--- a/aioxmpp/cache.py
+++ b/aioxmpp/cache.py
@@ -33,55 +33,55 @@
 
 import collections.abc
 
-
-PREV = 0
-NEXT = 1
-KEY = 2
-VALUE = 3
+class Link:
+    __slots__ = ("prev", "next_", "key", "value")
 
 
 def _init_linked_list():
-    root = []
-    root[:] = [root, root, None, None]
+    root = Link()
+    root.prev = root
+    root.next_ = root
+    root.key = None
+    root.value = None
     return root
 
 
 def _remove_link(link):
-    link[NEXT][PREV] = link[PREV]
-    link[PREV][NEXT] = link[NEXT]
+    link.next_.prev = link.prev
+    link.prev.next_ = link.next_
     return link
 
 
 def _insert_link(before, link):
-    link[NEXT] = before[NEXT]
-    link[NEXT][PREV] = link
-    link[PREV] = before
-    before[NEXT] = link
+    link.next_ = before.next_
+    link.next_.prev = link
+    link.prev = before
+    before.next_ = link
 
 
 def _length(link):
     # this is used only for testing
-    cur = link[NEXT]
+    cur = link.next_
     i = 0
     while cur is not link:
         i += 1
-        cur = cur[NEXT]
+        cur = cur.next_
     return i
 
 
 def _has_consistent_links(link, link_dict=None):
     # this is used only for testing
-    cur = link[NEXT]
+    cur = link.next_
 
-    if cur[PREV] is not link:
+    if cur.prev is not link:
         return False
 
     while cur is not link:
-        if link_dict is not None and link_dict[cur[KEY]] is not cur:
+        if link_dict is not None and link_dict[cur.key] is not cur:
             return False
-        if cur is not cur[NEXT][PREV]:
+        if cur is not cur.next_.prev:
             return False
-        cur = cur[NEXT]
+        cur = cur.next_
     return True
 
 
@@ -121,8 +121,8 @@ class LRUDict(collections.abc.MutableMapping):
             return
 
         while len(self.__links) > self.__maxsize:
-            link = _remove_link(self.__root[PREV])
-            del self.__links[link[KEY]]
+            link = _remove_link(self.__root.prev)
+            del self.__links[link.key]
 
     @property
     def maxsize(self):
@@ -154,9 +154,11 @@ class LRUDict(collections.abc.MutableMapping):
 
     def __setitem__(self, key, value):
         try:
-            self.__links[key][VALUE] = value
+            self.__links[key].value = value
         except KeyError:
-            link = [None, None, key, value]
+            link = Link()
+            link.key = key
+            link.value = value
             self.__links[key] = link
             _insert_link(self.__root, link)
             self._purge()
@@ -165,7 +167,7 @@ class LRUDict(collections.abc.MutableMapping):
         link = self.__links[key]
         _remove_link(link)
         _insert_link(self.__root, link)
-        return link[VALUE]
+        return link.value
 
     def __delitem__(self, key):
         link = self.__links.pop(key)

--- a/benchmarks/test_cache.py
+++ b/benchmarks/test_cache.py
@@ -1,0 +1,67 @@
+########################################################################
+# File name: test_cache.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import io
+import unittest
+import random
+
+import aioxmpp.cache
+
+from aioxmpp.benchtest import times, timed, record
+
+class TestLRUDict(unittest.TestCase):
+    KEY = "aioxmpp.cache", "LRUDict"
+
+    @times(1000)
+    def test_random_access(self):
+        key = self.KEY + ("random_access",)
+
+        N = 1000
+
+        lru_dict = aioxmpp.cache.LRUDict()
+        lru_dict.maxsize = N
+        keys = [object() for i in range(N)]
+        for i in range(N):
+            lru_dict[keys[i]] = object()
+
+        with timed() as t:
+            for i in range(N):
+                lru_dict[keys[random.randrange(0, N)]]
+
+        record(key, t.elapsed, "s")
+
+    @times(1000)
+    def test_inserts(self):
+        key = self.KEY + ("inserts",)
+
+        N = 1000
+
+        lru_dict = aioxmpp.cache.LRUDict()
+        lru_dict.maxsize = N
+        keys = [object() for i in range(N)]
+        for i in range(N):
+            lru_dict[keys[i]] = object()
+
+        with timed() as t:
+            for i in range(N):
+                lru_dict[object()] = object()
+
+        record(key, t.elapsed, "s")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -58,11 +58,17 @@ class TestLRUDict(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.d[key]
 
+        self.assertTrue(self.d._test_consistency())
+
         value = object()
         self.d[key] = value
 
+        self.assertTrue(self.d._test_consistency())
+
         with self.assertRaises(KeyError):
             self.d[object()]
+
+        self.assertTrue(self.d._test_consistency())
 
     def test_store_multiple(self):
         size = 3
@@ -87,11 +93,14 @@ class TestLRUDict(unittest.TestCase):
                 i + 1,
             )
 
+            self.assertTrue(self.d._test_consistency())
+
         for k, v in zip(keys, values):
             self.assertEqual(
                 self.d[k],
                 v,
             )
+            self.assertTrue(self.d._test_consistency())
 
     def test_iter_iterates_over_keys(self):
         size = 3
@@ -105,6 +114,7 @@ class TestLRUDict(unittest.TestCase):
                 self.d[k],
                 v,
             )
+            self.assertTrue(self.d._test_consistency())
 
         self.assertSetEqual(
             set(self.d),
@@ -129,14 +139,16 @@ class TestLRUDict(unittest.TestCase):
     def test_fetch_does_not_create_ghost_keys(self):
         with self.assertRaises(KeyError):
             self.d[object()]
+        self.assertTrue(self.d._test_consistency())
         self.d[object()] = object()
-
+        self.assertTrue(self.d._test_consistency())
         # "ghost key": if one part of the data structure (the "last used") is
         # updated before the check for existance of the key is made
         # in this case, the second store would raise because there is a key
         # in the "last used" data structure which isn’t in the main data
         # structure
         self.d[object()] = object()
+        self.assertTrue(self.d._test_consistency())
 
     def test_lru_purge_when_decreasing_maxsize(self):
         size = 4
@@ -150,29 +162,35 @@ class TestLRUDict(unittest.TestCase):
                 self.d[k],
                 v,
             )
+            self.assertTrue(self.d._test_consistency())
 
         # keys have now been fetached in insertion order
         # reducing maxsize by one should remove first key, but not the others
 
         self.d.maxsize = size - 1
+        self.assertTrue(self.d._test_consistency())
 
         with self.assertRaises(KeyError):
             self.d[keys[0]]
+        self.assertTrue(self.d._test_consistency())
 
         # we now fetch the second key, so that the third is purged instead of
         # the second when we reduce maxsize again
 
         self.d[keys[1]]
+        self.assertTrue(self.d._test_consistency())
 
         self.d.maxsize = size - 2
 
         with self.assertRaises(KeyError):
             self.d[keys[2]]
+        self.assertTrue(self.d._test_consistency())
 
         self.assertEqual(
             self.d[keys[1]],
             values[1]
         )
+        self.assertTrue(self.d._test_consistency())
 
         # reducing the size to 1 should leave only the third key
 
@@ -182,10 +200,12 @@ class TestLRUDict(unittest.TestCase):
             self.d[keys[1]],
             values[1]
         )
+        self.assertTrue(self.d._test_consistency())
 
         for i in [0, 2, 3]:
             with self.assertRaises(KeyError):
                 self.d[keys[i]]
+            self.assertTrue(self.d._test_consistency())
 
     def test_lru_purge_when_storing(self):
         size = 4
@@ -199,52 +219,67 @@ class TestLRUDict(unittest.TestCase):
                 self.d[k],
                 v,
             )
+            self.assertTrue(self.d._test_consistency())
 
         # keys have now been fetached in insertion order
         # reducing maxsize by one should remove first key, but not the others
 
         self.d[keys[size]] = values[size]
+        self.assertTrue(self.d._test_consistency())
 
         with self.assertRaises(KeyError):
             self.d[keys[0]]
+        self.assertTrue(self.d._test_consistency())
 
         # we now fetch the second key, so that the third is purged instead of
         # the second when we reduce maxsize again
 
         self.d[keys[2]]
+        self.assertTrue(self.d._test_consistency())
 
         self.d[keys[size + 1]] = values[size + 1]
+        self.assertTrue(self.d._test_consistency())
 
         with self.assertRaises(KeyError):
             self.d[keys[1]]
+        self.assertTrue(self.d._test_consistency())
 
         self.assertEqual(
             self.d[keys[2]],
             values[2]
         )
+        self.assertTrue(self.d._test_consistency())
 
         for i in [0, 1]:
             with self.assertRaises(KeyError, msg=i):
                 self.d[keys[i]]
+            self.assertTrue(self.d._test_consistency())
 
         for i in [2, 3, 4, 5]:
             self.assertEqual(
                 self.d[keys[i]],
                 values[i],
             )
+            self.assertTrue(self.d._test_consistency())
 
     def test_expire_removes_from_cache(self):
         key = object()
         value = object()
         self.d[key] = value
+        self.assertTrue(self.d._test_consistency())
 
         del self.d[key]
+        self.assertTrue(self.d._test_consistency())
 
         with self.assertRaises(KeyError):
             self.d[key]
+        self.assertTrue(self.d._test_consistency())
 
         self.d[object()] = value
+        self.assertTrue(self.d._test_consistency())
+
         self.d[object()] = value
+        self.assertTrue(self.d._test_consistency())
 
     def test_clear_removes_items(self):
         size = 3
@@ -254,11 +289,14 @@ class TestLRUDict(unittest.TestCase):
 
         for i, (k, v) in enumerate(zip(keys, values)):
             self.d[k] = v
+            self.assertTrue(self.d._test_consistency())
 
         self.d.clear()
+        self.assertTrue(self.d._test_consistency())
 
         self.assertEqual(len(self.d), 0)
 
         for k in keys:
             with self.assertRaises(KeyError):
                 self.d[k]
+            self.assertTrue(self.d._test_consistency())


### PR DESCRIPTION
* before insertion was O(maxsize*log(maxsize)) which got unacceptably slow
  even for maxsize = 1000
* now we got O(1) retrieval and insertion (getting is now about 1.5 times
  slower!)
* the code is inspired by functools.lru_cache