### PR TITLE
Take care of the startup races

### DIFF
--- a/aioxmpp/blocking/service.py
+++ b/aioxmpp/blocking/service.py
@@ -111,7 +111,7 @@ class BlockingClient(service.Service):
                     type_=aioxmpp.IQType.GET,
                     payload=blocking_xso.BlockList(),
                 )
-                result = yield from self.client.stream.send(iq)
+                result = yield from self.client.send(iq)
                 self._blocklist = frozenset(result.items)
             self.on_initial_blocklist_received(self._blocklist)
 
@@ -138,7 +138,7 @@ class BlockingClient(service.Service):
             type_=aioxmpp.IQType.SET,
             payload=cmd,
         )
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def unblock_jids(self, jids_to_unblock):
@@ -156,7 +156,7 @@ class BlockingClient(service.Service):
             type_=aioxmpp.IQType.SET,
             payload=cmd,
         )
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def unblock_all(self):
@@ -170,7 +170,7 @@ class BlockingClient(service.Service):
             type_=aioxmpp.IQType.SET,
             payload=cmd,
         )
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @service.iq_handler(aioxmpp.IQType.SET, blocking_xso.BlockCommand)
     @asyncio.coroutine

--- a/aioxmpp/carbons/service.py
+++ b/aioxmpp/carbons/service.py
@@ -87,7 +87,7 @@ class CarbonsClient(aioxmpp.service.Service):
             payload=carbons_xso.Enable()
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def disable(self):
@@ -106,4 +106,4 @@ class CarbonsClient(aioxmpp.service.Service):
             payload=carbons_xso.Disable()
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)

--- a/aioxmpp/carbons/service.py
+++ b/aioxmpp/carbons/service.py
@@ -78,7 +78,7 @@ class CarbonsClient(aioxmpp.service.Service):
         :raises RuntimeError: if the server does not support message carbons.
         :raises aioxmpp.XMPPError: if the server responded with an error to the
                                    request.
-        :raises: as specified in :meth:`aioxmpp.stream.StanzaStream.send`
+        :raises: as specified in :meth:`aioxmpp.Client.send`
         """
         yield from self._check_for_feature()
 
@@ -97,7 +97,7 @@ class CarbonsClient(aioxmpp.service.Service):
         :raises RuntimeError: if the server does not support message carbons.
         :raises aioxmpp.XMPPError: if the server responded with an error to the
                                    request.
-        :raises: as specified in :meth:`aioxmpp.stream.StanzaStream.send`
+        :raises: as specified in :meth:`aioxmpp.Client.send`
         """
         yield from self._check_for_feature()
 

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -599,7 +599,7 @@ class DiscoClient(service.Service):
         request_iq = stanza.IQ(to=jid, type_=structs.IQType.GET)
         request_iq.payload = disco_xso.InfoQuery(node=node)
 
-        response = yield from self.client.stream.send(
+        response = yield from self.client.send(
             request_iq
         )
 
@@ -747,7 +747,7 @@ class DiscoClient(service.Service):
         request_iq.payload = disco_xso.ItemsQuery(node=node)
 
         request = asyncio.async(
-            self.client.stream.send(request_iq)
+            self.client.send(request_iq)
         )
 
         self._items_pending[key] = request

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -651,7 +651,7 @@ class DiscoClient(service.Service):
         The `timeout` can be used to restrict the time to wait for a
         response. If the timeout triggers, :class:`TimeoutError` is raised.
 
-        If :meth:`~.StanzaStream.send` raises an
+        If :meth:`~.Client.send` raises an
         exception, all queries which were running simultanously for the same
         target re-raise that exception. The result is not cached though. If a
         new query is sent at a later point for the same target, a new query is

--- a/aioxmpp/im/p2p.py
+++ b/aioxmpp/im/p2p.py
@@ -112,7 +112,7 @@ class Conversation(AbstractConversation):
     def send_message(self, msg):
         msg.to = self.__peer_jid
         self.on_message(msg, self.me, MessageSource.STREAM)
-        return self._client.stream.enqueue(msg)
+        return self._client.enqueue(msg)
 
     @asyncio.coroutine
     def send_message_tracked(self, msg):

--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1102,7 +1102,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
         # TL;DR: we want to help entities to discover that a message is related
         # to a MUC.
         msg.xep0045_muc_user = muc_xso.UserExt()
-        result = self.service.client.stream.enqueue(msg)
+        result = self.service.client.enqueue(msg)
         return result
 
     def _tracker_closed(self, tracker):
@@ -1241,7 +1241,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             type_=aioxmpp.PresenceType.AVAILABLE,
             to=self._mucjid.replace(resource=new_nick),
         )
-        yield from self._service.client.stream.send(
+        yield from self._service.client.send(
             stanza
         )
 
@@ -1313,9 +1313,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             ]
         )
 
-        yield from self.service.client.stream.send(
-            iq
-        )
+        yield from self.service.client.send(iq)
 
     @asyncio.coroutine
     def ban(self, member, reason=None, *, request_kick=True):
@@ -1381,7 +1379,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
         )
         msg.subject.update(new_topic)
 
-        yield from self.service.client.stream.send(msg)
+        yield from self.service.client.send(msg)
 
     @asyncio.coroutine
     def leave(self):
@@ -1400,7 +1398,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
             type_=aioxmpp.structs.PresenceType.UNAVAILABLE,
             to=self._mucjid
         )
-        yield from self.service.client.stream.send(presence)
+        yield from self.service.client.send(presence)
 
         yield from fut
 
@@ -1445,7 +1443,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
 
         msg.xep0004_data.append(data)
 
-        yield from self.service.client.stream.send(msg)
+        yield from self.service.client.send(msg)
 
 
 def _connect_to_signal(signal, func):
@@ -1522,7 +1520,7 @@ class MUCClient(aioxmpp.im.conversation.AbstractConversationService,
         presence.xep0045_muc = muc_xso.GenericExt()
         presence.xep0045_muc.password = password
         presence.xep0045_muc.history = history
-        self.client.stream.enqueue(presence)
+        self.client.enqueue(presence)
 
     @aioxmpp.service.depsignal(aioxmpp.Client, "on_stream_established")
     def _stream_established(self):
@@ -1598,7 +1596,7 @@ class MUCClient(aioxmpp.im.conversation.AbstractConversationService,
                 type_=aioxmpp.structs.PresenceType.UNAVAILABLE,
             )
             unjoin.xep0045_muc = muc_xso.GenericExt()
-            self.client.stream.enqueue(unjoin)
+            self.client.enqueue(unjoin)
 
     def _pending_on_enter(self, presence, occupant, **kwargs):
         mucjid = presence.from_.bare()
@@ -1870,9 +1868,7 @@ class MUCClient(aioxmpp.im.conversation.AbstractConversationService,
             ]
         )
 
-        yield from self.client.stream.send(
-            iq
-        )
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def get_room_config(self, mucjid):
@@ -1901,9 +1897,7 @@ class MUCClient(aioxmpp.im.conversation.AbstractConversationService,
             payload=muc_xso.OwnerQuery(),
         )
 
-        return (yield from self.client.stream.send(
-            iq
-        )).form
+        return (yield from self.client.send(iq)).form
 
     @asyncio.coroutine
     def set_room_config(self, mucjid, data):
@@ -1938,6 +1932,4 @@ class MUCClient(aioxmpp.im.conversation.AbstractConversationService,
             payload=muc_xso.OwnerQuery(form=data),
         )
 
-        yield from self.client.stream.send(
-            iq,
-        )
+        yield from self.client.send(iq)

--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -958,7 +958,7 @@ class Client:
                     self.logger.info("connection error: (%s) %s",
                                      type(exc).__qualname__,
                                      exc)
-                    if     (not self._had_connection and
+                    if (not self._had_connection and
                             self._max_initial_attempts is not None and
                             self._nattempt >= self._max_initial_attempts):
                         self.logger.warning("out of connection attempts")

--- a/aioxmpp/ping/service.py
+++ b/aioxmpp/ping/service.py
@@ -79,4 +79,4 @@ class PingService(aioxmpp.service.Service):
             payload=ping_xso.Ping()
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)

--- a/aioxmpp/presence/service.py
+++ b/aioxmpp/presence/service.py
@@ -38,7 +38,7 @@ class PresenceClient(aioxmpp.service.Service):
 
     No method to send directed presence is provided; it would basically just
     take a stanza and enqueue it in the clients stream, thus being a mere
-    wrapper around :meth:`~.stream.StanzaStream.send`, without any benefit.
+    wrapper around :meth:`~.Client.send`, without any benefit.
 
     The service provides access to presence information summarized by bare JID
     or for each full JID individually. An index over the resources of a bare

--- a/aioxmpp/presence/service.py
+++ b/aioxmpp/presence/service.py
@@ -296,9 +296,7 @@ class PresenceServer(aioxmpp.service.Service):
         if not self._state.available:
             return True
 
-        yield from self.client.stream.send(
-            self.make_stanza()
-        )
+        yield from self.client.send(self.make_stanza())
 
         return True
 
@@ -432,6 +430,4 @@ class PresenceServer(aioxmpp.service.Service):
         """
 
         if self.client.established:
-            return self.client.stream.enqueue(
-                self.make_stanza()
-            )
+            return self.client.enqueue(self.make_stanza())

--- a/aioxmpp/private_xml/service.py
+++ b/aioxmpp/private_xml/service.py
@@ -57,7 +57,7 @@ class PrivateXMLService(service.Service):
             type_=aioxmpp.IQType.GET,
             payload=private_xml_xso.Query(query_xso)
         )
-        return (yield from self.client.stream.send(iq))
+        return (yield from self.client.send(iq))
 
     @asyncio.coroutine
     def set_private_xml(self, xso):
@@ -71,4 +71,4 @@ class PrivateXMLService(service.Service):
             type_=aioxmpp.IQType.SET,
             payload=private_xml_xso.Query(xso)
         )
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -807,7 +807,7 @@ def send_and_wait_for(xmlstream, send, wait_for, timeout=None):
             failure_future.result()
 
         raise TimeoutError()
-    except:
+    except:  # NOQA
         cleanup()
         raise
 

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -764,12 +764,16 @@ class XMLStream(asyncio.Protocol):
 
 
 @asyncio.coroutine
-def send_and_wait_for(xmlstream, send, wait_for, timeout=None):
+def send_and_wait_for(xmlstream, send, wait_for,
+                      timeout=None,
+                      cb=None):
     fut = asyncio.Future()
     wait_for = list(wait_for)
 
     def receive(obj):
         nonlocal fut, stack
+        if cb is not None:
+            cb(obj)
         fut.set_result(obj)
         stack.close()
 

--- a/aioxmpp/pubsub/service.py
+++ b/aioxmpp/pubsub/service.py
@@ -350,9 +350,7 @@ class PubSubClient(aioxmpp.service.Service):
             )
             iq.payload.options.data = config
 
-        response = yield from self.client.stream.send(
-            iq
-        )
+        response = yield from self.client.send(iq)
         return response
 
     @asyncio.coroutine
@@ -389,9 +387,7 @@ class PubSubClient(aioxmpp.service.Service):
             pubsub_xso.Unsubscribe(subscription_jid, node=node, subid=subid)
         )
 
-        yield from self.client.stream.send(
-            iq
-        )
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def get_subscription_config(self, jid, node=None, *,
@@ -433,9 +429,7 @@ class PubSubClient(aioxmpp.service.Service):
             subid=subid,
         )
 
-        response = yield from self.client.stream.send(
-            iq
-        )
+        response = yield from self.client.send(iq)
         return response.options.data
 
     @asyncio.coroutine
@@ -480,9 +474,7 @@ class PubSubClient(aioxmpp.service.Service):
         )
         iq.payload.options.data = data
 
-        yield from self.client.stream.send(
-            iq
-        )
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def get_default_config(self, jid, node=None):
@@ -508,7 +500,7 @@ class PubSubClient(aioxmpp.service.Service):
             pubsub_xso.Default(node=node)
         )
 
-        response = yield from self.client.stream.send(iq)
+        response = yield from self.client.send(iq)
         return response.payload.data
 
     @asyncio.coroutine
@@ -539,7 +531,7 @@ class PubSubClient(aioxmpp.service.Service):
             pubsub_xso.Items(node, max_items=max_items)
         )
 
-        return (yield from self.client.stream.send(iq))
+        return (yield from self.client.send(iq))
 
     @asyncio.coroutine
     def get_items_by_id(self, jid, node, ids):
@@ -578,7 +570,7 @@ class PubSubClient(aioxmpp.service.Service):
         if not iq.payload.payload.items:
             raise ValueError("ids must not be empty")
 
-        return (yield from self.client.stream.send(iq))
+        return (yield from self.client.send(iq))
 
     @asyncio.coroutine
     def get_subscriptions(self, jid, node=None):
@@ -602,7 +594,7 @@ class PubSubClient(aioxmpp.service.Service):
             pubsub_xso.Subscriptions(node=node)
         )
 
-        response = yield from self.client.stream.send(iq)
+        response = yield from self.client.send(iq)
         return response.payload
 
     @asyncio.coroutine
@@ -648,7 +640,7 @@ class PubSubClient(aioxmpp.service.Service):
             publish
         )
 
-        response = yield from self.client.stream.send(iq)
+        response = yield from self.client.send(iq)
 
         if response is not None and response.payload.item is not None:
             return response.payload.item.id_ or id_
@@ -704,7 +696,7 @@ class PubSubClient(aioxmpp.service.Service):
             retract
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def create(self, jid, node=None):
@@ -734,7 +726,7 @@ class PubSubClient(aioxmpp.service.Service):
             payload=pubsub_xso.Request(create)
         )
 
-        response = yield from self.client.stream.send(iq)
+        response = yield from self.client.send(iq)
 
         if response is not None and response.payload.node is not None:
             return response.payload.node
@@ -771,7 +763,7 @@ class PubSubClient(aioxmpp.service.Service):
             )
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def get_nodes(self, jid, node=None):
@@ -840,7 +832,7 @@ class PubSubClient(aioxmpp.service.Service):
             )
         )
 
-        return (yield from self.client.stream.send(iq))
+        return (yield from self.client.send(iq))
 
     @asyncio.coroutine
     def get_node_subscriptions(self, jid, node):
@@ -867,7 +859,7 @@ class PubSubClient(aioxmpp.service.Service):
             )
         )
 
-        return (yield from self.client.stream.send(iq))
+        return (yield from self.client.send(iq))
 
     @asyncio.coroutine
     def change_node_affiliations(self, jid, node, affiliations_to_set):
@@ -904,7 +896,7 @@ class PubSubClient(aioxmpp.service.Service):
             )
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def change_node_subscriptions(self, jid, node, subscriptions_to_set):
@@ -942,7 +934,7 @@ class PubSubClient(aioxmpp.service.Service):
             )
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
     @asyncio.coroutine
     def purge(self, jid, node):
@@ -966,4 +958,4 @@ class PubSubClient(aioxmpp.service.Service):
             )
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)

--- a/aioxmpp/roster/service.py
+++ b/aioxmpp/roster/service.py
@@ -542,7 +542,7 @@ class RosterClient(aioxmpp.service.Service):
                              self.version)
                 iq.payload.ver = self.version
 
-            response = yield from self.client.stream.send(
+            response = yield from self.client.send(
                 iq,
                 timeout=self.client.negotiation_timeout.total_seconds()
             )
@@ -659,7 +659,7 @@ class RosterClient(aioxmpp.service.Service):
                 for group_name in post_groups
             ])
 
-        yield from self.client.stream.send(
+        yield from self.client.send(
             stanza.IQ(
                 structs.IQType.SET,
                 payload=roster_xso.Query(items=[
@@ -683,7 +683,7 @@ class RosterClient(aioxmpp.service.Service):
         server replies with an error and also any kind of connection error if
         the connection gets fatally terminated while waiting for a response.
         """
