### PR TITLE
Implement vCard and vCard Based Avatars

### DIFF
--- a/aioxmpp/avatar/__init__.py
+++ b/aioxmpp/avatar/__init__.py
@@ -62,6 +62,29 @@ Helpers
 
 .. autofunction:: normalize_id
 
+How to work with avatar descriptors
+===================================
+
+.. currentmodule:: aioxmpp.avatar.service
+
+One you have retrieved the avatar descriptor list, the correct way to
+handle it in the application:
+
+1. Select the avatar you prefer based on the
+   :attr:`~AbstractAvatarDescriptor.can_get_image_bytes_via_xmpp`, and
+   metadata information (:attr:`~AbstractAvatarDescriptor.mime_type`,
+   :attr:`~AbstractAvatarDescriptor.width`,
+   :attr:`~AbstractAvatarDescriptor.height`,
+   :attr:`~AbstractAvatarDescriptor.nbytes`). If you cache avatar
+   images it might be a good choice to choose an avatar image you
+   already have cached based on
+   :attr:`~AbstractAvatarDescriptor.normalized_id`.
+
+2. If :attr:`~AbstractAvatarDescriptor.can_get_image_bytes_via_xmpp`
+   is true, try to retrieve the image by
+   :attr:`~AbstractAvatarDescriptor.get_image_bytes()`; if it is false
+   try to retrieve the object at the URL
+   :attr:`~AbstractAvatarDescriptor.url`.
 """
 
 from .service import (AvatarSet, AvatarService,  # NOQA

--- a/aioxmpp/avatar/service.py
+++ b/aioxmpp/avatar/service.py
@@ -40,6 +40,7 @@ from . import xso as avatar_xso
 
 logger = logging.getLogger(__name__)
 
+
 def normalize_id(id_):
     """
     Normalize a SHA1 sum encoded as hexadecimal number in ASCII.
@@ -511,10 +512,10 @@ class AvatarService(service.Service):
                     self._metadata_cache[full_jid] = metadata
 
                 if (full_jid.bare() == self.client.local_jid.bare() and
-                    full_jid != self.client.local_jid):
+                        full_jid != self.client.local_jid):
                     if (self._vcard_id is None or
-                        stanza.xep0153_x.photo.lower() !=
-                        self._vcard_id.lower()):
+                            stanza.xep0153_x.photo.lower() !=
+                            self._vcard_id.lower()):
                         if self._vcard_rehash_task is not None:
                             self._vcard_rehash_task.cancel()
 
@@ -522,9 +523,11 @@ class AvatarService(service.Service):
                         self._vcard_rehash_task = asyncio.async(
                             self._calculate_vcard_id()
                         )
+
                         def set_new_vcard_id(fut):
                             if not fut.cancelled():
                                 self._vcard_id = fut.result()
+
                         self._vcard_rehash_task.add_done_callback(
                             set_new_vcard_id
                         )
@@ -650,7 +653,8 @@ class AvatarService(service.Service):
                 # here we can know, so we should pass it on
                 photo = vcard.get_photo_data()
                 if photo is not None:
-                    logger.debug("success vCard avatar as fallback for %s", jid)
+                    logger.debug("success vCard avatar as fallback for %s",
+                                 jid)
                     sha1 = hashlib.sha1()
                     sha1.update(photo)
                     metadata = collections.defaultdict(lambda: [])
@@ -747,7 +751,8 @@ class AvatarService(service.Service):
             finally:
                 if self._synchronize_vcard:
                     my_vcard = yield from self._vcard.get_vcard()
-                    my_vcard.set_photo_data("image/png", avatar_set.image_bytes)
+                    my_vcard.set_photo_data("image/png",
+                                            avatar_set.image_bytes)
                     self._vcard_id = avatar_set.png_id
                     yield from self._vcard.set_vcard(my_vcard)
                     yield from self._presence_server.resend_presence()

--- a/aioxmpp/avatar/xso.py
+++ b/aioxmpp/avatar/xso.py
@@ -43,7 +43,9 @@ class VCardTempUpdate(xso.XSO):
     def __init__(self, photo=None):
         self.photo = photo
 
-    photo = xso.ChildText("photo", type_=xso.String(), default=None)
+    photo = xso.ChildText((namespaces.xep0153, "photo"),
+                          type_=xso.String(),
+                          default=None)
 
 
 Presence.xep0153_x = xso.Child([VCardTempUpdate])

--- a/aioxmpp/avatar/xso.py
+++ b/aioxmpp/avatar/xso.py
@@ -24,8 +24,29 @@ import aioxmpp.pubsub.xso as pubsub_xso
 
 from aioxmpp.utils import namespaces
 
