### PR TITLE
Propagate pre-stream-features errors to features_future

### DIFF
--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -196,7 +196,8 @@ class XMLStream(asyncio.Protocol):
 
     `features_future` must be a :class:`asyncio.Future` instance; the XML
     stream will set the first :class:`~aioxmpp.nonza.StreamFeatures` node
-    it receives as the result of the future.
+    it receives as the result of the future. The future will also receive any
+    pre-stream-features exception.
 
     `sorted_attributes` is mainly for unittesting purposes; this is an argument
     to the :class:`~aioxmpp.xml.XMPPXMLGenerator` and slows down the XML
@@ -348,6 +349,8 @@ class XMLStream(asyncio.Protocol):
             if not fut.done():
                 fut.set_exception(exc)
         self._error_futures.clear()
+        if self._features_future:
+            self._features_future.set_exception(exc)
 
         if task.cancelled():
             # this happens if connection_lost happens before we enter closing

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -483,7 +483,7 @@ class TransportMock(InteractivityMock,
             logging.info("got this: %r", data)
             self._tester.assertEqual(
                 expected_data[:len(data)],
-                data,
+                bytes(data),
                 "mismatch of expected and written data"+self._previously()
             )
         self._rxd.append(data)

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -309,6 +309,12 @@ Version 0.10
   roster items is ``"none"``. :mod:`aioxmpp` treated an absent attribute as
   fatal.
 
+* Pass pre-stream-features exception down to stream feature listeners. This
+  fixes hangs on errors before the stream features are received. This can
+  happen with misconfigured SRV records or lack of ALPN support in a :xep:`368`
+  setting. Thanks to Travis Burtrum for providing a test setup for hunting this
+  down.
+
 .. _api-changelog-0.9:
 
 Version 0.9


### PR DESCRIPTION
This is needed for proper error handling. Without this fix, the connectors (which wait for the features_future) would block indefinitely if an error happens before the stream features are received.

Another way to fix that would’ve been to make the connectors *also* listen for error_futures from the stream. I consider this solution cleaner though.