-        yield from self.client.stream.send(
+        yield from self.client.send(
             stanza.IQ(
                 structs.IQType.SET,
                 payload=roster_xso.Query(items=[
@@ -715,7 +715,7 @@ class RosterClient(aioxmpp.service.Service):
             Pre-approval is an OPTIONAL feature in :rfc:`6121`. It is announced
             as a stream feature.
         """
-        self.client.stream.enqueue(
+        self.client.enqueue(
             stanza.Presence(type_=structs.PresenceType.SUBSCRIBED,
                             to=peer_jid)
         )
@@ -729,7 +729,7 @@ class RosterClient(aioxmpp.service.Service):
         confirm at all. Use :meth:`on_subscribed` to get notified when a peer
         accepted a subscription request.
         """
-        self.client.stream.enqueue(
+        self.client.enqueue(
             stanza.Presence(type_=structs.PresenceType.SUBSCRIBE,
                             to=peer_jid)
         )
@@ -738,7 +738,7 @@ class RosterClient(aioxmpp.service.Service):
         """
         Unsubscribe from the presence of the given `peer_jid`.
         """
-        self.client.stream.enqueue(
+        self.client.enqueue(
             stanza.Presence(type_=structs.PresenceType.UNSUBSCRIBE,
                             to=peer_jid)
         )

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -166,6 +166,7 @@ class ConnectedClientMock(unittest.mock.Mock):
             "stop",
             "set_presence",
             "local_jid",
+            "enqueue",
         ])
 
         self.established = True
@@ -183,8 +184,13 @@ class ConnectedClientMock(unittest.mock.Mock):
         self.stream.service_outbound_message_filter = FilterMock()
         self.stream.service_outbound_presence_filter = FilterMock()
         self.stream.on_stream_destroyed = callbacks.AdHocSignal()
-        self.stream.send_iq_and_wait_for_reply = CoroutineMock()
-        self.stream.send = CoroutineMock()
+        self.stream.send_iq_and_wait_for_reply.side_effect = \
+            AssertionError("use of deprecated function")
+        self.stream.send.side_effect = \
+            AssertionError("use of deprecated function")
+        self.stream.enqueue.side_effect = \
+            AssertionError("use of deprecated function")
+        self.send = CoroutineMock()
         self.stream.enqueue_stanza = self.stream.enqueue
         self.mock_services = {}
 

--- a/aioxmpp/tracking.py
+++ b/aioxmpp/tracking.py
@@ -427,7 +427,7 @@ class BasicTrackingService(aioxmpp.service.Service):
               can be used if the stanza cannot be sent (e.g. because it is a
               carbon-copy) or has already been sent.
         """
-        token = self.client.stream.enqueue(stanza)
+        token = self.client.enqueue(stanza)
         self.attach_tracker(stanza, tracker, token)
         return token
 

--- a/aioxmpp/vcard/service.py
+++ b/aioxmpp/vcard/service.py
@@ -61,7 +61,7 @@ class VCardService(service.Service):
         )
 
         try:
-            return (yield from self.client.stream.send(iq))
+            return (yield from self.client.send(iq))
         except aioxmpp.XMPPCancelError as e:
             if e.condition in (
                     (namespaces.stanzas, "feature-not-implemented"),
@@ -92,4 +92,4 @@ class VCardService(service.Service):
             type_=aioxmpp.IQType.SET,
             payload=vcard,
         )
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -239,6 +239,15 @@ Version 0.10
 * Support for escaping additional characters as entities when writing XML, see
   the `additional_escapes` argument to :class:`aioxmpp.xml.XMPPXMLGenerator`.
 
+* Add `cb` argument to :func:`aioxmpp.protocol.send_and_wait_for` to allow to
+  act synchronously on the response. This is needed for transactional things
+  like stream management.
+
+* Fix a race condition where stream management handlers would be installed too
+  late on the XML stream, leading it to be closed with an
+  ``unsupported-stanza-type`` because :mod:`aioxmpp` failed to interpret SM
+  requests.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -248,6 +248,13 @@ Version 0.10
   ``unsupported-stanza-type`` because :mod:`aioxmpp` failed to interpret SM
   requests.
 
+* Move :meth:`aioxmpp.stream.StanzaStream.enqueue` and
+  :meth:`aioxmpp.stream.StanzaStream.send` to the client as
+  :meth:`aioxmpp.node.Client.enqueue` and :meth:`aioxmpp.node.Client.send`.
+
+  The old names are deprecated, but aliases are provided until version 1.0.
+
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -250,10 +250,15 @@ Version 0.10
 
 * Move :meth:`aioxmpp.stream.StanzaStream.enqueue` and
   :meth:`aioxmpp.stream.StanzaStream.send` to the client as
-  :meth:`aioxmpp.node.Client.enqueue` and :meth:`aioxmpp.node.Client.send`.
+  :meth:`aioxmpp.Client.enqueue` and :meth:`aioxmpp.Client.send`.
 
   The old names are deprecated, but aliases are provided until version 1.0.
 
+* :meth:`aioxmpp.Client.enqueue` now raises :class:`ConnectionError` if the
+  stream of the client is not :attr:`aioxmpp.Client.established` yet.
+
+* :meth:`aioxmpp.Client.send` now blocks until the stream of the client is
+  :attr:`aioxmpp.Client.established`.
 
 .. _api-changelog-0.9:
 

--- a/docs/user-guide/quickstart.rst
+++ b/docs/user-guide/quickstart.rst
@@ -84,12 +84,12 @@ inside the ``async with`` block::
   # None is for "default language"
   msg.body[None] = "Hello World!"
 
-  await stream.send(msg)
+  await client.send(msg)
 
 Relevant documentation:
 
 * :class:`aioxmpp.Message`
-* :meth:`aioxmpp.stream.StanzaStream.send`
+* :meth:`aioxmpp.Client.send`
 
 
 .. note::
@@ -162,7 +162,7 @@ This example can be modified to be an echo bot by implementing the
       reply = msg.make_reply()
       reply.body.update(msg.body)
 
-      client.stream.enqueue(reply)
+      client.enqueue(reply)
 
 .. note::
 
@@ -173,7 +173,7 @@ This example can be modified to be an echo bot by implementing the
   :meth:`~aioxmpp.dispatcher.SimpleStanzaDispatcher.register_callback`.
   Definitely check this out for the semantics of the first two arguments!
 * :class:`aioxmpp.Message`
-* :meth:`~aioxmpp.stream.StanzaStream.enqueue`
+* :meth:`~aioxmpp.Client.enqueue`
 * :meth:`aioxmpp.Client.summon`
 
 
@@ -394,7 +394,7 @@ Relevant documentation:
 * :mod:`aioxmpp.xso`, especially :class:`aioxmpp.xso.XSO` and
   :class:`aioxmpp.xso.ChildText`
 * :meth:`aioxmpp.IQ.as_payload_class`
-* :meth:`aioxmpp.stream.StanzaStream.send`
+* :meth:`aioxmpp.Client.send`
 * also make sure to read the source of, for example, :mod:`aioxmpp.disco.xso`
   for more examples of :class:`~aioxmpp.XSO` subclasses.
 

--- a/examples/echo_bot.py
+++ b/examples/echo_bot.py
@@ -44,7 +44,7 @@ class EchoBot(Example):
         # make_reply() would not set the body though
         reply.body.update(msg.body)
 
-        self.client.stream.enqueue(reply)
+        self.client.enqueue(reply)
 
     @asyncio.coroutine
     def run_simple_example(self):

--- a/examples/quickstart_echo_bot.py
+++ b/examples/quickstart_echo_bot.py
@@ -50,7 +50,7 @@ async def main(local_jid, password):
         # make_reply() would not set the body though
         reply.body.update(msg.body)
 
-        client.stream.enqueue(reply)
+        client.enqueue(reply)
 
     message_dispatcher = client.summon(
         aioxmpp.dispatcher.SimpleMessageDispatcher

--- a/examples/send_message.py
+++ b/examples/send_message.py
@@ -58,7 +58,7 @@ class SendMessage(Example):
         msg.body[None] = self.args.message
 
         print("sending message ...")
-        yield from self.client.stream.send(msg)
+        yield from self.client.send(msg)
         print("message sent!")
 
 

--- a/examples/send_raw.py
+++ b/examples/send_raw.py
@@ -61,7 +61,7 @@ class SendMessage(Example):
         msg.raw.append(self.args.xml)
 
         print("sending message ...")
-        yield from self.client.stream.send(msg)
+        yield from self.client.send(msg)
         print("message sent!")
 
 

--- a/tests/blocking/test_service.py
+++ b/tests/blocking/test_service.py
@@ -127,7 +127,7 @@ class TestBlockingClient(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch.object(
-                    self.cc.stream, "send",
+                    self.cc, "send",
                     new=CoroutineMock()
                 )
             )
@@ -140,7 +140,7 @@ class TestBlockingClient(unittest.TestCase):
             BLOCKLIST = [TEST_JID1, TEST_JID2]
             blocklist = blocking_xso.BlockList()
             blocklist.items[:] = BLOCKLIST
-            self.cc.stream.send.return_value = blocklist
+            self.cc.send.return_value = blocklist
 
             run_coroutine(self.s._get_initial_blocklist())
 
@@ -149,8 +149,8 @@ class TestBlockingClient(unittest.TestCase):
                 BLOCKLIST
             )
 
-            self.assertEqual(len(self.cc.stream.send.mock_calls), 1)
-            (_, (arg,), _), = self.cc.stream.send.mock_calls
+            self.assertEqual(len(self.cc.send.mock_calls), 1)
+            (_, (arg,), _), = self.cc.send.mock_calls
             self.assertIsInstance(arg, aioxmpp.IQ)
             self.assertEqual(arg.type_, aioxmpp.IQType.GET)
             self.assertIsInstance(arg.payload, blocking_xso.BlockList)
@@ -184,7 +184,7 @@ class TestBlockingClient(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch.object(
-                    self.cc.stream, "send",
+                    self.cc, "send",
                     new=CoroutineMock()
                 )
             )
@@ -196,8 +196,8 @@ class TestBlockingClient(unittest.TestCase):
                 [unittest.mock.call()]
             )
 
-            self.assertEqual(len(self.cc.stream.send.mock_calls), 1)
-            (_, (arg,), _), = self.cc.stream.send.mock_calls
+            self.assertEqual(len(self.cc.send.mock_calls), 1)
+            (_, (arg,), _), = self.cc.send.mock_calls
 
             self.assertIsInstance(arg, aioxmpp.IQ)
             self.assertEqual(arg.type_, aioxmpp.IQType.SET)
@@ -218,7 +218,7 @@ class TestBlockingClient(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch.object(
-                    self.cc.stream, "send",
+                    self.cc, "send",
                     new=CoroutineMock()
                 )
             )
@@ -230,7 +230,7 @@ class TestBlockingClient(unittest.TestCase):
                 [unittest.mock.call()]
             )
 
-            self.assertSequenceEqual(self.cc.stream.send.mock_calls, [])
+            self.assertSequenceEqual(self.cc.send.mock_calls, [])
 
     def test_unblock_jids(self):
         with contextlib.ExitStack() as stack:
@@ -243,7 +243,7 @@ class TestBlockingClient(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch.object(
-                    self.cc.stream, "send",
+                    self.cc, "send",
                     new=CoroutineMock()
                 )
             )
@@ -255,8 +255,8 @@ class TestBlockingClient(unittest.TestCase):
                 [unittest.mock.call()]
             )
 
-            self.assertEqual(len(self.cc.stream.send.mock_calls), 1)
-            (_, (arg,), _), = self.cc.stream.send.mock_calls
+            self.assertEqual(len(self.cc.send.mock_calls), 1)
+            (_, (arg,), _), = self.cc.send.mock_calls
 
             self.assertIsInstance(arg, aioxmpp.IQ)
             self.assertEqual(arg.type_, aioxmpp.IQType.SET)
@@ -277,7 +277,7 @@ class TestBlockingClient(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch.object(
-                    self.cc.stream, "send",
+                    self.cc, "send",
                     new=CoroutineMock()
                 )
             )
@@ -289,7 +289,7 @@ class TestBlockingClient(unittest.TestCase):
                 [unittest.mock.call()]
             )
 
-            self.assertSequenceEqual(self.cc.stream.send.mock_calls, [])
+            self.assertSequenceEqual(self.cc.send.mock_calls, [])
 
     def test_unblock_all(self):
         with contextlib.ExitStack() as stack:
@@ -302,7 +302,7 @@ class TestBlockingClient(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch.object(
-                    self.cc.stream, "send",
+                    self.cc, "send",
                     new=CoroutineMock()
                 )
             )

--- a/tests/carbons/test_service.py
+++ b/tests/carbons/test_service.py
@@ -129,11 +129,11 @@ class TestCarbonsClient(unittest.TestCase):
 
             check_for_feature.assert_called_once_with()
 
-            self.cc.stream.send.assert_called_once_with(
+            self.cc.send.assert_called_once_with(
                 unittest.mock.ANY,
             )
 
-            _, (iq,), _ = self.cc.stream.send.mock_calls[0]
+            _, (iq,), _ = self.cc.send.mock_calls[0]
 
             self.assertIsInstance(iq, aioxmpp.IQ)
             self.assertEqual(iq.type_, aioxmpp.IQType.SET)
@@ -153,7 +153,7 @@ class TestCarbonsClient(unittest.TestCase):
 
             check_for_feature.assert_called_once_with()
 
-            self.cc.stream.send.assert_not_called()
+            self.cc.send.assert_not_called()
 
     def test_disable_checks_for_feature_and_sends_iq(self):
         with contextlib.ExitStack() as stack:
@@ -167,11 +167,11 @@ class TestCarbonsClient(unittest.TestCase):
 
             check_for_feature.assert_called_once_with()
 
-            self.cc.stream.send.assert_called_once_with(
+            self.cc.send.assert_called_once_with(
                 unittest.mock.ANY,
             )
 
-            _, (iq,), _ = self.cc.stream.send.mock_calls[0]
+            _, (iq,), _ = self.cc.send.mock_calls[0]
 
             self.assertIsInstance(iq, aioxmpp.IQ)
             self.assertEqual(iq.type_, aioxmpp.IQType.SET)
@@ -191,4 +191,4 @@ class TestCarbonsClient(unittest.TestCase):
 
             check_for_feature.assert_called_once_with()
 
-            self.cc.stream.send.assert_not_called()
+            self.cc.send.assert_not_called()

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -965,7 +965,7 @@ class TestDiscoClient(unittest.TestCase):
         node = "foobar"
         response = disco_xso.InfoQuery()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(
             self.s.send_and_decode_info_query(to, node)
@@ -975,10 +975,10 @@ class TestDiscoClient(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         # call[1] are args
         request_iq, = call[1]
 
@@ -1449,7 +1449,7 @@ class TestDiscoClient(unittest.TestCase):
         to = structs.JID.fromstr("user@foo.example/res1")
         response = disco_xso.ItemsQuery()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(
             self.s.query_items(to)
@@ -1458,10 +1458,10 @@ class TestDiscoClient(unittest.TestCase):
         self.assertIs(result, response)
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         # call[1] are args
         request_iq, = call[1]
 
@@ -1481,7 +1481,7 @@ class TestDiscoClient(unittest.TestCase):
         to = structs.JID.fromstr("user@foo.example/res1")
         response = disco_xso.ItemsQuery()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         with self.assertRaises(TypeError):
             self.s.query_items(to, "foobar")
@@ -1493,10 +1493,10 @@ class TestDiscoClient(unittest.TestCase):
         self.assertIs(result, response)
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         # call[1] are args
         request_iq, = call[1]
 
@@ -1516,7 +1516,7 @@ class TestDiscoClient(unittest.TestCase):
         to = structs.JID.fromstr("user@foo.example/res1")
         response = disco_xso.ItemsQuery()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         with self.assertRaises(TypeError):
             self.s.query_items(to, "foobar")
@@ -1533,7 +1533,7 @@ class TestDiscoClient(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
     def test_query_items_reraises_and_aliases_exception(self):
@@ -1553,7 +1553,7 @@ class TestDiscoClient(unittest.TestCase):
                 raise ConnectionError()
 
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=mock):
 
@@ -1573,7 +1573,7 @@ class TestDiscoClient(unittest.TestCase):
     def test_query_info_reraises_but_does_not_cache_exception(self):
         to = structs.JID.fromstr("user@foo.example/res1")
 
-        self.cc.stream.send.side_effect = \
+        self.cc.send.side_effect = \
             errors.XMPPCancelError(
                 condition=(namespaces.stanzas, "feature-not-implemented"),
             )
@@ -1583,7 +1583,7 @@ class TestDiscoClient(unittest.TestCase):
                 self.s.query_items(to, node="foobar")
             )
 
-        self.cc.stream.send.side_effect = \
+        self.cc.send.side_effect = \
             ConnectionError()
 
         with self.assertRaises(ConnectionError):
@@ -1595,7 +1595,7 @@ class TestDiscoClient(unittest.TestCase):
         to = structs.JID.fromstr("user@foo.example/res1")
 
         response1 = disco_xso.ItemsQuery()
-        self.cc.stream.send.return_value = response1
+        self.cc.send.return_value = response1
 
         with self.assertRaises(TypeError):
             self.s.query_items(to, "foobar")
@@ -1605,7 +1605,7 @@ class TestDiscoClient(unittest.TestCase):
         )
 
         response2 = disco_xso.ItemsQuery()
-        self.cc.stream.send.return_value = response2
+        self.cc.send.return_value = response2
 
         result2 = run_coroutine(
             self.s.query_items(to, node="foobar", require_fresh=True)
@@ -1616,14 +1616,14 @@ class TestDiscoClient(unittest.TestCase):
 
         self.assertEqual(
             2,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
     def test_query_items_cache_clears_on_disconnect(self):
         to = structs.JID.fromstr("user@foo.example/res1")
 
         response1 = disco_xso.ItemsQuery()
-        self.cc.stream.send.return_value = response1
+        self.cc.send.return_value = response1
 
         with self.assertRaises(TypeError):
             self.s.query_items(to, "foobar")
@@ -1635,7 +1635,7 @@ class TestDiscoClient(unittest.TestCase):
         self.cc.on_stream_destroyed()
 
         response2 = disco_xso.ItemsQuery()
-        self.cc.stream.send.return_value = response2
+        self.cc.send.return_value = response2
 
         result2 = run_coroutine(
             self.s.query_items(to, node="foobar")
@@ -1646,15 +1646,15 @@ class TestDiscoClient(unittest.TestCase):
 
         self.assertEqual(
             2,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
     def test_query_items_timeout(self):
         to = structs.JID.fromstr("user@foo.example/res1")
         response = disco_xso.ItemsQuery()
 
-        self.cc.stream.send.delay = 1
-        self.cc.stream.send.return_value = response
+        self.cc.send.delay = 1
+        self.cc.send.return_value = response
 
         with self.assertRaises(TimeoutError):
             result = run_coroutine(
@@ -1665,14 +1665,14 @@ class TestDiscoClient(unittest.TestCase):
             [
                 unittest.mock.call(unittest.mock.ANY),
             ],
-            self.cc.stream.send.mock_calls
+            self.cc.send.mock_calls
         )
 
     def test_query_items_deduplicate_requests(self):
         to = structs.JID.fromstr("user@foo.example/res1")
         response = disco_xso.ItemsQuery()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(
             asyncio.gather(
@@ -1688,15 +1688,15 @@ class TestDiscoClient(unittest.TestCase):
             [
                 unittest.mock.call(unittest.mock.ANY),
             ],
-            self.cc.stream.send.mock_calls
+            self.cc.send.mock_calls
         )
 
     def test_query_items_transparent_deduplication_when_cancelled(self):
         to = structs.JID.fromstr("user@foo.example/res1")
         response = disco_xso.ItemsQuery()
 
-        self.cc.stream.send.return_value = response
-        self.cc.stream.send.delay = 0.1
+        self.cc.send.return_value = response
+        self.cc.send.delay = 0.1
 
         q1 = asyncio.async(self.s.query_items(to))
         q2 = asyncio.async(self.s.query_items(to))
@@ -1714,7 +1714,7 @@ class TestDiscoClient(unittest.TestCase):
                 unittest.mock.call(unittest.mock.ANY),
                 unittest.mock.call(unittest.mock.ANY),
             ],
-            self.cc.stream.send.mock_calls
+            self.cc.send.mock_calls
         )
 
     def test_set_info_cache(self):
@@ -1728,7 +1728,7 @@ class TestDiscoClient(unittest.TestCase):
         )
 
         other_response = disco_xso.InfoQuery()
-        self.cc.stream.send.return_value = \
+        self.cc.send.return_value = \
             other_response
 
         result = run_coroutine(self.s.query_info(to, node=None))

--- a/tests/entitycaps/test_e2e.py
+++ b/tests/entitycaps/test_e2e.py
@@ -76,7 +76,7 @@ class TestEntityCapabilities(TestCase):
             type_=aioxmpp.PresenceType.AVAILABLE,
             to=self.sink.local_jid,
         )
-        yield from self.source.stream.send(presence)
+        yield from self.source.send(presence)
 
         presence = yield from fut
 
@@ -179,7 +179,7 @@ class TestEntityCapabilities(TestCase):
             "sha-1",
         )
 
-        yield from self.source.stream.send(presence)
+        yield from self.source.send(presence)
 
         yield from fut
 
@@ -264,7 +264,7 @@ class TestEntityCapabilities(TestCase):
         presence.xep0390_caps = caps.xso.Caps390()
         presence.xep0390_caps.digests["sha-256"] = info_hash
 
-        yield from self.source.stream.send(presence)
+        yield from self.source.send(presence)
 
         yield from fut
 

--- a/tests/im/test_p2p.py
+++ b/tests/im/test_p2p.py
@@ -55,7 +55,7 @@ class TestConversation(unittest.TestCase):
         self.listener = unittest.mock.Mock()
 
         self.cc = make_connected_client()
-        self.cc.stream.send = CoroutineMock()
+        self.cc.send = CoroutineMock()
         self.cc.local_jid = LOCAL_JID
         self.svc = unittest.mock.Mock(["client", "_conversation_left",
                                        "logger"])
@@ -128,7 +128,7 @@ class TestConversation(unittest.TestCase):
         msg = unittest.mock.Mock()
         token = self.c.send_message(msg)
 
-        self.cc.stream.enqueue.assert_called_once_with(msg)
+        self.cc.enqueue.assert_called_once_with(msg)
         self.assertEqual(msg.to, PEER_JID)
 
         self.listener.on_message.assert_called_once_with(
@@ -137,7 +137,7 @@ class TestConversation(unittest.TestCase):
             im_dispatcher.MessageSource.STREAM,
         )
 
-        self.assertEqual(token, self.cc.stream.enqueue())
+        self.assertEqual(token, self.cc.enqueue())
 
     def test_inbound_message_dispatched_to_event(self):
         msg = unittest.mock.sentinel.message
@@ -177,8 +177,8 @@ class TestConversation(unittest.TestCase):
 class TestService(unittest.TestCase):
     def setUp(self):
         self.cc = make_connected_client()
-        self.cc.stream.send = CoroutineMock()
-        self.cc.stream.send.side_effect = AssertionError("not configured")
+        self.cc.send = CoroutineMock()
+        self.cc.send.side_effect = AssertionError("not configured")
         self.cc.local_jid = LOCAL_JID
         deps = {
             im_service.ConversationService: im_service.ConversationService(

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -519,7 +519,7 @@ class TestRoom(unittest.TestCase):
 
         self.base = unittest.mock.Mock()
         self.base.service.logger = unittest.mock.Mock(name="logger")
-        self.base.service.client.stream.send = \
+        self.base.service.client.send = \
             CoroutineMock()
         self.base.service.dependencies = {}
         self.base.service.dependencies[
@@ -2142,7 +2142,7 @@ class TestRoom(unittest.TestCase):
         new_role = "participant"
 
         with unittest.mock.patch.object(
-                self.base.service.client.stream,
+                self.base.service.client,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -2197,7 +2197,7 @@ class TestRoom(unittest.TestCase):
 
     def test_muc_set_role_rejects_None_nick(self):
         with unittest.mock.patch.object(
-                self.base.service.client.stream,
+                self.base.service.client,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -2214,7 +2214,7 @@ class TestRoom(unittest.TestCase):
 
     def test_muc_set_role_rejects_None_role(self):
         with unittest.mock.patch.object(
-                self.base.service.client.stream,
+                self.base.service.client,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -2231,7 +2231,7 @@ class TestRoom(unittest.TestCase):
 
     def test_muc_set_role_fails(self):
         with unittest.mock.patch.object(
-                self.base.service.client.stream,
+                self.base.service.client,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -2248,7 +2248,7 @@ class TestRoom(unittest.TestCase):
 
     def test_set_nick(self):
         with unittest.mock.patch.object(
-                self.base.service.client.stream,
+                self.base.service.client,
                 "send",
                 new=CoroutineMock()) as send_stanza:
             send_stanza.return_value = None
@@ -2298,7 +2298,7 @@ class TestRoom(unittest.TestCase):
 
         result = run_coroutine(self.jmuc.set_topic(d))
 
-        _, (stanza,), _ = self.base.service.client.stream.\
+        _, (stanza,), _ = self.base.service.client.\
             send.mock_calls[-1]
 
         self.assertIsInstance(
@@ -2325,7 +2325,7 @@ class TestRoom(unittest.TestCase):
         run_coroutine(asyncio.sleep(0))
         self.assertFalse(fut.done(), fut.done() and fut.result())
 
-        _, (stanza,), _ = self.base.service.client.stream.\
+        _, (stanza,), _ = self.base.service.client.\
             send.mock_calls[-1]
 
         self.assertIsInstance(
@@ -2419,12 +2419,12 @@ class TestRoom(unittest.TestCase):
         run_coroutine(self.jmuc.muc_request_voice())
 
         self.assertEqual(
-            len(self.base.service.client.stream.send.mock_calls),
+            len(self.base.service.client.send.mock_calls),
             1,
         )
 
         _, (msg, ), _ = \
-            self.base.service.client.stream.send.mock_calls[0]
+            self.base.service.client.send.mock_calls[0]
 
         self.assertIsInstance(
             msg,
@@ -2511,13 +2511,13 @@ class TestRoom(unittest.TestCase):
 
         token = self.jmuc.send_message(msg)
 
-        self.base.service.client.stream.enqueue.assert_called_once_with(
+        self.base.service.client.enqueue.assert_called_once_with(
             unittest.mock.ANY,
         )
 
-        _, (msg, ), _ = self.base.service.client.stream.enqueue.mock_calls[0]
+        _, (msg, ), _ = self.base.service.client.enqueue.mock_calls[0]
 
-        self.assertEqual(token, self.base.service.client.stream.enqueue())
+        self.assertEqual(token, self.base.service.client.enqueue())
 
         self.assertIsInstance(
             msg,
@@ -2569,11 +2569,11 @@ class TestRoom(unittest.TestCase):
 
         self.jmuc.send_message(msg)
 
-        self.base.service.client.stream.enqueue.assert_called_once_with(
+        self.base.service.client.enqueue.assert_called_once_with(
             unittest.mock.ANY,
         )
 
-        _, (msg, ), _ = self.base.service.client.stream.enqueue.mock_calls[0]
+        _, (msg, ), _ = self.base.service.client.enqueue.mock_calls[0]
 
         reply = msg.make_reply()
         reply.body.update(msg.body)
@@ -4218,7 +4218,7 @@ class TestService(unittest.TestCase):
         self.assertTrue(room.muc_autorejoin)
         self.assertIsNone(room.muc_password)
 
-        _, (stanza,), _ = self.cc.stream.enqueue.mock_calls[-1]
+        _, (stanza,), _ = self.cc.enqueue.mock_calls[-1]
         self.assertIsInstance(
             stanza,
             aioxmpp.stanza.Presence
@@ -4263,7 +4263,7 @@ class TestService(unittest.TestCase):
             room
         )
 
-        _, (stanza,), _ = self.cc.stream.enqueue.mock_calls[-1]
+        _, (stanza,), _ = self.cc.enqueue.mock_calls[-1]
         self.assertIsInstance(
             stanza,
             aioxmpp.stanza.Presence
@@ -4303,7 +4303,7 @@ class TestService(unittest.TestCase):
         self.assertFalse(room.muc_autorejoin)
         self.assertEqual(room.muc_password, "foobar")
 
-        _, (stanza,), _ = self.cc.stream.enqueue.mock_calls[-1]
+        _, (stanza,), _ = self.cc.enqueue.mock_calls[-1]
         self.assertIsInstance(
             stanza,
             aioxmpp.stanza.Presence
@@ -4343,7 +4343,7 @@ class TestService(unittest.TestCase):
             room
         )
 
-        _, (stanza,), _ = self.cc.stream.enqueue.mock_calls[-1]
+        _, (stanza,), _ = self.cc.enqueue.mock_calls[-1]
         self.assertIsInstance(
             stanza,
             aioxmpp.stanza.Presence
@@ -4458,7 +4458,7 @@ class TestService(unittest.TestCase):
         room, future = self.s.join(TEST_MUC_JID, "thirdwitch")
         listener = make_listener(room)
 
-        self.cc.stream.enqueue.mock_calls.clear()
+        self.cc.enqueue.mock_calls.clear()
 
         future.cancel()
 
@@ -4467,7 +4467,7 @@ class TestService(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.s.get_muc(TEST_MUC_JID)
 
-        _, (stanza,), _ = self.cc.stream.enqueue.mock_calls[-1]
+        _, (stanza,), _ = self.cc.enqueue.mock_calls[-1]
         self.assertIsInstance(
             stanza,
             aioxmpp.stanza.Presence
@@ -4821,7 +4821,7 @@ class TestService(unittest.TestCase):
         )
 
         self.assertSequenceEqual(
-            self.cc.stream.enqueue.mock_calls,
+            self.cc.enqueue.mock_calls,
             []
         )
 
@@ -4829,7 +4829,7 @@ class TestService(unittest.TestCase):
 
         run_coroutine(asyncio.sleep(0))
 
-        _, (stanza,), _ = self.cc.stream.enqueue.mock_calls[-1]
+        _, (stanza,), _ = self.cc.enqueue.mock_calls[-1]
         self.assertIsInstance(
             stanza,
             aioxmpp.stanza.Presence
@@ -4923,7 +4923,7 @@ class TestService(unittest.TestCase):
             ]
         )
         base.mock_calls.clear()
-        self.cc.stream.enqueue.mock_calls.clear()
+        self.cc.enqueue.mock_calls.clear()
 
         self.cc.on_stream_established()
         run_coroutine(asyncio.sleep(0))
@@ -4939,13 +4939,13 @@ class TestService(unittest.TestCase):
             return result
 
         self.assertEqual(
-            len(self.cc.stream.enqueue.mock_calls),
+            len(self.cc.enqueue.mock_calls),
             2,
         )
 
         self.assertSetEqual(
             extract(
-                self.cc.stream.enqueue.mock_calls,
+                self.cc.enqueue.mock_calls,
                 lambda stanza: (stanza.to.bare(),)
             ),
             {
@@ -4956,7 +4956,7 @@ class TestService(unittest.TestCase):
 
         self.assertSetEqual(
             extract(
-                self.cc.stream.enqueue.mock_calls,
+                self.cc.enqueue.mock_calls,
                 lambda stanza: (stanza.to.bare(),
                                 stanza.xep0045_muc.history.since)
             ),
@@ -5096,13 +5096,13 @@ class TestService(unittest.TestCase):
             ]
         )
         base.mock_calls.clear()
-        self.cc.stream.enqueue.mock_calls.clear()
+        self.cc.enqueue.mock_calls.clear()
 
         self.cc.on_stream_established()
         run_coroutine(asyncio.sleep(0))
 
         self.assertEqual(
-            len(self.cc.stream.enqueue.mock_calls),
+            len(self.cc.enqueue.mock_calls),
             0,
         )
 
@@ -5219,7 +5219,7 @@ class TestService(unittest.TestCase):
         new_affiliation = "owner"
 
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -5276,7 +5276,7 @@ class TestService(unittest.TestCase):
 
     def test_set_affiliation_rejects_None_affiliation(self):
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -5294,7 +5294,7 @@ class TestService(unittest.TestCase):
 
     def test_set_affiliation_rejects_None_jid(self):
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -5312,7 +5312,7 @@ class TestService(unittest.TestCase):
 
     def test_set_affiliation_rejects_None_mucjid(self):
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -5330,7 +5330,7 @@ class TestService(unittest.TestCase):
 
     def test_set_affiliation_rejects_full_mucjid(self):
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -5348,7 +5348,7 @@ class TestService(unittest.TestCase):
 
     def test_set_affiliation_fails(self):
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
@@ -5369,7 +5369,7 @@ class TestService(unittest.TestCase):
         reply.form = unittest.mock.sentinel.form
 
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = reply
@@ -5413,7 +5413,7 @@ class TestService(unittest.TestCase):
 
     def test_get_room_config_rejects_full_mucjid(self):
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             with self.assertRaisesRegex(ValueError,
@@ -5428,7 +5428,7 @@ class TestService(unittest.TestCase):
         data = unittest.mock.sentinel.data
 
         with unittest.mock.patch.object(
-                self.cc.stream,
+                self.cc,
                 "send",
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None

--- a/tests/ping/test_e2e.py
+++ b/tests/ping/test_e2e.py
@@ -100,6 +100,6 @@ class TestPing(TestCase):
             payload=aioxmpp.ping.Ping(),
         )
 
-        resp = yield from self.unimplemented.stream.send(req)
+        resp = yield from self.unimplemented.send(req)
 
         self.assertIsInstance(resp, aioxmpp.ping.Ping)

--- a/tests/ping/test_service.py
+++ b/tests/ping/test_service.py
@@ -61,13 +61,13 @@ class TestService(unittest.TestCase):
         )
 
     def test_ping_sends_ping(self):
-        self.cc.stream.send.return_value = ping_xso.Ping()
+        self.cc.send.return_value = ping_xso.Ping()
 
         run_coroutine(self.s.ping(TEST_PEER))
 
-        self.cc.stream.send.assert_called_once_with(unittest.mock.ANY)
+        self.cc.send.assert_called_once_with(unittest.mock.ANY)
 
-        _, (iq, ), _ = self.cc.stream.send.mock_calls[0]
+        _, (iq, ), _ = self.cc.send.mock_calls[0]
 
         self.assertIsInstance(
             iq,
@@ -93,7 +93,7 @@ class TestService(unittest.TestCase):
         class FooException(Exception):
             pass
 
-        self.cc.stream.send.side_effect = FooException()
+        self.cc.send.side_effect = FooException()
 
         with self.assertRaises(FooException):
             run_coroutine(self.s.ping(TEST_PEER))
@@ -103,7 +103,7 @@ class TestService(unittest.TestCase):
             ("condition_ns", "condition_name"),
         )
         exc.TYPE = unittest.mock.sentinel.type_
-        self.cc.stream.send.side_effect = exc
+        self.cc.send.side_effect = exc
 
         with self.assertRaises(aioxmpp.errors.XMPPError) as ctx:
             run_coroutine(self.s.ping(TEST_PEER))

--- a/tests/presence/test_e2e.py
+++ b/tests/presence/test_e2e.py
@@ -73,7 +73,7 @@ class TestPresence(TestCase):
         svc.on_available.connect(on_available)
         svc.on_changed.connect(on_changed)
 
-        yield from self.a.stream.send(pres)
+        yield from self.a.send(pres)
 
         stanza = yield from bare_fut
         self.assertIsInstance(stanza, aioxmpp.Presence)
@@ -89,7 +89,7 @@ class TestPresence(TestCase):
         self.assertFalse(changed_fut.done())
 
         pres.show = aioxmpp.PresenceShow.DND
-        yield from self.a.stream.send(pres)
+        yield from self.a.send(pres)
 
         full_jid, stanza = yield from changed_fut
         self.assertIsInstance(stanza, aioxmpp.Presence)
@@ -120,7 +120,7 @@ class TestPresence(TestCase):
 
         svc.on_bare_available.connect(on_bare_available)
 
-        yield from self.a.stream.send(pres)
+        yield from self.a.send(pres)
 
         yield from bare_fut
 

--- a/tests/presence/test_service.py
+++ b/tests/presence/test_service.py
@@ -429,8 +429,8 @@ class TestPresenceClient(unittest.TestCase):
 class TestPresenceServer(unittest.TestCase):
     def setUp(self):
         self.cc = make_connected_client()
-        self.cc.stream.send = CoroutineMock()
-        self.cc.stream.send.return_value = None
+        self.cc.send = CoroutineMock()
+        self.cc.send.return_value = None
         self.s = presence_service.PresenceServer(self.cc)
 
     def tearDown(self):
@@ -444,7 +444,7 @@ class TestPresenceServer(unittest.TestCase):
 
         run_coroutine(self.cc.before_stream_established())
 
-        self.cc.stream.send.assert_not_called()
+        self.cc.send.assert_not_called()
 
     def test_before_stream_established_handler_returns_true_for_unav(self):
         self.assertTrue(
@@ -548,7 +548,7 @@ class TestPresenceServer(unittest.TestCase):
             make_stanza.return_value = unittest.mock.sentinel.presence
             run_coroutine(self.cc.before_stream_established())
 
-        self.cc.stream.send.assert_called_with(
+        self.cc.send.assert_called_with(
             unittest.mock.sentinel.presence,
         )
 
@@ -567,13 +567,13 @@ class TestPresenceServer(unittest.TestCase):
                 status="foo",
             )
 
-        self.cc.stream.enqueue.assert_called_with(
+        self.cc.enqueue.assert_called_with(
             unittest.mock.sentinel.presence
         )
 
         self.assertEqual(
             result,
-            self.cc.stream.enqueue()
+            self.cc.enqueue()
         )
 
     def test_make_stanza_converts_state_to_stanza(self):
@@ -716,7 +716,7 @@ class TestPresenceServer(unittest.TestCase):
             priority=new_priority,
         )
 
-        self.cc.stream.enqueue.assert_not_called()
+        self.cc.enqueue.assert_not_called()
 
     def test_resend_presence_broadcasts_if_established(self):
         self.cc.established = True
@@ -726,11 +726,11 @@ class TestPresenceServer(unittest.TestCase):
 
             result = self.s.resend_presence()
 
-        self.cc.stream.enqueue.assert_called_with(
+        self.cc.enqueue.assert_called_with(
             unittest.mock.sentinel.presence
         )
 
         self.assertEqual(
             result,
-            self.cc.stream.enqueue(),
+            self.cc.enqueue(),
         )

--- a/tests/private_xml/test_e2e.py
+++ b/tests/private_xml/test_e2e.py
@@ -67,7 +67,7 @@ class TestPrivateXMLStorage(TestCase):
             payload=query,
         )
 
-        yield from self.client.stream.send(iq)
+        yield from self.client.send(iq)
 
         query.unregistered_payload[0].clear()
 
@@ -76,7 +76,7 @@ class TestPrivateXMLStorage(TestCase):
             payload=query,
         )
 
-        retrieved = yield from self.client.stream.send(iq)
+        retrieved = yield from self.client.send(iq)
 
         self.assertEqual(len(retrieved.unregistered_payload), 1)
         self.assertEqual(

--- a/tests/private_xml/test_service.py
+++ b/tests/private_xml/test_service.py
@@ -60,7 +60,7 @@ class TestService(unittest.TestCase):
     def test_get_private_xml(self):
         payload = FakePayload()
 
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.return_value = unittest.mock.sentinel.result
             res = run_coroutine(self.s.get_private_xml(payload))
@@ -81,7 +81,7 @@ class TestService(unittest.TestCase):
     def test_set_private_xml(self):
         payload = FakePayload()
 
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             run_coroutine(self.s.set_private_xml(payload))
 

--- a/tests/pubsub/test_service.py
+++ b/tests/pubsub/test_service.py
@@ -442,16 +442,16 @@ class TestService(unittest.TestCase):
             subid="bar",
             subscription="subscribed",
         )
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.s.subscribe(TEST_TO, node="foo"))
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -474,7 +474,7 @@ class TestService(unittest.TestCase):
             subid="bar",
             subscription="subscribed",
         )
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.s.subscribe(
             TEST_TO,
@@ -484,10 +484,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -511,7 +511,7 @@ class TestService(unittest.TestCase):
             subid="bar",
             subscription="subscribed",
         )
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         data = unittest.mock.Mock()
 
@@ -524,10 +524,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -551,7 +551,7 @@ class TestService(unittest.TestCase):
     def test_subscribe_returns_full_response(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.subscribe(
             TEST_TO,
@@ -567,7 +567,7 @@ class TestService(unittest.TestCase):
     def test_unsubscribe(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.s.unsubscribe(
             TEST_TO,
@@ -576,10 +576,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -597,7 +597,7 @@ class TestService(unittest.TestCase):
     def test_unsubscribe_with_subscription_jid(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.s.unsubscribe(
             TEST_TO,
@@ -607,10 +607,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -628,7 +628,7 @@ class TestService(unittest.TestCase):
     def test_unsubscribe_with_subid(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.s.unsubscribe(
             TEST_TO,
@@ -638,10 +638,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -658,7 +658,7 @@ class TestService(unittest.TestCase):
     def test_get_subscription_config(self):
         response = pubsub_xso.Request()
         response.options = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_subscription_config(
             TEST_TO,
@@ -667,10 +667,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -690,7 +690,7 @@ class TestService(unittest.TestCase):
     def test_get_subscription_config_with_subid(self):
         response = pubsub_xso.Request()
         response.options = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_subscription_config(
             TEST_TO,
@@ -700,10 +700,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -723,7 +723,7 @@ class TestService(unittest.TestCase):
     def test_get_subscription_config_with_subscription_jid(self):
         response = pubsub_xso.Request()
         response.options = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_subscription_config(
             TEST_TO,
@@ -734,10 +734,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -758,7 +758,7 @@ class TestService(unittest.TestCase):
     def test_set_subscription_config(self):
         response = pubsub_xso.Request()
         response.options = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         data = unittest.mock.Mock()
 
@@ -770,10 +770,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -792,7 +792,7 @@ class TestService(unittest.TestCase):
     def test_set_subscription_config_with_subid(self):
         response = pubsub_xso.Request()
         response.options = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         data = unittest.mock.Mock()
 
@@ -805,10 +805,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -827,7 +827,7 @@ class TestService(unittest.TestCase):
     def test_set_subscription_config_with_subscription_jid_and_subid(self):
         response = pubsub_xso.Request()
         response.options = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         data = unittest.mock.Mock()
 
@@ -841,10 +841,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -864,7 +864,7 @@ class TestService(unittest.TestCase):
     def test_get_default_config(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_default_config(
             TEST_TO,
@@ -873,10 +873,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -893,7 +893,7 @@ class TestService(unittest.TestCase):
     def test_get_items(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_items(
             TEST_TO,
@@ -902,10 +902,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -923,7 +923,7 @@ class TestService(unittest.TestCase):
     def test_get_items_max_items(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_items(
             TEST_TO,
@@ -933,10 +933,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -954,7 +954,7 @@ class TestService(unittest.TestCase):
     def test_get_items_by_id(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         ids = [
             "abc",
@@ -970,10 +970,10 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         request_iq, = call[1]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
@@ -998,7 +998,7 @@ class TestService(unittest.TestCase):
     def test_get_items_by_id_rejects_empty_iterable(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         ids = []
 
@@ -1011,14 +1011,14 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             0,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
     def test_get_subscriptions(self):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_subscriptions(
             TEST_TO,
@@ -1029,11 +1029,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.GET)
@@ -1048,7 +1048,7 @@ class TestService(unittest.TestCase):
         response = pubsub_xso.Request()
         response.payload = unittest.mock.Mock()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.get_subscriptions(
             TEST_TO,
@@ -1058,11 +1058,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.GET)
@@ -1079,7 +1079,7 @@ class TestService(unittest.TestCase):
         response = pubsub_xso.Request()
         response.payload = pubsub_xso.Publish()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.publish(
             TEST_TO,
@@ -1090,11 +1090,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1120,7 +1120,7 @@ class TestService(unittest.TestCase):
         response.payload.item = pubsub_xso.Item()
         response.payload.item.id_ = "some-other-id"
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.publish(
             TEST_TO,
@@ -1131,11 +1131,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1161,7 +1161,7 @@ class TestService(unittest.TestCase):
         response.payload.item = pubsub_xso.Item()
         response.payload.item.id_ = "generated-id"
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.publish(
             TEST_TO,
@@ -1171,11 +1171,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1197,7 +1197,7 @@ class TestService(unittest.TestCase):
         response = pubsub_xso.Request()
         response.payload = pubsub_xso.Publish()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.publish(
             TEST_TO,
@@ -1207,11 +1207,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1227,7 +1227,7 @@ class TestService(unittest.TestCase):
 
     def test_publish_without_id_without_response(self):
         payload = SomePayload()
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         result = run_coroutine(self.s.publish(
             TEST_TO,
@@ -1237,11 +1237,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1261,7 +1261,7 @@ class TestService(unittest.TestCase):
         response = pubsub_xso.Request()
         response.payload = pubsub_xso.Publish()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.publish(
             TEST_TO,
@@ -1272,11 +1272,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1297,7 +1297,7 @@ class TestService(unittest.TestCase):
         response.payload = pubsub_xso.Publish()
         response.payload.item = pubsub_xso.Item()
         response.payload.item.id_ = "some-other-id"
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.publish(
             None,
@@ -1307,11 +1307,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1351,7 +1351,7 @@ class TestService(unittest.TestCase):
         )
 
     def test_retract(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(self.s.retract(
             TEST_TO,
@@ -1361,11 +1361,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1382,7 +1382,7 @@ class TestService(unittest.TestCase):
         self.assertIs(item.id_, "some-id")
 
     def test_retract_with_notify(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(self.s.retract(
             TEST_TO,
@@ -1393,11 +1393,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1440,7 +1440,7 @@ class TestService(unittest.TestCase):
         response = pubsub_xso.Request()
         response.payload = pubsub_xso.Create()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.create(
             TEST_TO,
@@ -1449,11 +1449,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1469,7 +1469,7 @@ class TestService(unittest.TestCase):
     def test_create_with_node_copes_with_empty_reply(self):
         response = None
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.create(
             TEST_TO,
@@ -1478,11 +1478,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1500,7 +1500,7 @@ class TestService(unittest.TestCase):
         response.payload = pubsub_xso.Create()
         response.payload.node = "autogen-id"
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(self.s.create(
             TEST_TO,
@@ -1508,11 +1508,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1560,7 +1560,7 @@ class TestService(unittest.TestCase):
         )
 
     def test_delete_without_redirect_uri(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.delete(TEST_TO, "node"),
@@ -1568,11 +1568,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1585,7 +1585,7 @@ class TestService(unittest.TestCase):
         self.assertIsNone(payload.redirect_uri)
 
     def test_delete_with_redirect_uri(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.delete(TEST_TO, "node", redirect_uri="fnord"),
@@ -1593,11 +1593,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1614,7 +1614,7 @@ class TestService(unittest.TestCase):
             pubsub_xso.OwnerAffiliations(node="fnord")
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(
             self.s.get_node_affiliations(TEST_TO, "node"),
@@ -1622,11 +1622,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.GET)
@@ -1645,7 +1645,7 @@ class TestService(unittest.TestCase):
             pubsub_xso.OwnerSubscriptions(node="fnord")
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         result = run_coroutine(
             self.s.get_node_subscriptions(TEST_TO, "node"),
@@ -1653,11 +1653,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.GET)
@@ -1678,7 +1678,7 @@ class TestService(unittest.TestCase):
             (TEST_JID3, "none"),
         ]
 
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.change_node_affiliations(
@@ -1690,11 +1690,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1720,7 +1720,7 @@ class TestService(unittest.TestCase):
             (TEST_JID3, "none"),
         ]
 
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.change_node_subscriptions(
@@ -1732,11 +1732,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)
@@ -1756,7 +1756,7 @@ class TestService(unittest.TestCase):
         )
 
     def test_purge(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.purge(
@@ -1767,11 +1767,11 @@ class TestService(unittest.TestCase):
 
         self.assertEqual(
             1,
-            len(self.cc.stream.send.mock_calls)
+            len(self.cc.send.mock_calls)
         )
 
         _, (request_iq, ), _ = \
-            self.cc.stream.send.mock_calls[0]
+            self.cc.send.mock_calls[0]
 
         self.assertIsInstance(request_iq, aioxmpp.stanza.IQ)
         self.assertEqual(request_iq.type_, aioxmpp.structs.IQType.SET)

--- a/tests/roster/test_service.py
+++ b/tests/roster/test_service.py
@@ -237,11 +237,11 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
-        self.cc.stream.send.reset_mock()
+        self.cc.send.reset_mock()
 
         self.listener = make_listener(self.s)
 
@@ -442,12 +442,12 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
         self.assertSequenceEqual(
             [
-                unittest.mock.call.stream.send(
+                unittest.mock.call.send(
                     unittest.mock.ANY,
                     timeout=self.cc.negotiation_timeout.total_seconds()
                 )
@@ -479,8 +479,8 @@ class TestService(unittest.TestCase):
 
         self.s.on_initial_roster_received.connect(cb_impl)
 
-        self.cc.stream.send.return_value = response
-        self.cc.stream.send.delay = 0.05
+        self.cc.send.return_value = response
+        self.cc.send.delay = 0.05
 
         task = asyncio.async(self.cc.before_stream_established())
 
@@ -518,7 +518,7 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
@@ -553,7 +553,7 @@ class TestService(unittest.TestCase):
         mock.return_value = False
         self.s.on_entry_added.connect(mock)
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
@@ -580,7 +580,7 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
@@ -603,7 +603,7 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
@@ -638,7 +638,7 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
@@ -671,7 +671,7 @@ class TestService(unittest.TestCase):
             ver="foobar"
         )
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
@@ -714,7 +714,7 @@ class TestService(unittest.TestCase):
             else:
                 fut.set_result(None)
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         self.s.on_entry_removed.connect(handler)
 
@@ -846,7 +846,7 @@ class TestService(unittest.TestCase):
 
         old_item = self.s.items[self.user1]
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         cb = unittest.mock.Mock()
         with self.s.on_entry_removed.context_connect(cb):
@@ -1090,11 +1090,11 @@ class TestService(unittest.TestCase):
     def test_do_not_send_versioned_request_if_not_supported_by_server(self):
         response = roster_xso.Query()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         _, call_args, call_kwargs = call
 
         iq_request, = call_args
@@ -1110,11 +1110,11 @@ class TestService(unittest.TestCase):
 
         response = roster_xso.Query()
 
-        self.cc.stream.send.return_value = response
+        self.cc.send.return_value = response
 
         run_coroutine(self.cc.before_stream_established())
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         _, call_args, call_kwargs = call
 
         iq_request, = call_args
@@ -1126,7 +1126,7 @@ class TestService(unittest.TestCase):
     def test_process_none_response_to_versioned_request(self):
         self.cc.stream_features[...] = roster_xso.RosterVersioningFeature()
 
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         cb = unittest.mock.Mock()
         cb.return_value = True
@@ -1135,7 +1135,7 @@ class TestService(unittest.TestCase):
 
         run_coroutine(self.cc.before_stream_established())
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         _, call_args, call_kwargs = call
 
         iq_request, = call_args
@@ -1336,7 +1336,7 @@ class TestService(unittest.TestCase):
         )
 
     def test_set_entry_name(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.set_entry(
@@ -1350,10 +1350,10 @@ class TestService(unittest.TestCase):
             [
                 unittest.mock.call(unittest.mock.ANY, timeout=10)
             ],
-            self.cc.stream.send.mock_calls
+            self.cc.send.mock_calls
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         _, call_args, _ = call
 
         request_iq, = call_args
@@ -1389,7 +1389,7 @@ class TestService(unittest.TestCase):
         self.assertIsNone(item.ask)
 
     def test_set_entry_groups(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.set_entry(
@@ -1404,10 +1404,10 @@ class TestService(unittest.TestCase):
             [
                 unittest.mock.call(unittest.mock.ANY, timeout=10)
             ],
-            self.cc.stream.send.mock_calls
+            self.cc.send.mock_calls
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         _, call_args, _ = call
 
         request_iq, = call_args
@@ -1443,7 +1443,7 @@ class TestService(unittest.TestCase):
         self.assertIsNone(item.ask)
 
     def test_remove_entry(self):
-        self.cc.stream.send.return_value = None
+        self.cc.send.return_value = None
 
         run_coroutine(
             self.s.remove_entry(
@@ -1456,10 +1456,10 @@ class TestService(unittest.TestCase):
             [
                 unittest.mock.call(unittest.mock.ANY, timeout=10)
             ],
-            self.cc.stream.send.mock_calls
+            self.cc.send.mock_calls
         )
 
-        call, = self.cc.stream.send.mock_calls
+        call, = self.cc.send.mock_calls
         _, call_args, _ = call
 
         request_iq, = call_args
@@ -1554,13 +1554,13 @@ class TestService(unittest.TestCase):
         self.s.approve(TEST_JID)
 
         self.assertSequenceEqual(
-            self.cc.stream.enqueue.mock_calls,
+            self.cc.enqueue.mock_calls,
             [
                 unittest.mock.call(unittest.mock.ANY),
             ]
         )
 
-        call, = self.cc.stream.enqueue.mock_calls
+        call, = self.cc.enqueue.mock_calls
         _, call_args, _ = call
 
         st, = call_args
@@ -1572,13 +1572,13 @@ class TestService(unittest.TestCase):
         self.s.subscribe(TEST_JID)
 
         self.assertSequenceEqual(
-            self.cc.stream.enqueue.mock_calls,
+            self.cc.enqueue.mock_calls,
             [
                 unittest.mock.call(unittest.mock.ANY),
             ]
         )
 
-        call, = self.cc.stream.enqueue.mock_calls
+        call, = self.cc.enqueue.mock_calls
         _, call_args, _ = call
 
         st, = call_args
@@ -1590,13 +1590,13 @@ class TestService(unittest.TestCase):
         self.s.unsubscribe(TEST_JID)
 
         self.assertSequenceEqual(
-            self.cc.stream.enqueue.mock_calls,
+            self.cc.enqueue.mock_calls,
             [
                 unittest.mock.call(unittest.mock.ANY),
             ]
         )
 
-        call, = self.cc.stream.enqueue.mock_calls
+        call, = self.cc.enqueue.mock_calls
         _, call_args, _ = call
 
         st, = call_args
@@ -1645,8 +1645,8 @@ class TestService(unittest.TestCase):
             yield from asyncio.sleep(0)
             return initial
 
-        self.cc.stream.send = unittest.mock.Mock()
-        self.cc.stream.send.side_effect = send
+        self.cc.send = unittest.mock.Mock()
+        self.cc.send.side_effect = send
 
         initial_roster = asyncio.async(self.cc.before_stream_established())
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -70,7 +70,7 @@ class TestMessaging(TestCase):
             msg_sent.body[aioxmpp.structs.LanguageTag.fromstr("en")] = \
                 "Hello World!"
 
-            yield from a.stream.send(msg_sent)
+            yield from a.send(msg_sent)
 
             msg_rcvd = yield from fut
 
@@ -93,7 +93,7 @@ class TestMisc(TestCase):
         )
 
         with self.assertRaises(aioxmpp.errors.XMPPCancelError):
-            yield from c.stream.send(iq)
+            yield from c.send(iq)
 
     @blocking_timed
     @asyncio.coroutine
@@ -107,7 +107,7 @@ class TestMisc(TestCase):
         )
 
         with self.assertRaises(aioxmpp.errors.XMPPCancelError):
-            yield from c.stream.send(iq)
+            yield from c.send(iq)
 
     @blocking_timed
     @asyncio.coroutine
@@ -121,8 +121,8 @@ class TestMisc(TestCase):
         msg.body[None] = "foo\u0000"
 
         with self.assertRaisesRegex(ValueError, "not allowed"):
-            yield from c.stream.send(msg)
+            yield from c.send(msg)
 
         msg.body[None] = "foo"
 
-        yield from c.stream.send(msg)
+        yield from c.send(msg)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1787,6 +1787,68 @@ class TestClient(xmltestutils.XMLTestCase):
         with self.assertRaises(AttributeError):
             client.local_jid = structs.JID.fromstr("bar@bar.example/baz")
 
+    def test_monkeypatches_send_and_warns_on_use(self):
+        client = node.Client(
+            self.test_jid,
+            self.security_layer,
+            negotiation_timeout=timedelta(seconds=30)
+        )
+
+        with contextlib.ExitStack() as stack:
+            client_send = stack.enter_context(unittest.mock.patch.object(
+                client,
+                "send",
+                new=CoroutineMock()
+            ))
+
+            with self.assertWarnsRegex(
+                    DeprecationWarning,
+                    r"send\(\) on StanzaStream is deprecated and "
+                    r"will be removed in 1\.0. Use send\(\) on the Client "
+                    r"instead."):
+                run_coroutine(client.stream.send(
+                    unittest.mock.sentinel.foo,
+                    unittest.mock.sentinel.bar,
+                    fnord=unittest.mock.sentinel.foo,
+                ))
+
+            client_send.assert_called_once_with(
+                unittest.mock.sentinel.foo,
+                unittest.mock.sentinel.bar,
+                fnord=unittest.mock.sentinel.foo,
+            )
+
+    def test_monkeypatches_enqueue_and_warns_on_use(self):
+        client = node.Client(
+            self.test_jid,
+            self.security_layer,
+            negotiation_timeout=timedelta(seconds=30)
+        )
+
+        with contextlib.ExitStack() as stack:
+            client_enqueue = stack.enter_context(unittest.mock.patch.object(
+                client,
+                "enqueue",
+                new=CoroutineMock()
+            ))
+
+            with self.assertWarnsRegex(
+                    DeprecationWarning,
+                    r"enqueue\(\) on StanzaStream is deprecated and "
+                    r"will be removed in 1\.0. Use enqueue\(\) on the Client "
+                    r"instead."):
+                run_coroutine(client.stream.enqueue(
+                    unittest.mock.sentinel.foo,
+                    unittest.mock.sentinel.bar,
+                    fnord=unittest.mock.sentinel.foo,
+                ))
+
+            client_enqueue.assert_called_once_with(
+                unittest.mock.sentinel.foo,
+                unittest.mock.sentinel.bar,
+                fnord=unittest.mock.sentinel.foo,
+            )
+
     def test_start(self):
         self.assertFalse(self.client.established)
         run_coroutine(asyncio.sleep(0))

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1844,6 +1844,10 @@ class Testsend_and_wait_for(xmltestutils.XMLTestCase):
         self.loop = asyncio.get_event_loop()
         self.xmlstream = XMLStreamMock(self, loop=self.loop)
 
+    def tearDown(self):
+        del self.xmlstream
+        del self.loop
+
     def _run_test(self, send, wait_for, actions, stimulus=None,
                   timeout=None, **kwargs):
         return run_coroutine(
@@ -1896,7 +1900,7 @@ class Testsend_and_wait_for(xmltestutils.XMLTestCase):
         instance = R()
 
         with self.assertRaisesRegex(AssertionError,
-                                     "no handler registered for"):
+                                    "no handler registered for"):
             self._run_test(
                 [
                     Q(),
@@ -1941,7 +1945,7 @@ class Testsend_and_wait_for(xmltestutils.XMLTestCase):
             )
 
         with self.assertRaisesRegex(AssertionError,
-                                     "no handler registered for"):
+                                    "no handler registered for"):
             run_coroutine(self.xmlstream.run_test(
                 [],
                 stimulus=XMLStreamMock.Receive(instance)
@@ -1962,7 +1966,6 @@ class Testsend_and_wait_for(xmltestutils.XMLTestCase):
             [],
             stimulus=XMLStreamMock.Fail(exc=exc)
         ))
-
 
         with self.assertRaises(ValueError) as ctx:
             self._run_test(
@@ -2009,11 +2012,6 @@ class Testsend_and_wait_for(xmltestutils.XMLTestCase):
             )
 
         self.assertIs(exc, ctx.exception)
-
-
-    def tearDown(self):
-        del self.xmlstream
-        del self.loop
 
 
 class Testreset_stream_and_get_features(xmltestutils.XMLTestCase):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -326,7 +326,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         iq = make_test_iq(type_=structs.IQType.GET)
 
         self.stream.start(self.xmlstream)
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
 
         obj = run_coroutine(self.sent_stanzas.get())
         self.assertIs(obj, iq)
@@ -336,7 +336,7 @@ class TestStanzaStream(StanzaStreamTestBase):
     def test_enqueue_validates_stanza(self):
         iq = unittest.mock.Mock()
 
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
 
         iq.validate.assert_called_with()
 
@@ -1330,14 +1330,14 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.stream.on_failure.connect(failure_handler)
 
         self.stream.start(self.xmlstream)
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
 
         iq_sent = run_coroutine(self.sent_stanzas.get())
         self.assertIs(iq, iq_sent)
 
         self.xmlstream.send_xso = unittest.mock.MagicMock(
             side_effect=RuntimeError())
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
         self.stream.recv_stanza(iq)
         self.stream.stop()
 
@@ -1354,14 +1354,14 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.stream.on_failure.connect(failure_handler)
 
         self.stream.start(self.xmlstream)
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
 
         iq_sent = run_coroutine(self.sent_stanzas.get())
         self.assertIs(iq, iq_sent)
 
         self.xmlstream.send_xso = unittest.mock.MagicMock(
             side_effect=RuntimeError())
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
         self.stream.recv_stanza(iq)
         self.stream.stop()
 
@@ -1561,7 +1561,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             run_coroutine(asyncio.sleep(0))
             self.assertTrue(self.stream.running)
 
-            token = self.stream.enqueue(make_test_message())
+            token = self.stream._enqueue(make_test_message())
 
             run_coroutine(self.stream.close())
 
@@ -1579,7 +1579,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 "get",
                 new=get_mock):
 
-            token = self.stream.enqueue(make_test_message())
+            token = self.stream._enqueue(make_test_message())
 
             run_coroutine(self.stream.close())
 
@@ -1591,7 +1591,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         run_coroutine(self.stream.close())
 
         with self.assertRaisesRegex(ConnectionError, r"close\(\) called"):
-            self.stream.enqueue(unittest.mock.sentinel.stanza)
+            self.stream._enqueue(unittest.mock.sentinel.stanza)
 
     def test_enqueue_works_after_close_and_start(self):
         run_coroutine(self.stream.close())
@@ -1599,7 +1599,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         iq = make_test_iq(type_=structs.IQType.GET)
 
         self.stream.start(self.xmlstream)
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
 
         obj = run_coroutine(self.sent_stanzas.get())
         self.assertIs(obj, iq)
@@ -1621,7 +1621,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.xmlstream.send_xso = send_handler
 
         tokens = [
-            self.stream.enqueue(
+            self.stream._enqueue(
                 iq,
                 on_state_change=state_change_handler)
             for iq in iqs
@@ -1782,7 +1782,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
 
     def test_enqueue_returns_token(self):
-        token = self.stream.enqueue(make_test_iq())
+        token = self.stream._enqueue(make_test_iq())
         self.assertIsInstance(
             token,
             stream.StanzaToken)
@@ -1790,7 +1790,7 @@ class TestStanzaStream(StanzaStreamTestBase):
     def test_abort_stanza(self):
         iqs = [make_test_iq() for i in range(3)]
         self.stream.start(self.xmlstream)
-        tokens = [self.stream.enqueue(iq) for iq in iqs]
+        tokens = [self.stream._enqueue(iq) for iq in iqs]
         tokens[1].abort()
         run_coroutine(asyncio.sleep(0))
 
@@ -1917,7 +1917,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaises(ConnectionError):
             run_coroutine(asyncio.gather(
                 kill_it(),
-                self.stream.send_iq_and_wait_for_reply(iq)
+                self.stream._send_immediately(iq)
             ))
 
     def _test_inbound_presence_filter(self, filter_attr, **register_kwargs):
@@ -2129,7 +2129,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         filter_attr.register(filter_func, **register_kwargs)
 
         self.stream.start(self.xmlstream)
-        token = self.stream.enqueue(pres)
+        token = self.stream._enqueue(pres)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -2153,7 +2153,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         filter_func.reset_mock()
         filter_func.return_value = None
 
-        token = self.stream.enqueue(pres)
+        token = self.stream._enqueue(pres)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -2205,7 +2205,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
 
         self.stream.start(self.xmlstream)
-        self.stream.enqueue(pres)
+        self.stream._enqueue(pres)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -2228,7 +2228,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         filter_attr.register(filter_func, **register_kwargs)
 
         self.stream.start(self.xmlstream)
-        token = self.stream.enqueue(msg)
+        token = self.stream._enqueue(msg)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -2252,7 +2252,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         filter_func.reset_mock()
         filter_func.return_value = None
 
-        token = self.stream.enqueue(msg)
+        token = self.stream._enqueue(msg)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -2304,7 +2304,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
 
         self.stream.start(self.xmlstream)
-        self.stream.enqueue(msg)
+        self.stream._enqueue(msg)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -2330,7 +2330,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         msg = make_test_message()
         msg.autoset_id()
 
-        self.stream.enqueue(msg)
+        self.stream._enqueue(msg)
 
         self.xmlstream.on_closing(None)
 
@@ -2879,21 +2879,21 @@ class TestStanzaStream(StanzaStreamTestBase):
         iq = make_test_iq()
 
         base = unittest.mock.Mock()
-        base.enqueue = CoroutineMock()
-        base.enqueue.return_value = \
+        base._enqueue = CoroutineMock()
+        base._enqueue.return_value = \
             unittest.mock.sentinel.token_await_result
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             run_coroutine(self.stream.send_and_wait_for_sent(
                 iq
             ))
 
-        base.enqueue.assert_called_with(unittest.mock.ANY)
+        base._enqueue.assert_called_with(unittest.mock.ANY)
 
     def test_send_and_wait_for_sent_emits_deprecation_warning(self):
         iq = make_test_iq()
@@ -2909,14 +2909,14 @@ class TestStanzaStream(StanzaStreamTestBase):
         pres = make_test_presence()
 
         base = unittest.mock.Mock()
-        base.enqueue = CoroutineMock()
-        base.enqueue.return_value = \
+        base._enqueue = CoroutineMock()
+        base._enqueue.return_value = \
             unittest.mock.sentinel.token_await_result
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -2925,23 +2925,23 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.register_iq_response_future,
             ))
 
-            run_coroutine(self.stream.send(pres))
+            run_coroutine(self.stream._send_immediately(pres))
 
         base.register_iq_response_future.assert_not_called()
-        base.enqueue.assert_called_with(unittest.mock.ANY)
+        base._enqueue.assert_called_with(unittest.mock.ANY)
 
     def test_send_awaits_stanza_token_for_message(self):
         message = make_test_presence()
 
         base = unittest.mock.Mock()
-        base.enqueue = CoroutineMock()
-        base.enqueue.return_value = \
+        base._enqueue = CoroutineMock()
+        base._enqueue.return_value = \
             unittest.mock.sentinel.token_await_result
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -2950,23 +2950,23 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.register_iq_response_future,
             ))
 
-            run_coroutine(self.stream.send(message))
+            run_coroutine(self.stream._send_immediately(message))
 
         base.register_iq_response_future.assert_not_called()
-        base.enqueue.assert_called_with(unittest.mock.ANY)
+        base._enqueue.assert_called_with(unittest.mock.ANY)
 
     def test_send_awaits_stanza_token_for_iq_response(self):
         iq = make_test_iq(type_=aioxmpp.IQType.RESULT)
 
         base = unittest.mock.Mock()
-        base.enqueue = CoroutineMock()
-        base.enqueue.return_value = \
+        base._enqueue = CoroutineMock()
+        base._enqueue.return_value = \
             unittest.mock.sentinel.token_await_result
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -2975,10 +2975,10 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.register_iq_response_future,
             ))
 
-            run_coroutine(self.stream.send(iq))
+            run_coroutine(self.stream._send_immediately(iq))
 
         base.register_iq_response_future.assert_not_called()
-        base.enqueue.assert_called_with(unittest.mock.ANY)
+        base._enqueue.assert_called_with(unittest.mock.ANY)
 
     def test_send_awaits_stanza_token_for_iq_and_registers_for_reply(self):
         iq = make_test_iq()
@@ -2988,12 +2988,12 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut = asyncio.Future()
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -3002,11 +3002,11 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream.send(iq))
+            task = asyncio.async(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
             base.iq_response_map.add_listener.assert_called_once_with(
                 (iq.to, iq.id_),
                 unittest.mock.ANY,
@@ -3035,12 +3035,12 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut = asyncio.Future()
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -3049,11 +3049,11 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream.send(iq))
+            task = asyncio.async(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
             base.iq_response_map.add_listener.assert_called_once_with(
                 (iq.to, iq.id_),
                 unittest.mock.ANY,
@@ -3088,12 +3088,12 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut = asyncio.Future()
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -3102,11 +3102,11 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream.send(iq))
+            task = asyncio.async(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
             base.iq_response_map.add_listener.assert_called_once_with(
                 (iq.to, iq.id_),
                 unittest.mock.ANY,
@@ -3136,19 +3136,21 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut = asyncio.Future()
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
-            task = asyncio.async(self.stream.send(iq, timeout=0.001))
+            task = asyncio.async(self.stream._send_immediately(
+                iq,
+                timeout=0.001))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
 
             stanza_fut.set_result(None)
 
@@ -3162,12 +3164,12 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut = asyncio.Future()
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -3176,11 +3178,13 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream.send(iq, timeout=0.001))
+            task = asyncio.async(self.stream._send_immediately(
+                iq,
+                timeout=0.001))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
             base.iq_response_map.add_listener.assert_called_once_with(
                 (iq.to, iq.id_),
                 unittest.mock.ANY,
@@ -3207,12 +3211,12 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut.set_result(None)
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -3221,11 +3225,11 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream.send(iq))
+            task = asyncio.async(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
             base.iq_response_map.add_listener.assert_called_once_with(
                 (iq.to, iq.id_),
                 unittest.mock.ANY,
@@ -3249,12 +3253,12 @@ class TestStanzaStream(StanzaStreamTestBase):
         stanza_fut.set_result(None)
 
         base = unittest.mock.Mock()
-        base.enqueue.return_value = stanza_fut
+        base._enqueue.return_value = stanza_fut
         with contextlib.ExitStack() as stack:
             stack.enter_context(unittest.mock.patch.object(
                 self.stream,
-                "enqueue",
-                new=base.enqueue
+                "_enqueue",
+                new=base._enqueue
             ))
 
             stack.enter_context(unittest.mock.patch.object(
@@ -3263,11 +3267,11 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream.send(iq))
+            task = asyncio.async(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
-            base.enqueue.assert_called_with(unittest.mock.ANY)
+            base._enqueue.assert_called_with(unittest.mock.ANY)
             base.iq_response_map.add_listener.assert_called_once_with(
                 (iq.to, iq.id_),
                 unittest.mock.ANY,
@@ -3297,7 +3301,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.xmlstream.send_xso.side_effect = exc
 
         self.stream.start(self.xmlstream)
-        token = self.stream.enqueue(msg)
+        token = self.stream._enqueue(msg)
         self.assertEqual(token.state, stream.StanzaState.ACTIVE)
 
         run_coroutine(asyncio.sleep(0.05))
@@ -3444,7 +3448,9 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaisesRegex(
                 ValueError,
                 r"cb not supported with non-IQ non-request stanzas"):
-            run_coroutine(self.stream.send(msg, cb=unittest.mock.sentinel.cb))
+            run_coroutine(self.stream._send_immediately(
+                msg,
+                cb=unittest.mock.sentinel.cb))
 
         self.assertTrue(self.sent_stanzas.empty())
 
@@ -3456,7 +3462,9 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaisesRegex(
                 ValueError,
                 r"cb not supported with non-IQ non-request stanzas"):
-            run_coroutine(self.stream.send(pres, cb=unittest.mock.sentinel.cb))
+            run_coroutine(self.stream._send_immediately(
+                pres,
+                cb=unittest.mock.sentinel.cb))
 
         self.assertTrue(self.sent_stanzas.empty())
 
@@ -3468,7 +3476,9 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaisesRegex(
                 ValueError,
                 r"cb not supported with non-IQ non-request stanzas"):
-            run_coroutine(self.stream.send(iq, cb=unittest.mock.sentinel.cb))
+            run_coroutine(self.stream._send_immediately(
+                iq,
+                cb=unittest.mock.sentinel.cb))
 
         self.assertTrue(self.sent_stanzas.empty())
 
@@ -3481,7 +3491,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream.send(iq, cb=cb))
+        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3519,7 +3529,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream.send(iq, cb=cb))
+        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3553,7 +3563,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream.send(iq, cb=cb))
+        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3580,7 +3590,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream.send(iq, cb=cb))
+        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3613,7 +3623,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream.send(iq, cb=cb))
+        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -4009,7 +4019,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         @asyncio.coroutine
         def starter():
             sm_start_future = asyncio.async(self.stream.start_sm())
-            self.stream.enqueue(iq_sent)
+            self.stream._enqueue(iq_sent)
 
         self.stream.start(self.xmlstream)
         run_coroutine_with_peer(
@@ -4065,7 +4075,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         tokens = [
-            self.stream.enqueue(
+            self.stream._enqueue(
                 iq, on_state_change=state_change_handler)
             for iq in iqs]
 
@@ -4163,7 +4173,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         tokens = [
-            self.stream.enqueue(
+            self.stream._enqueue(
                 iq, on_state_change=state_change_handler)
             for iq in iqs]
 
@@ -4352,7 +4362,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         for iq in iqs:
-            self.stream.enqueue(iq)
+            self.stream._enqueue(iq)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -4379,7 +4389,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
 
         # enqueue a stanza before resumption and check that the sequence is
         # correct (resumption-generated stanzas before new stanzas)
-        self.stream.enqueue(additional_iq)
+        self.stream._enqueue(additional_iq)
 
         run_coroutine_with_peer(
             self.stream.resume_sm(self.xmlstream),
@@ -4427,7 +4437,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         for iq in iqs:
-            self.stream.enqueue(iq)
+            self.stream._enqueue(iq)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -4455,7 +4465,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
 
         # enqueue a stanza before resumption and check that the sequence is
         # correct (resumption-generated stanzas before new stanzas)
-        self.stream.enqueue(additional_iq)
+        self.stream._enqueue(additional_iq)
 
         run_coroutine_with_peer(
             self.stream.resume_sm(self.xmlstream),
@@ -4503,7 +4513,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         for iq in iqs:
-            self.stream.enqueue(iq)
+            self.stream._enqueue(iq)
 
         run_coroutine(asyncio.sleep(0))
 
@@ -4530,7 +4540,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
 
         # enqueue a stanza before resumption and check that the sequence is
         # correct (resumption-generated stanzas before new stanzas)
-        self.stream.enqueue(additional_iq)
+        self.stream._enqueue(additional_iq)
 
         run_coroutine_with_peer(
             self.stream.resume_sm(self.xmlstream),
@@ -4697,7 +4707,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         iq = make_test_iq()
-        self.stream.enqueue(iq)
+        self.stream._enqueue(iq)
 
         run_coroutine(self.xmlstream.run_test([
             XMLStreamMock.Send(iq),
@@ -4734,9 +4744,9 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         )
 
         run_coroutine(asyncio.sleep(0))
-        self.stream.enqueue(iqs[0])
+        self.stream._enqueue(iqs[0])
         run_coroutine(asyncio.sleep(0.05))
-        self.stream.enqueue(iqs[1])
+        self.stream._enqueue(iqs[1])
         run_coroutine(asyncio.sleep(0.06))
 
         run_coroutine(self.xmlstream.run_test([
@@ -4772,12 +4782,12 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test(self.successful_sm)
         )
 
-        self.stream.enqueue(iqs[0])
+        self.stream._enqueue(iqs[0])
         run_coroutine(self.xmlstream.run_test([
             XMLStreamMock.Send(iqs[0]),
             XMLStreamMock.Send(nonza.SMRequest()),
         ]))
-        self.stream.enqueue(iqs[1])
+        self.stream._enqueue(iqs[1])
         run_coroutine(self.xmlstream.run_test([
             XMLStreamMock.Send(iqs[1]),
             XMLStreamMock.Send(
@@ -4870,7 +4880,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test(self.successful_sm)
         )
 
-        tokens = [self.stream.enqueue(iq) for iq in iqs]
+        tokens = [self.stream._enqueue(iq) for iq in iqs]
 
         run_coroutine(self.xmlstream.run_test([
             XMLStreamMock.Send(iqs[0]),
@@ -5101,7 +5111,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
 
         self.stream.stop()
 
-        self.stream.enqueue(pres)
+        self.stream._enqueue(pres)
 
         self.assertIs(
             pres,
@@ -5118,7 +5128,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test(self.successful_sm)
         )
 
-        self.stream.enqueue(pres)
+        self.stream._enqueue(pres)
         self.stream.stop()
 
         self.assertIs(
@@ -5136,7 +5146,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test(self.successful_sm)
         )
 
-        token = self.stream.enqueue(pres)
+        token = self.stream._enqueue(pres)
 
         run_coroutine_with_peer(
             self.stream.close(),

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -3772,9 +3772,9 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
                         nonza.SMEnable(resume=True),
                         response=XMLStreamMock.Receive(
                             nonza.SMEnabled(resume=True,
-                                                  id_="foobar",
-                                                  location=("fe80::", 5222),
-                                                  max_=1200)
+                                            id_="foobar",
+                                            location=("fe80::", 5222),
+                                            max_=1200)
                         )
                     )
                 ]
@@ -3987,7 +3987,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
                     response=[
                         XMLStreamMock.Receive(
                             nonza.SMEnabled(resume=True,
-                                                  id_="foobar"),
+                                            id_="foobar"),
                         ),
                         XMLStreamMock.Fail(exc)
                     ]
@@ -4050,7 +4050,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
                     response=[
                         XMLStreamMock.Receive(
                             nonza.SMEnabled(resume=True,
-                                                  id_="barbaz")
+                                            id_="barbaz")
                         ),
                         XMLStreamMock.Receive(iq)
                     ]
@@ -4416,10 +4416,10 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test([
                 XMLStreamMock.Send(
                     nonza.SMResume(previd="foobar",
-                                         counter=0),
+                                   counter=0),
                     response=XMLStreamMock.Receive(
                         nonza.SMResumed(previd="foobar",
-                                              counter=2)
+                                        counter=2)
                     )
                 ),
                 XMLStreamMock.Send(iqs[2]),
@@ -4492,10 +4492,10 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test([
                 XMLStreamMock.Send(
                     nonza.SMResume(previd="foobar",
-                                         counter=0),
+                                   counter=0),
                     response=XMLStreamMock.Receive(
                         nonza.SMResumed(previd="foobar",
-                                              counter=0)
+                                        counter=0)
                     )
                 ),
                 XMLStreamMock.Send(iqs[2]),
@@ -4567,11 +4567,11 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
             self.xmlstream.run_test([
                 XMLStreamMock.Send(
                     nonza.SMResume(previd="foobar",
-                                         counter=0),
+                                   counter=0),
                     response=[
                         XMLStreamMock.Receive(
                             nonza.SMResumed(previd="foobar",
-                                                  counter=2)
+                                            counter=2)
                         ),
                         XMLStreamMock.Receive(
                             nonza.SMRequest()
@@ -4605,7 +4605,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
                 self.xmlstream.run_test([
                     XMLStreamMock.Send(
                         nonza.SMResume(previd="foobar",
-                                             counter=0),
+                                       counter=0),
                         response=XMLStreamMock.Receive(
                             nonza.SMFailed()
                         )
@@ -5210,9 +5210,9 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
                         nonza.SMEnable(resume=True),
                         response=XMLStreamMock.Receive(
                             nonza.SMEnabled(resume=True,
-                                                  id_="foobar",
-                                                  location=("fe80::", 5222),
-                                                  max_=1200)
+                                            id_="foobar",
+                                            location=("fe80::", 5222),
+                                            max_=1200)
                         )
                     )
                 ]
@@ -5260,9 +5260,9 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
                         response=[
                             XMLStreamMock.Receive(
                                 nonza.SMEnabled(resume=True,
-                                                      id_="foobar",
-                                                      location=("fe80::", 5222),
-                                                      max_=1200)
+                                                id_="foobar",
+                                                location=("fe80::", 5222),
+                                                max_=1200)
                             ),
                             XMLStreamMock.Fail(
                                 ConnectionError()
@@ -5819,7 +5819,7 @@ class Testiq_handler(unittest.TestCase):
         # we need to generate a trackback object
         try:
             raise ValueError()
-        except:
+        except:  # NOQA
             info = sys.exc_info()
 
         result = self.cm.__exit__(*info)
@@ -5881,7 +5881,7 @@ class Testmessage_handler(unittest.TestCase):
         # we need to generate a trackback object
         try:
             raise ValueError()
-        except:
+        except:  # NOQA
             info = sys.exc_info()
 
         result = self.cm.__exit__(*info)
@@ -5943,7 +5943,7 @@ class Testpresence_handler(unittest.TestCase):
         # we need to generate a trackback object
         try:
             raise ValueError()
-        except:
+        except:  # NOQA
             info = sys.exc_info()
 
         result = self.cm.__exit__(*info)

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -975,6 +975,8 @@ class Testmake_connected_client(unittest.TestCase):
         self.assertTrue(hasattr(cc, "start"))
         self.assertTrue(hasattr(cc, "stop"))
         self.assertTrue(hasattr(cc, "established"))
+        self.assertTrue(hasattr(cc, "send"))
+        self.assertTrue(hasattr(cc, "enqueue"))
 
         self.assertIs(cc.established, True)
 
@@ -996,9 +998,7 @@ class Testmake_connected_client(unittest.TestCase):
         self.assertTrue(hasattr(cc.stream, "register_message_callback"))
         self.assertTrue(hasattr(cc.stream, "register_iq_response_callback"))
         self.assertTrue(hasattr(cc.stream, "register_presence_callback"))
-        self.assertIsInstance(cc.stream.send_iq_and_wait_for_reply,
-                              CoroutineMock)
-        self.assertIsInstance(cc.stream.send, CoroutineMock)
+        self.assertIsInstance(cc.send, CoroutineMock)
 
         self.assertIsInstance(cc.stream_features, nonza.StreamFeatures)
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -726,17 +726,17 @@ class TestBasicTrackingService(unittest.TestCase):
 
             result = self.s.send_tracked(msg, tracker)
 
-            self.cc.stream.enqueue.assert_called_once_with(
+            self.cc.enqueue.assert_called_once_with(
                 msg,
             )
 
             attach_tracker.assert_called_once_with(
                 msg,
                 tracker,
-                self.cc.stream.enqueue(),
+                self.cc.enqueue(),
             )
 
             self.assertEqual(
                 result,
-                self.cc.stream.enqueue(),
+                self.cc.enqueue(),
             )

--- a/tests/vcard/test_service.py
+++ b/tests/vcard/test_service.py
@@ -60,7 +60,7 @@ class TestService(unittest.TestCase):
         ))
 
     def test_get_vcard_own(self):
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.return_value = unittest.mock.sentinel.result
             res = run_coroutine(self.s.get_vcard())
@@ -79,7 +79,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(res, unittest.mock.sentinel.result)
 
     def test_get_vcard_other(self):
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.return_value = unittest.mock.sentinel.result
             res = run_coroutine(self.s.get_vcard(TEST_JID1))
@@ -98,7 +98,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(res, unittest.mock.sentinel.result)
 
     def test_get_vcard_mask_cancel_error(self):
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.side_effect = aioxmpp.XMPPCancelError(
                 (namespaces.stanzas, "feature-not-implemented"))
@@ -107,7 +107,7 @@ class TestService(unittest.TestCase):
         self.assertIsInstance(res, vcard_xso.VCard)
         self.assertEqual(len(res.elements), 0)
 
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.side_effect = aioxmpp.XMPPCancelError(
                 (namespaces.stanzas, "item-not-found"))
@@ -117,14 +117,14 @@ class TestService(unittest.TestCase):
         self.assertEqual(len(res.elements), 0)
 
         with self.assertRaises(aioxmpp.XMPPCancelError):
-            with unittest.mock.patch.object(self.cc.stream, "send",
+            with unittest.mock.patch.object(self.cc, "send",
                                             new=CoroutineMock()) as mock_send:
                 mock_send.side_effect = aioxmpp.XMPPCancelError(
                     (namespaces.stanzas, "fnord"))
                 res = run_coroutine(self.s.get_vcard(TEST_JID1))
 
     def test_set_vcard(self):
-        with unittest.mock.patch.object(self.cc.stream, "send",
+        with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             vcard = vcard_xso.VCard()
             run_coroutine(self.s.set_vcard(vcard))


### PR DESCRIPTION
Fixes #174, fixes #173.

This does quite a bit of things:

* fixes the Stream Management race by doing things right
* deprecates the ``send()`` and ``enqueue()`` methods on the ``StanzaStream`` by moving them to the ``Client``
* makes ``enqueue()`` raise if the stream is not established yet
* makes ``send()`` block until the stream is established (and raise if the stream fails to establish)

TODO:

* [x] fix all the deprecated uses in our services and tests
* [x] fix the deprecated uses in the docs
* [x] fix the deprecated uses in the examples

(The things on the TODO should not affect the review, so feel free to start.)