+from ..stanza import Presence
+
+
 namespaces.xep0084_data = "urn:xmpp:avatar:data"
 namespaces.xep0084_metadata = "urn:xmpp:avatar:metadata"
+
+namespaces.xep0153 = "vcard-temp:x:update"
+
+
+class VCardTempUpdate(xso.XSO):
+    """
+    The vcard temp update note as per :xep:`0153`
+    """
+
+    TAG = (namespaces.xep0153, "x")
+
+    def __init__(self, photo=None):
+        self.photo = photo
+
+    photo = xso.ChildText("photo", type_=xso.String(), default=None)
+
+
+Presence.xep0153_x = xso.Child([VCardTempUpdate])
 
 
 @pubsub_xso.as_payload_class

--- a/aioxmpp/avatar/xso.py
+++ b/aioxmpp/avatar/xso.py
@@ -35,7 +35,7 @@ namespaces.xep0153 = "vcard-temp:x:update"
 
 class VCardTempUpdate(xso.XSO):
     """
-    The vcard temp update note as per :xep:`0153`
+    The vcard update notify element as per :xep:`0153`
     """
 
     TAG = (namespaces.xep0153, "x")

--- a/aioxmpp/errors.py
+++ b/aioxmpp/errors.py
@@ -76,6 +76,8 @@ Other exceptions
 
 .. autoclass:: MultiOSError
 
+.. autoclass:: GatherError
+
 """
 import gettext
 
@@ -274,6 +276,32 @@ class MultiOSError(OSError):
     """
     Describe an error situation which has been caused by the sequential
     occurence of multiple other `exceptions`.
+
+    The `message` shall be descriptive and will be prepended to a concatenation
+    of the error messages of the given `exceptions`.
+    """
+
+    def __init__(self, message, exceptions):
+        flattened_exceptions = []
+        for exc in exceptions:
+            if hasattr(exc, "exceptions"):
+                flattened_exceptions.extend(exc.exceptions)
+            else:
+                flattened_exceptions.append(exc)
+
+        super().__init__(
+            "{}: multiple errors: {}".format(
+                message,
+                ", ".join(map(str, flattened_exceptions))
+            )
+        )
+        self.exceptions = flattened_exceptions
+
+
+class GatherError(RuntimeError):
+    """
+    Describe an error situation which has been caused by the occurence
+    of multiple other `exceptions`.
 
     The `message` shall be descriptive and will be prepended to a concatenation
     of the error messages of the given `exceptions`.

--- a/aioxmpp/utils.py
+++ b/aioxmpp/utils.py
@@ -25,7 +25,7 @@ import types
 
 import lxml.etree as etree
 
