### PR TITLE
connector/security_layer: Move ALPN support to connector

### DIFF
--- a/aioxmpp/security_layer.py
+++ b/aioxmpp/security_layer.py
@@ -1136,8 +1136,6 @@ def default_ssl_context():
     ctx = OpenSSL.SSL.Context(OpenSSL.SSL.SSLv23_METHOD)
     ctx.set_options(OpenSSL.SSL.OP_NO_SSLv2 | OpenSSL.SSL.OP_NO_SSLv3)
     ctx.set_verify(OpenSSL.SSL.VERIFY_PEER, default_verify_callback)
-    if hasattr(ctx, "set_alpn_protos"):
-        ctx.set_alpn_protos([b'xmpp-client'])
     return ctx
 
 

--- a/tests/test_security_layer.py
+++ b/tests/test_security_layer.py
@@ -2186,6 +2186,25 @@ class TestSTARTTLSProvider(unittest.TestCase):
         )
 
 
+class Test_default_ssl_context(unittest.TestCase):
+
+    def test_default_ssl_context(self):
+        with unittest.mock.patch.object(OpenSSL.SSL, "Context") as ctxt:
+            security_layer.default_ssl_context()
+
+        self.assertCountEqual(
+            ctxt.mock_calls,
+            [
+                unittest.mock.call(OpenSSL.SSL.SSLv23_METHOD),
+                unittest.mock.call().set_options(
+                    OpenSSL.SSL.OP_NO_SSLv2 | OpenSSL.SSL.OP_NO_SSLv3),
+                unittest.mock.call().set_verify(
+                    OpenSSL.SSL.VERIFY_PEER,
+                    security_layer.default_verify_callback),
+            ]
+        )
+
+
 class Testsecurity_layer(unittest.TestCase):
     def test_sanity_checks_on_providers(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
Fixes #170.

* ALPN support now lives in the connector module

* improved checking for ALPN availablity (pyOpenSSL raises
  NotImplementedError if the underlying OpenSSL does not
  support ALPN)

* warnings if ALPN is required but not available

NOTE: e2e tests for the ALPN support in the connector would be nice.