-from . import errors
+from aioxmpp import errors
 
 __all__ = [
     "etree",

--- a/aioxmpp/vcard/__init__.py
+++ b/aioxmpp/vcard/__init__.py
@@ -1,0 +1,42 @@
+########################################################################
+# File name: __init__.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+"""
+:mod:`~aioxmpp.vcard` --- vcard-temp support (:xep:`0054`)
+##########################################################
+
+This subpackage provides minimal support for setting and retrieving
+vCard as per :xep:`0054`.
+
+.. versionadded:: 0.10
+
+We supply the service:
+
+.. autoclass:: VCardService()
+
+.. currentmodule:: aioxmpp.vcard.xso
+
+The VCards are exposed as:
+
+.. autoclass:: VCard()
+
+"""
+from .service import VCardService  # NOQA

--- a/aioxmpp/vcard/service.py
+++ b/aioxmpp/vcard/service.py
@@ -1,0 +1,97 @@
+########################################################################
+# File name: xso.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import asyncio
+
+import aioxmpp
+import aioxmpp.xso as xso
+import aioxmpp.service as service
+
+from aioxmpp.utils import namespaces
+
+from . import xso as vcard_xso
+
+
+class VCardService(service.Service):
+    """
+    Service for handling vcard-temp.
+
+    .. automethod:: get_vcard
+
+    .. automethod:: set_vcard
+    """
+
+    @asyncio.coroutine
+    def get_vcard(self, jid=None):
+        """
+        Get the vCard stored for the bare jid `jid`. If `jid` is
+        :data:`None` get the vCard of the connected entity.
+
+        :param jid: the object to retrieve.
+        :returns: the stored vCard.
+
+        We mask a :class:`XMPPCancelError` in case it is
+        ``feature-not-implemented`` or ``item-not-found`` and return
+        an empty vCard, since this can be understood to be semantically
+        equivalent.
+        """
+        if not (jid is None or jid.is_bare):
+            raise ValueError("JID must be None or bare")
+
+        iq = aioxmpp.IQ(
+            type_=aioxmpp.IQType.GET,
+            to=jid,
+            payload=vcard_xso.VCard(),
+        )
+
+        try:
+            return (yield from self.client.stream.send(iq))
+        except aioxmpp.XMPPCancelError as e:
+            if e.condition in (
+                    (namespaces.stanzas, "feature-not-implemented"),
+                    (namespaces.stanzas, "item-not-found")):
+                return vcard_xso.VCard()
+            else:
+                raise
+
+    @asyncio.coroutine
+    def set_vcard(self, vcard):
+        """
+        Store the vCard `vcard` for the connected entity.
+
+        :param vcard: the vCard to store.
+
+        .. note::
+
+           `vcard` should always be derived from the result of
+           `get_vcard` to preserve the elements of the vcard the
+           client does not modify.
+
+        .. warning::
+
+           It is in the responsibility of the user to supply valid
+           vcard data as per :xep:`0054`.
+        """
+        iq = aioxmpp.IQ(
+            type_=aioxmpp.IQType.SET,
+            payload=vcard,
+        )
+        yield from self.client.stream.send(iq)

--- a/aioxmpp/vcard/service.py
+++ b/aioxmpp/vcard/service.py
@@ -42,7 +42,7 @@ class VCardService(service.Service):
     @asyncio.coroutine
     def get_vcard(self, jid=None):
         """
-        Get the vCard stored for the bare jid `jid`. If `jid` is
+        Get the vCard stored for the jid `jid`. If `jid` is
         :data:`None` get the vCard of the connected entity.
 
         :param jid: the object to retrieve.
@@ -53,8 +53,6 @@ class VCardService(service.Service):
         an empty vCard, since this can be understood to be semantically
         equivalent.
         """
-        if not (jid is None or jid.is_bare):
-            raise ValueError("JID must be None or bare")
 
         iq = aioxmpp.IQ(
             type_=aioxmpp.IQType.GET,

--- a/aioxmpp/vcard/xso.py
+++ b/aioxmpp/vcard/xso.py
@@ -1,0 +1,41 @@
+########################################################################
+# File name: xso.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+import aioxmpp
+import aioxmpp.xso as xso
+
+from aioxmpp.utils import namespaces
+
+namespaces.xep0054 = "vcard-temp"
+
+@aioxmpp.IQ.as_payload_class
+class VCard(xso.XSO):
+    """
+    The container for vCard data as per :xep:`vcard-temp <54>`.
+
+    .. attribute:: elements
+
+       The raw elements of the vCard (as etree).
+    """
+
+    TAG = (namespaces.xep0054, "vCard")
+
+    elements = xso.Collector()

--- a/aioxmpp/vcard/xso.py
+++ b/aioxmpp/vcard/xso.py
@@ -52,6 +52,18 @@ class VCard(xso.XSO):
 
     elements = xso.Collector()
 
+    def get_photo_mime_type(self):
+        """
+        Get the mime type of the photo stored in the vCard.
+
+        :returns: the MIME type of the photo as :class:`str` or :data:`None`.
+        """
+        mime_type = self.elements.xpath("/ns0:vCard/ns0:PHOTO/ns0:TYPE/text()",
+                                        namespaces={"ns0": namespaces.xep0054})
+        if mime_type:
+            return mime_type[0]
+        return None
+
     def get_photo_data(self):
         """
         Get the photo stored in the vCard.

--- a/aioxmpp/vcard/xso.py
+++ b/aioxmpp/vcard/xso.py
@@ -19,6 +19,9 @@
 # <http://www.gnu.org/licenses/>.
 #
 ########################################################################
+import base64
+import lxml.etree as etree
+
 import aioxmpp
 import aioxmpp.xso as xso
 
@@ -34,8 +37,67 @@ class VCard(xso.XSO):
     .. attribute:: elements
 
        The raw elements of the vCard (as etree).
+
+    The following methods are defined to access and modify certain
+    entries of the vCard in a highlevel manner:
+
+    .. automethod:: get_photo_data
+
+    .. automethod:: set_photo_data
+
+    .. automethod:: clear_photo_data
     """
 
     TAG = (namespaces.xep0054, "vCard")
 
     elements = xso.Collector()
+
+    def get_photo_data(self):
+        """
+        Get the photo stored in the vCard.
+
+        :returns: the photo as :class:`bytes` or :data:`None`.
+        """
+        photo = self.elements.xpath("/ns0:vCard/ns0:PHOTO/ns0:BINVAL/text()",
+                                    namespaces={"ns0": namespaces.xep0054})
+        if photo:
+            return base64.b64decode(photo[0])
+        return None
+
+    def set_photo_data(self, mime_type, data):
+        """
+        Set the photo stored in the vCard.
+
+        :param mime_type: the MIME type of the image data
+        :param data: the image data as :class:`bytes`
+        """
+        res = self.elements.xpath("/ns0:vCard/ns0:PHOTO",
+                                  namespaces={"ns0": namespaces.xep0054})
+        if res:
+            photo = res[0]
+            photo.clear()
+        else:
+            photo = etree.SubElement(
+                self.elements,
+                etree.QName(namespaces.xep0054, "PHOTO")
+            )
+
+        binval = etree.SubElement(
+            photo,
+            etree.QName(namespaces.xep0054, "BINVAL")
+        )
+        binval.text = base64.b64encode(data)
+        type_ = etree.SubElement(
+            photo,
+            etree.QName(namespaces.xep0054, "TYPE")
+        )
+        type_.text = mime_type
+
+    def clear_photo_data(self):
+        """
+        Remove the photo stored in the vCard.
+        """
+        res = self.elements.xpath("/ns0:vCard/ns0:PHOTO",
+                                  namespaces={"ns0": namespaces.xep0054})
+        for to_remove in res:
+            self.elements.remove(to_remove)

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -186,6 +186,11 @@ Version 0.10
   Not having this workaround leads to being unable to receive presence stanzas
   from those entities, which is rather unfortunate.
 
+* **Breaking change**:
+  :meth:`aioxmpp.AvatarService.get_avatar_metadata`
+  now returns a list instead of a mapping from MIME types to lists of
+  descriptors.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/public/index.rst
+++ b/docs/api/public/index.rst
@@ -47,6 +47,7 @@ functionality or provide backwards compatibility.
    rfc3921
    rsm
    shim
+   vcard
 
 
 Less common and helper classes

--- a/docs/api/public/vcard.rst
+++ b/docs/api/public/vcard.rst
@@ -1,0 +1,1 @@
+.. automodule:: aioxmpp.vcard

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -137,3 +137,21 @@ operations:
   --set-avatar AVATAR_FILE
                         set the avatar to content of the supplied PNG file.
   --wipe-avatar         set the avatar to no avatar.
+
+`get_vcard.py`
+==============
+
+``get_vcard.py`` gets the vCard for a remote JID.
+
+Additional optional argument:
+
+  --remote-jid REMOTE_JID
+                        the jid of which to retrieve the avatar
+
+The remote JID may also be supplied in the examples config file::
+
+      [vcard]
+      remote_jid=foo@example.com
+
+If the remote JID is not given on the command line and also missing
+from the config file ``get_vcard.py`` will prompt for it.

--- a/examples/get_vcard.py
+++ b/examples/get_vcard.py
@@ -1,0 +1,83 @@
+########################################################################
+# File name: get_vcard.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+
+import asyncio
+
+import lxml
+
+import aioxmpp
+import aioxmpp.vcard as vcard
+
+from framework import Example, exec_example
+
+
+class VCard(Example):
+    def prepare_argparse(self):
+        super().prepare_argparse()
+
+        # this gives a nicer name in argparse errors
+        def jid(s):
+            return aioxmpp.JID.fromstr(s)
+
+        self.argparse.add_argument(
+            "--remote-jid",
+            type=jid,
+            help="the jid of which to retrieve the avatar"
+        )
+
+    def configure(self):
+        super().configure()
+
+        self.remote_jid = self.args.remote_jid
+        if self.remote_jid is None:
+            try:
+                self.remote_jid = aioxmpp.JID.fromstr(
+                    self.config.get("vcard", "remote_jid")
+                )
+            except (configparser.NoSectionError,
+                    configparser.NoOptionError):
+                self.remote_jid = aioxmpp.JID.fromstr(
+                    input("Remote JID> ")
+                )
+
+    def make_simple_client(self):
+        client = super().make_simple_client()
+        self.vcard = client.summon(aioxmpp.vcard.VCardService)
+        return client
+
+    @asyncio.coroutine
+    def run_simple_example(self):
+        vcard = yield from self.vcard.get_vcard(
+            self.remote_jid
+        )
+
+        for element in vcard.elements:
+            es = lxml.etree.tostring(element, pretty_print=True,
+                                     encoding="utf-8")
+            print(es.decode("utf-8"))
+
+    @asyncio.coroutine
+    def run_example(self):
+        yield from super().run_example()
+
+if __name__ == "__main__":
+    exec_example(VCard())

--- a/examples/get_vcard.py
+++ b/examples/get_vcard.py
@@ -70,10 +70,10 @@ class VCard(Example):
             self.remote_jid
         )
 
-        for element in vcard.elements:
-            es = lxml.etree.tostring(element, pretty_print=True,
-                                     encoding="utf-8")
-            print(es.decode("utf-8"))
+
+        es = lxml.etree.tostring(vcard.elements, pretty_print=True,
+                                 encoding="utf-8")
+        print(es.decode("utf-8"))
 
     @asyncio.coroutine
     def run_example(self):

--- a/examples/retrieve_avatar.py
+++ b/examples/retrieve_avatar.py
@@ -74,14 +74,14 @@ class Avatar(Example):
             self.remote_jid
         )
 
-        for metadatum in metadata["image/png"]:
-            if metadatum.has_image_data_in_pubsub:
+        for metadatum in metadata:
+            if metadatum.can_get_image_bytes_via_xmpp:
                 image = yield from metadatum.get_image_bytes()
                 with open(self.output_file, "wb") as avatar_image:
                     avatar_image.write(image)
                 return
 
-        print("retrieving avatar failed: no avatar in pubsub")
+        print("retrieving avatar failed: no png-avatar in pubsub")
 
     @asyncio.coroutine
     def run_example(self):

--- a/examples/retrieve_avatar.py
+++ b/examples/retrieve_avatar.py
@@ -81,7 +81,7 @@ class Avatar(Example):
                     avatar_image.write(image)
                 return
 
-        print("retrieving avatar failed: no png-avatar in pubsub")
+        print("retrieving avatar failed: no avatar available via xmpp")
 
     @asyncio.coroutine
     def run_example(self):

--- a/tests/avatar/test_e2e.py
+++ b/tests/avatar/test_e2e.py
@@ -152,7 +152,7 @@ class TestAvatar(TestCase):
             1
         )
 
-        (info, ), = avatar_info.values()
+        info = avatar_info[0]
 
         test_image_retrieved = yield from info.get_image_bytes()
 

--- a/tests/avatar/test_service.py
+++ b/tests/avatar/test_service.py
@@ -474,7 +474,8 @@ class TestAvatarService(unittest.TestCase):
         self.assertEqual(self.s._vcard_id, "")
 
         # XXX: should we test minutely that we get the right metadata
-        mock_handler.assert_called_with(TEST_FROM_OTHER, unittest.mock.ANY)
+        mock_handler.assert_called_with(TEST_FROM_OTHER.bare(),
+                                        unittest.mock.ANY)
 
     def test_handle_on_changed_is_depsignal_handler(self):
         self.assertTrue(aioxmpp.service.is_depsignal_handler(
@@ -563,8 +564,7 @@ class TestAvatarService(unittest.TestCase):
             e.enter_context(unittest.mock.patch.object(self.pep, "publish",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.presence_server,
-                                                       "resend_presence",
-                                                       new=CoroutineMock()))
+                                                       "resend_presence"))
             e.enter_context(unittest.mock.patch.object(self.vcard, "get_vcard",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.vcard, "set_vcard",
@@ -623,8 +623,7 @@ class TestAvatarService(unittest.TestCase):
             e.enter_context(unittest.mock.patch.object(self.pep, "publish",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.presence_server,
-                                                       "resend_presence",
-                                                       new=CoroutineMock()))
+                                                       "resend_presence"))
             e.enter_context(unittest.mock.patch.object(self.vcard, "get_vcard",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.vcard, "set_vcard",
@@ -714,8 +713,7 @@ class TestAvatarService(unittest.TestCase):
             e.enter_context(unittest.mock.patch.object(self.pep, "publish",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.presence_server,
-                                                       "resend_presence",
-                                                       new=CoroutineMock()))
+                                                       "resend_presence"))
             e.enter_context(unittest.mock.patch.object(self.vcard, "get_vcard",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.vcard, "set_vcard",
@@ -766,8 +764,6 @@ class TestAvatarService(unittest.TestCase):
             self.assertTrue(isinstance(data, avatar_xso.Data))
             self.assertEqual(0, len(data.data))
 
-
-
     def test_disable_avatar_synchronize_vcard_pep_raises(self):
         self.s.synchronize_vcard = True
 
@@ -775,8 +771,7 @@ class TestAvatarService(unittest.TestCase):
             e.enter_context(unittest.mock.patch.object(self.pep, "publish",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.presence_server,
-                                                       "resend_presence",
-                                                       new=CoroutineMock()))
+                                                       "resend_presence"))
             e.enter_context(unittest.mock.patch.object(self.vcard, "get_vcard",
                                                        new=CoroutineMock()))
             e.enter_context(unittest.mock.patch.object(self.vcard, "set_vcard",
@@ -811,7 +806,7 @@ class TestAvatarService(unittest.TestCase):
         self.assertTrue(aioxmpp.service.is_attrsignal_handler(
             avatar_service.AvatarService.avatar_pep,
             "on_item_publish",
-            self.s.handle_pubsub_publish
+            self.s._handle_pubsub_publish
         ))
 
         aset = avatar_service.AvatarSet()
@@ -827,7 +822,7 @@ class TestAvatarService(unittest.TestCase):
         mock_handler = unittest.mock.Mock()
         self.s.on_metadata_changed.connect(mock_handler)
 
-        self.s.handle_pubsub_publish(
+        self.s._handle_pubsub_publish(
             TEST_JID1,
             namespaces.xep0084_metadata,
             item)

--- a/tests/avatar/test_xso.py
+++ b/tests/avatar/test_xso.py
@@ -42,6 +42,46 @@ class TestNamespaces(unittest.TestCase):
             namespaces.xep0084_metadata
         )
 
+    def test_xep0153_namespace(self):
+        self.assertEqual(
+            "vcard-temp:x:update",
+            namespaces.xep0153
+        )
+
+
+class TestVCardTempUpdate(unittest.TestCase):
+    def test_is_xso(self):
+        self.assertTrue(issubclass(avatar_xso.VCardTempUpdate, xso.XSO))
+
+    def test_init(self):
+        vcard_update = avatar_xso.VCardTempUpdate()
+        self.assertEqual(vcard_update.photo, None)
+
+        vcard_update = avatar_xso.VCardTempUpdate("foobar")
+        self.assertEqual(vcard_update.photo, "foobar")
+
+    def test_tag(self):
+        self.assertEqual(
+            (namespaces.xep0153, "x"),
+            avatar_xso.VCardTempUpdate.TAG
+        )
+
+    def test_photo(self):
+        self.assertIsInstance(
+            avatar_xso.VCardTempUpdate.photo,
+            xso.ChildText
+        )
+
+        self.assertIsInstance(
+            avatar_xso.VCardTempUpdate.photo.type_,
+            xso.String
+        )
+
+        self.assertEqual(
+            avatar_xso.VCardTempUpdate.photo.tag,
+            (namespaces.xep0153, "photo")
+        )
+
 
 class TestData(unittest.TestCase):
     def test_is_xso(self):

--- a/tests/vcard/__init__.py
+++ b/tests/vcard/__init__.py
@@ -1,0 +1,21 @@
+########################################################################
+# File name: __init__.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################

--- a/tests/vcard/test_service.py
+++ b/tests/vcard/test_service.py
@@ -1,0 +1,138 @@
+########################################################################
+# File name: test_service.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+
+import unittest
+
+import aioxmpp
+import aioxmpp.service as service
+
+from aioxmpp.utils import namespaces
+
+import aioxmpp.vcard.service as vcard_service
+import aioxmpp.vcard.xso as vcard_xso
+
+from aioxmpp.testutils import (
+    make_connected_client,
+    CoroutineMock,
+    run_coroutine,
+)
+
+TEST_JID1 = aioxmpp.JID.fromstr("foo@baz.bar")
+TEST_JID2 = aioxmpp.JID.fromstr("foo@baz.bar/quux")
+
+class TestService(unittest.TestCase):
+
+    def setUp(self):
+        self.cc = make_connected_client()
+        self.s = vcard_service.VCardService(
+            self.cc,
+            dependencies={},
+        )
+        self.cc.mock_calls.clear()
+
+    def tearDown(self):
+        del self.cc
+        del self.s
+
+    def test_is_service(self):
+        self.assertTrue(issubclass(
+            vcard_service.VCardService,
+            service.Service,
+        ))
+
+    def test_get_vcard_own(self):
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            mock_send.return_value = unittest.mock.sentinel.result
+            res = run_coroutine(self.s.get_vcard())
+
+        self.assertEqual(len(mock_send.mock_calls), 1)
+        try:
+            (_, (arg,), kwargs), = mock_send.mock_calls
+        except ValueError:
+            self.fail("send called with wrong signature")
+        self.assertEqual(len(kwargs), 0)
+        self.assertIsInstance(arg, aioxmpp.IQ)
+        self.assertEqual(arg.type_, aioxmpp.IQType.GET)
+        self.assertEqual(arg.to, None)
+        self.assertIsInstance(arg.payload, vcard_xso.VCard)
+        self.assertEqual(len(arg.payload.elements), 0)
+        self.assertEqual(res, unittest.mock.sentinel.result)
+
+    def test_get_vcard_other(self):
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            mock_send.return_value = unittest.mock.sentinel.result
+            res = run_coroutine(self.s.get_vcard(TEST_JID1))
+
+        self.assertEqual(len(mock_send.mock_calls), 1)
+        try:
+            (_, (arg,), kwargs), = mock_send.mock_calls
+        except ValueError:
+            self.fail("send called with wrong signature")
+        self.assertEqual(len(kwargs), 0)
+        self.assertIsInstance(arg, aioxmpp.IQ)
+        self.assertEqual(arg.type_, aioxmpp.IQType.GET)
+        self.assertEqual(arg.to, TEST_JID1)
+        self.assertIsInstance(arg.payload, vcard_xso.VCard)
+        self.assertEqual(len(arg.payload.elements), 0)
+        self.assertEqual(res, unittest.mock.sentinel.result)
+
+    def test_get_vcard_not_bare_raises(self):
+        with self.assertRaises(ValueError):
+            res = run_coroutine(self.s.get_vcard(TEST_JID2))
+
+    def test_get_vcard_mask_cancel_error(self):
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            mock_send.side_effect = aioxmpp.XMPPCancelError(
+                (namespaces.stanzas, "feature-not-implemented"))
+            res = run_coroutine(self.s.get_vcard(TEST_JID1))
+
+        self.assertIsInstance(res, vcard_xso.VCard)
+        self.assertEqual(len(res.elements), 0)
+
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            mock_send.side_effect = aioxmpp.XMPPCancelError(
+                (namespaces.stanzas, "item-not-found"))
+            res = run_coroutine(self.s.get_vcard(TEST_JID1))
+
+        self.assertIsInstance(res, vcard_xso.VCard)
+        self.assertEqual(len(res.elements), 0)
+
+    def test_set_vcard(self):
+        with unittest.mock.patch.object(self.cc.stream, "send",
+                                        new=CoroutineMock()) as mock_send:
+            vcard = vcard_xso.VCard()
+            run_coroutine(self.s.set_vcard(vcard))
+
+        self.assertEqual(len(mock_send.mock_calls), 1)
+        try:
+            (_, (arg,), kwargs), = mock_send.mock_calls
+        except ValueError:
+            self.fail("send called with wrong signature")
+        self.assertEqual(len(kwargs), 0)
+        self.assertIsInstance(arg, aioxmpp.IQ)
+        self.assertEqual(arg.type_, aioxmpp.IQType.SET)
+        self.assertEqual(arg.to, None)
+        self.assertIs(arg.payload, vcard)

--- a/tests/vcard/test_service.py
+++ b/tests/vcard/test_service.py
@@ -97,10 +97,6 @@ class TestService(unittest.TestCase):
         self.assertEqual(len(arg.payload.elements), 0)
         self.assertEqual(res, unittest.mock.sentinel.result)
 
-    def test_get_vcard_not_bare_raises(self):
-        with self.assertRaises(ValueError):
-            res = run_coroutine(self.s.get_vcard(TEST_JID2))
-
     def test_get_vcard_mask_cancel_error(self):
         with unittest.mock.patch.object(self.cc.stream, "send",
                                         new=CoroutineMock()) as mock_send:
@@ -119,6 +115,13 @@ class TestService(unittest.TestCase):
 
         self.assertIsInstance(res, vcard_xso.VCard)
         self.assertEqual(len(res.elements), 0)
+
+        with self.assertRaises(aioxmpp.XMPPCancelError):
+            with unittest.mock.patch.object(self.cc.stream, "send",
+                                            new=CoroutineMock()) as mock_send:
+                mock_send.side_effect = aioxmpp.XMPPCancelError(
+                    (namespaces.stanzas, "fnord"))
+                res = run_coroutine(self.s.get_vcard(TEST_JID1))
 
     def test_set_vcard(self):
         with unittest.mock.patch.object(self.cc.stream, "send",

--- a/tests/vcard/test_xso.py
+++ b/tests/vcard/test_xso.py
@@ -65,6 +65,23 @@ class TestVCard(unittest.TestCase):
         )
         self.assertEqual(vcard.get_photo_data(), b'foo\n')
 
+    def test_get_photo_mime_type(self):
+        vcard = vcard_xso.VCard()
+        vcard.elements.append(
+            lxml.etree.fromstring("""
+<ns0:PHOTO xmlns:ns0="vcard-temp"><ns0:TYPE>image/png</ns0:TYPE></ns0:PHOTO>
+            """)
+        )
+        self.assertEqual(vcard.get_photo_mime_type(), 'image/png')
+
+        vcard = vcard_xso.VCard()
+        vcard.elements.append(
+            lxml.etree.fromstring("""
+<ns0:PHOTO xmlns:ns0="vcard-temp"></ns0:PHOTO>
+            """)
+        )
+        self.assertEqual(vcard.get_photo_mime_type(), None)
+
     def test_set_photo_data(self):
         vcard = vcard_xso.VCard()
         vcard.elements.append(

--- a/tests/vcard/test_xso.py
+++ b/tests/vcard/test_xso.py
@@ -1,0 +1,54 @@
+########################################################################
+# File name: test_xso.py
+# This file is part of: aioxmpp
+#
+# LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+########################################################################
+
+import unittest
+
+import aioxmpp.xso as xso
+import aioxmpp.vcard.xso as vcard_xso
+
+from aioxmpp.utils import namespaces
+
+
+class TestNamespace(unittest.TestCase):
+    def test_namespace(self):
+        self.assertEqual(
+            namespaces.xep0054,
+            "vcard-temp"
+        )
+
+
+class TestVCard(unittest.TestCase):
+
+    def test_is_xso(self):
+        self.assertTrue(issubclass(vcard_xso.VCard, xso.XSO))
+
+    def test_tag(self):
+        self.assertEqual(
+            vcard_xso.VCard.TAG,
+            (namespaces.xep0054, "vCard"),
+        )
+
+    def test_elements(self):
+        self.assertIsInstance(
+            vcard_xso.VCard.elements,
+            xso.Collector
+        )

--- a/tests/vcard/test_xso.py
+++ b/tests/vcard/test_xso.py
@@ -21,6 +21,9 @@
 ########################################################################
 
 import unittest
+import unittest.mock
+
+import lxml.etree
 
 import aioxmpp.xso as xso
 import aioxmpp.vcard.xso as vcard_xso
@@ -51,4 +54,46 @@ class TestVCard(unittest.TestCase):
         self.assertIsInstance(
             vcard_xso.VCard.elements,
             xso.Collector
+        )
+
+    def test_get_photo_data(self):
+        vcard = vcard_xso.VCard()
+        vcard.elements.append(
+            lxml.etree.fromstring("""
+<ns0:PHOTO xmlns:ns0="vcard-temp"><ns0:BINVAL>Zm9vCg==</ns0:BINVAL></ns0:PHOTO>
+            """)
+        )
+        self.assertEqual(vcard.get_photo_data(), b'foo\n')
+
+    def test_set_photo_data(self):
+        vcard = vcard_xso.VCard()
+        vcard.elements.append(
+            lxml.etree.fromstring("""
+<ns0:PHOTO xmlns:ns0="vcard-temp"><ns0:BINVAL>Zm9vCg==</ns0:BINVAL></ns0:PHOTO>
+            """)
+        )
+        vcard.set_photo_data("image/png", b'bar')
+        self.assertEqual(
+            vcard.get_photo_data(),
+            b'bar'
+        )
+
+        vcard.clear_photo_data()
+        vcard.set_photo_data("image/png", b'quux')
+        self.assertEqual(
+            vcard.get_photo_data(),
+            b'quux'
+        )
+
+    def test_clear_photo_data(self):
+        vcard = vcard_xso.VCard()
+        vcard.elements.append(
+            lxml.etree.fromstring("""
+<ns0:PHOTO xmlns:ns0="vcard-temp"><ns0:BINVAL>Zm9vCg==</ns0:BINVAL></ns0:PHOTO>
+            """)
+        )
+        vcard.clear_photo_data()
+        self.assertEqual(
+            vcard.get_photo_data(),
+            None
         )


### PR DESCRIPTION
This fixes #138.

I am unsure about two points, but I think a review might help to clarify them:
* how to prevent races that result in inconsistent metadata (between calls of get_avatar_metadata
  and the handlers for avatar pushes) – this would be easy if we would have a stanza serial number
  and add this info to the cache as "age" information. Another partial solution would be to bundle 
  requests.
* is the fallback behaviour on vCard avatars done correctly (in which cases do we want to use the 
  fallback). This might take some testing with real implementations to get right (as the responses we
  get may well depend on the XMPP server and client of the peer).
