### PR TITLE
Replace use of asyncio.async with asyncio.ensure_future and provide fallback

### DIFF
--- a/aioxmpp/__init__.py
+++ b/aioxmpp/__init__.py
@@ -89,6 +89,12 @@ version_info = version_info
 #:    :ref:`api-stability`
 __version__ = __version__
 
+import asyncio
+#: Adds fallback if asyncio version does not provide an ensure_future function.
+#:
+if not hasattr(asyncio, "ensure_future"):
+    asyncio.ensure_future = getattr(asyncio, "async")
+
 # XXX: ^ this is a hack to make Sphinx find the docs. We could also be using
 # .. data instead of .. autodata, but that has the downside that the actual
 # version number isn’t printed in the docs (without additional maintenance

--- a/aioxmpp/__init__.py
+++ b/aioxmpp/__init__.py
@@ -66,7 +66,6 @@ Shorthands
    Alias of :func:`aioxmpp.security_layer.make`.
 
 """
-
 from ._version import version_info, __version__, version
 
 #: The imported :mod:`aioxmpp` version as a tuple.
@@ -94,9 +93,8 @@ __version__ = __version__
 # version number isn’t printed in the docs (without additional maintenance
 # cost).
 
-import asyncio
-#: Adds fallback if asyncio version does not provide an ensure_future function.
-#:
+import asyncio # NOQA
+# Adds fallback if asyncio version does not provide an ensure_future function.
 if not hasattr(asyncio, "ensure_future"):
     asyncio.ensure_future = getattr(asyncio, "async")
 

--- a/aioxmpp/__init__.py
+++ b/aioxmpp/__init__.py
@@ -89,16 +89,16 @@ version_info = version_info
 #:    :ref:`api-stability`
 __version__ = __version__
 
+# XXX: ^ this is a hack to make Sphinx find the docs. We could also be using
+# .. data instead of .. autodata, but that has the downside that the actual
+# version number isn’t printed in the docs (without additional maintenance
+# cost).
+
 import asyncio
 #: Adds fallback if asyncio version does not provide an ensure_future function.
 #:
 if not hasattr(asyncio, "ensure_future"):
     asyncio.ensure_future = getattr(asyncio, "async")
-
-# XXX: ^ this is a hack to make Sphinx find the docs. We could also be using
-# .. data instead of .. autodata, but that has the downside that the actual
-# version number isn’t printed in the docs (without additional maintenance
-# cost).
 
 from .errors import ( # NOQA
     XMPPAuthError,

--- a/aioxmpp/avatar/service.py
+++ b/aioxmpp/avatar/service.py
@@ -682,7 +682,7 @@ class AvatarService(service.Service):
         # presence stanzas coherent as well).
         self._presence_server.resend_presence()
 
-        self._vcard_rehash_task = asyncio.async(
+        self._vcard_rehash_task = asyncio.ensure_future(
             self._calculate_vcard_id()
         )
 

--- a/aioxmpp/callbacks.py
+++ b/aioxmpp/callbacks.py
@@ -358,7 +358,7 @@ class AdHocSignal(AbstractAdHocSignal):
        connect time.
 
        When the signal is emitted, the coroutine is spawned using
-       :func:`asyncio.async` in the given `loop`, with the arguments passed to
+       :func:`asyncio.ensure_future` in the given `loop`, with the arguments passed to
        the signal.
 
        A strong reference is held to the coroutine.
@@ -438,7 +438,7 @@ class AdHocSignal(AbstractAdHocSignal):
                 raise TypeError("must be coroutine, got {!r}".format(f))
 
             def wrapper(args, kwargs):
-                task = asyncio.async(f(*args, **kwargs), loop=loop)
+                task = asyncio.ensure_future(f(*args, **kwargs), loop=loop)
                 task.add_done_callback(
                     functools.partial(
                         log_spawned,

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -674,7 +674,7 @@ class DiscoClient(service.Service):
                 except asyncio.CancelledError:
                     pass
 
-        request = asyncio.async(
+        request = asyncio.ensure_future(
             self.send_and_decode_info_query(jid, node)
         )
         request.add_done_callback(
@@ -746,7 +746,7 @@ class DiscoClient(service.Service):
         request_iq = stanza.IQ(to=jid, type_=structs.IQType.GET)
         request_iq.payload = disco_xso.ItemsQuery(node=node)
 
-        request = asyncio.async(
+        request = asyncio.ensure_future(
             self.client.send(request_iq)
         )
 

--- a/aioxmpp/e2etest/provision.py
+++ b/aioxmpp/e2etest/provision.py
@@ -467,7 +467,7 @@ class Provisioner(metaclass=abc.ABCMeta):
 
         futures = []
         for cm in self._accounts_to_dispose:
-            futures.append(asyncio.async(cm.__aexit__(None, None, None)))
+            futures.append(asyncio.ensure_future(cm.__aexit__(None, None, None)))
         self._accounts_to_dispose.clear()
 
         self._logger.debug("waiting for %d accounts to shut down",

--- a/aioxmpp/entitycaps/service.py
+++ b/aioxmpp/entitycaps/service.py
@@ -187,7 +187,7 @@ class Cache:
         copied_entry = copy.copy(entry)
         self._memory_overlay[key] = copied_entry
         if self._user_db_path is not None:
-            asyncio.async(asyncio.get_event_loop().run_in_executor(
+            asyncio.ensure_future(asyncio.get_event_loop().run_in_executor(
                 None,
                 writeback,
                 self._user_db_path / key.path,

--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -1020,7 +1020,7 @@ class Client:
         if self.running:
             raise RuntimeError("client already running")
 
-        self._main_task = asyncio.async(
+        self._main_task = asyncio.ensure_future(
             self._main(),
             loop=self._loop
         )

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -302,7 +302,7 @@ class XMLStream(asyncio.Protocol):
         self._transport_closing = False
         self._footer_timeout_future = None
 
-        self._closing_future = asyncio.async(
+        self._closing_future = asyncio.ensure_future(
             self._smachine.wait_for(
                 State.CLOSING
             ),
@@ -364,7 +364,7 @@ class XMLStream(asyncio.Protocol):
             return
         task.result()
 
-        self._footer_timeout_future = asyncio.async(
+        self._footer_timeout_future = asyncio.ensure_future(
             self._stream_footer_timeout(),
             loop=self._loop
         )

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -933,7 +933,7 @@ class StanzaStream:
                 awaitable = asyncio.Future()
                 awaitable.set_exception(exc)
 
-            task = asyncio.async(awaitable)
+            task = asyncio.ensure_future(awaitable)
             task.add_done_callback(
                 functools.partial(
                     self._iq_request_coro_done,
@@ -1771,7 +1771,7 @@ class StanzaStream:
             self.on_stream_established()
             self._established = True
 
-        self._task = asyncio.async(self._run(xmlstream), loop=self._loop)
+        self._task = asyncio.ensure_future(self._run(xmlstream), loop=self._loop)
         self._task.add_done_callback(self._done_handler)
         self._logger.debug("broker task started as %r", self._task)
 
@@ -1882,9 +1882,9 @@ class StanzaStream:
     @asyncio.coroutine
     def _run(self, xmlstream):
         self._xmlstream = xmlstream
-        active_fut = asyncio.async(self._active_queue.get(),
+        active_fut = asyncio.ensure_future(self._active_queue.get(),
                                    loop=self._loop)
-        incoming_fut = asyncio.async(self._incoming_queue.get(),
+        incoming_fut = asyncio.ensure_future(self._incoming_queue.get(),
                                      loop=self._loop)
 
         try:
@@ -1904,14 +1904,14 @@ class StanzaStream:
                 with (yield from self._broker_lock):
                     if active_fut in done:
                         self._process_outgoing(xmlstream, active_fut.result())
-                        active_fut = asyncio.async(
+                        active_fut = asyncio.ensure_future(
                             self._active_queue.get(),
                             loop=self._loop)
 
                     if incoming_fut in done:
                         self._process_incoming(xmlstream,
                                                incoming_fut.result())
-                        incoming_fut = asyncio.async(
+                        incoming_fut = asyncio.ensure_future(
                             self._incoming_queue.get(),
                             loop=self._loop)
 

--- a/aioxmpp/tasks.py
+++ b/aioxmpp/tasks.py
@@ -199,4 +199,4 @@ class TaskPool:
 
 
 
-        return asyncio.async(__coro_fun(*args, **kwargs))
+        return asyncio.ensure_future(__coro_fun(*args, **kwargs))

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -72,8 +72,8 @@ def run_coroutine_with_peer(
         loop=None):
     loop = loop or asyncio.get_event_loop()
 
-    local_future = asyncio.async(coroutine, loop=loop)
-    remote_future = asyncio.async(peer_coroutine, loop=loop)
+    local_future = asyncio.ensure_future(coroutine, loop=loop)
+    remote_future = asyncio.ensure_future(peer_coroutine, loop=loop)
 
     done, pending = loop.run_until_complete(
         asyncio.wait(

--- a/aioxmpp/utils.py
+++ b/aioxmpp/utils.py
@@ -63,7 +63,7 @@ def background_task(coro, logger):
                             task,
                             result)
 
-    task = asyncio.async(coro)
+    task = asyncio.ensure_future(coro)
     task.add_done_callback(log_result)
     try:
         yield
@@ -129,7 +129,7 @@ class LazyTask(asyncio.Future):
 
     def __start_task(self):
         if self.__task is None:
-            self.__task = asyncio.async(
+            self.__task = asyncio.ensure_future(
                 self.__coroutine_function(*self.__args)
             )
             self.__task.add_done_callback(self.__task_done)
@@ -154,7 +154,7 @@ class LazyTask(asyncio.Future):
 def gather_reraise_multi(*fut_or_coros, message="gather_reraise_multi"):
     """
     Wrap all the arguments `fut_or_coros` in futures with
-    :func:`asyncio.async` and wait until all of them are finish or
+    :func:`asyncio.ensure_future` and wait until all of them are finish or
     fail.
 
     :param fut_or_coros: the futures or coroutines to wait for
@@ -189,7 +189,7 @@ def gather_reraise_multi(*fut_or_coros, message="gather_reraise_multi"):
     # this late import is needed for Python 3.4
     from aioxmpp import errors
 
-    todo = [asyncio.async(fut_or_coro) for fut_or_coro in fut_or_coros]
+    todo = [asyncio.ensure_future(fut_or_coro) for fut_or_coro in fut_or_coros]
     if not todo:
         return []
 

--- a/examples/adhoc_browser/utils.py
+++ b/examples/adhoc_browser/utils.py
@@ -47,7 +47,7 @@ def asyncified_unblock(dlg, cursor, task):
 def asyncify(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        task = asyncio.async(fn(*args, **kwargs))
+        task = asyncio.ensure_future(fn(*args, **kwargs))
         task.add_done_callback(functools.partial(asyncified_done, None))
     return wrapper
 
@@ -59,7 +59,7 @@ def asyncify_blocking(fn):
         self.setEnabled(False)
         self.setCursor(Qt.Qt.WaitCursor)
         try:
-            task = asyncio.async(fn(self, *args, **kwargs))
+            task = asyncio.ensure_future(fn(self, *args, **kwargs))
         except:
             self.setEnabled(True)
             self.setCursor(prev_cursor)

--- a/examples/list_presence.py
+++ b/examples/list_presence.py
@@ -36,7 +36,7 @@ class PresenceCollector:
         self._reset_timer()
 
     def _reset_timer(self):
-        self._done_task = asyncio.async(
+        self._done_task = asyncio.ensure_future(
             asyncio.sleep(self.done_timeout.total_seconds())
         )
         self._done_task.add_done_callback(self._sleep_done)

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -1263,10 +1263,10 @@ class TestDiscoClient(unittest.TestCase):
                 "send_and_decode_info_query",
                 new=mock):
 
-            task1 = asyncio.async(
+            task1 = asyncio.ensure_future(
                 self.s.query_info(to, node="foobar")
             )
-            task2 = asyncio.async(
+            task2 = asyncio.ensure_future(
                 self.s.query_info(to, node="foobar")
             )
 
@@ -1426,8 +1426,8 @@ class TestDiscoClient(unittest.TestCase):
             send_and_decode.return_value = response
             send_and_decode.delay = 0.1
 
-            q1 = asyncio.async(self.s.query_info(to))
-            q2 = asyncio.async(self.s.query_info(to))
+            q1 = asyncio.ensure_future(self.s.query_info(to))
+            q2 = asyncio.ensure_future(self.s.query_info(to))
 
             run_coroutine(asyncio.sleep(0.05))
 
@@ -1557,10 +1557,10 @@ class TestDiscoClient(unittest.TestCase):
                 "send",
                 new=mock):
 
-            task1 = asyncio.async(
+            task1 = asyncio.ensure_future(
                 self.s.query_info(to, node="foobar")
             )
-            task2 = asyncio.async(
+            task2 = asyncio.ensure_future(
                 self.s.query_info(to, node="foobar")
             )
 
@@ -1698,8 +1698,8 @@ class TestDiscoClient(unittest.TestCase):
         self.cc.send.return_value = response
         self.cc.send.delay = 0.1
 
-        q1 = asyncio.async(self.s.query_items(to))
-        q2 = asyncio.async(self.s.query_items(to))
+        q1 = asyncio.ensure_future(self.s.query_items(to))
+        q2 = asyncio.ensure_future(self.s.query_items(to))
 
         run_coroutine(asyncio.sleep(0.05))
 
@@ -1747,7 +1747,7 @@ class TestDiscoClient(unittest.TestCase):
             fut
         )
 
-        request = asyncio.async(
+        request = asyncio.ensure_future(
             self.s.query_info(to)
         )
 
@@ -1771,7 +1771,7 @@ class TestDiscoClient(unittest.TestCase):
             fut
         )
 
-        request = asyncio.async(
+        request = asyncio.ensure_future(
             self.s.query_info(to)
         )
 

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -236,7 +236,7 @@ class TestCache(unittest.TestCase):
                 fut,
             )
 
-            task = asyncio.async(
+            task = asyncio.ensure_future(
                 self.c.lookup(unittest.mock.sentinel.key)
             )
             run_coroutine(asyncio.sleep(0))
@@ -298,7 +298,7 @@ class TestCache(unittest.TestCase):
             base.Future.return_value = fut1
             self.c.create_query_future(unittest.mock.sentinel.key)
 
-            task = asyncio.async(
+            task = asyncio.ensure_future(
                 self.c.lookup(unittest.mock.sentinel.key)
             )
             run_coroutine(asyncio.sleep(0))
@@ -353,7 +353,7 @@ class TestCache(unittest.TestCase):
                 fut,
             )
 
-            task = asyncio.async(
+            task = asyncio.ensure_future(
                 self.c.lookup(unittest.mock.sentinel.key)
             )
             run_coroutine(asyncio.sleep(0))
@@ -384,7 +384,7 @@ class TestCache(unittest.TestCase):
             ))
 
             async = stack.enter_context(unittest.mock.patch(
-                "asyncio.async"
+                "asyncio.ensure_future"
             ))
 
             self.c.add_cache_entry(
@@ -421,7 +421,7 @@ class TestCache(unittest.TestCase):
             ))
 
             async = stack.enter_context(unittest.mock.patch(
-                "asyncio.async"
+                "asyncio.ensure_future"
             ))
 
             self.c.add_cache_entry(
@@ -464,7 +464,7 @@ class TestCache(unittest.TestCase):
             ))
 
             async = stack.enter_context(unittest.mock.patch(
-                "asyncio.async"
+                "asyncio.ensure_future"
             ))
 
             self.c.add_cache_entry(

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -2453,7 +2453,7 @@ class TestRoom(unittest.TestCase):
         self.assertFalse(stanza.body)
 
     def test_leave(self):
-        fut = asyncio.async(self.jmuc.leave())
+        fut = asyncio.ensure_future(self.jmuc.leave())
         run_coroutine(asyncio.sleep(0))
         self.assertFalse(fut.done(), fut.done() and fut.result())
 

--- a/tests/roster/test_service.py
+++ b/tests/roster/test_service.py
@@ -482,7 +482,7 @@ class TestService(unittest.TestCase):
         self.cc.send.return_value = response
         self.cc.send.delay = 0.05
 
-        task = asyncio.async(self.cc.before_stream_established())
+        task = asyncio.ensure_future(self.cc.before_stream_established())
 
         run_coroutine(asyncio.sleep(0.01))
 
@@ -1638,7 +1638,7 @@ class TestService(unittest.TestCase):
         @asyncio.coroutine
         def send(iq, timeout=None):
             # this is brutal, but a sure way to provoke the race
-            asyncio.async(self.s.handle_roster_push(push))
+            asyncio.ensure_future(self.s.handle_roster_push(push))
             # give the roster push a chance to act
             # (we cannot yield from the handle_roster_push() here: in the fixed
             # version that would be a deadlock)
@@ -1648,7 +1648,7 @@ class TestService(unittest.TestCase):
         self.cc.send = unittest.mock.Mock()
         self.cc.send.side_effect = send
 
-        initial_roster = asyncio.async(self.cc.before_stream_established())
+        initial_roster = asyncio.ensure_future(self.cc.before_stream_established())
 
         run_coroutine(initial_roster)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -535,7 +535,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch(
-                    "asyncio.async",
+                    "asyncio.ensure_future",
                     new=base.async_,
                 )
             )
@@ -667,7 +667,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch(
-                    "asyncio.async",
+                    "asyncio.ensure_future",
                     new=base.async_,
                 )
             )
@@ -892,7 +892,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch(
-                    "asyncio.async",
+                    "asyncio.ensure_future",
                     new=base.async_,
                 )
             )
@@ -1021,7 +1021,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
 
             stack.enter_context(
                 unittest.mock.patch(
-                    "asyncio.async",
+                    "asyncio.ensure_future",
                     new=base.async_,
                 )
             )

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -4163,7 +4163,7 @@ class TestUseConnected(unittest.TestCase):
         del self.cm
 
     def test_aenter_listens_to_on_stream_established_to_detect_success(self):
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.assertFalse(task.done(), task)
@@ -4173,7 +4173,7 @@ class TestUseConnected(unittest.TestCase):
         self.assertEqual(run_coroutine(task), self.client.stream)
 
     def test_aenter_listens_to_on_failure_to_detect_failure(self):
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.assertFalse(task.done(), task)
@@ -4188,7 +4188,7 @@ class TestUseConnected(unittest.TestCase):
         self.assertIs(ctx.exception, exc)
 
     def test_aenter_calls_start_if_client_not_running(self):
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.client.start.assert_called_once_with()
@@ -4199,7 +4199,7 @@ class TestUseConnected(unittest.TestCase):
     def test_aenter_does_not_call_start_but_waits_if_not_established(self):
         self.client.running = True
 
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.client.start.assert_not_called()
@@ -4233,7 +4233,7 @@ class TestUseConnected(unittest.TestCase):
         self.client.stop.assert_called_once_with()
 
     def test_aenter_does_not_set_presence_by_default(self):
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.presence_server.set_presence.assert_not_called()
@@ -4249,7 +4249,7 @@ class TestUseConnected(unittest.TestCase):
             presence=p,
         )
 
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.presence_server.set_presence.assert_called_once_with(p)
@@ -4268,7 +4268,7 @@ class TestUseConnected(unittest.TestCase):
             presence=p,
         )
 
-        task = asyncio.async(self.cm.__aenter__())
+        task = asyncio.ensure_future(self.cm.__aenter__())
         run_coroutine(asyncio.sleep(0.1))
 
         self.presence_server.set_presence.assert_called_once_with(p)
@@ -4279,7 +4279,7 @@ class TestUseConnected(unittest.TestCase):
         self.client.established = True
         self.client.running = True
 
-        task = asyncio.async(self.cm.__aexit__(None, None, None))
+        task = asyncio.ensure_future(self.cm.__aexit__(None, None, None))
         run_coroutine(asyncio.sleep(0.01))
 
         self.assertFalse(task.done(), task)
@@ -4293,7 +4293,7 @@ class TestUseConnected(unittest.TestCase):
         self.client.established = True
         self.client.running = True
 
-        task = asyncio.async(self.cm.__aexit__(None, None, None))
+        task = asyncio.ensure_future(self.cm.__aexit__(None, None, None))
         run_coroutine(asyncio.sleep(0.01))
 
         self.assertFalse(task.done(), task)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1391,7 +1391,7 @@ class TestXMLStream(unittest.TestCase):
             protocol.State.OPEN
         )
 
-        fut = asyncio.async(p.close_and_wait())
+        fut = asyncio.ensure_future(p.close_and_wait())
 
         run_coroutine(t.run_test(
             [
@@ -1454,7 +1454,7 @@ class TestXMLStream(unittest.TestCase):
             protocol.State.OPEN
         )
 
-        fut = asyncio.async(p.close_and_wait())
+        fut = asyncio.ensure_future(p.close_and_wait())
 
         run_coroutine(t.run_test(
             [
@@ -1830,7 +1830,7 @@ class TestXMLStream(unittest.TestCase):
 
     def test_future_for_closing_state_is_disposed_of_in_connection_lost(
             self):
-        with unittest.mock.patch("asyncio.async") as async_:
+        with unittest.mock.patch("asyncio.ensure_future") as async_:
             t, p = self._make_stream(to=TEST_PEER)
 
         run_coroutine(t.run_test(

--- a/tests/test_statemachine.py
+++ b/tests/test_statemachine.py
@@ -87,7 +87,7 @@ class TestOrderedStateMachine(unittest.TestCase):
 
     def test_wait_for_at_least(self):
         state_tasks = {
-            state: asyncio.async(self.osm.wait_for_at_least(state),
+            state: asyncio.ensure_future(self.osm.wait_for_at_least(state),
                                  loop=self.loop)
             for state in States
         }
@@ -107,7 +107,7 @@ class TestOrderedStateMachine(unittest.TestCase):
 
     def test_wait_for_at_least_checks_current_state(self):
         state_tasks = {
-            state: asyncio.async(self.osm.wait_for_at_least(state),
+            state: asyncio.ensure_future(self.osm.wait_for_at_least(state),
                                  loop=self.loop)
             for state in States
         }
@@ -125,7 +125,7 @@ class TestOrderedStateMachine(unittest.TestCase):
 
     def test_wait_for_at_least_can_be_cancelled(self):
         state_tasks = {
-            state: asyncio.async(self.osm.wait_for_at_least(state),
+            state: asyncio.ensure_future(self.osm.wait_for_at_least(state),
                                  loop=self.loop)
             for state in States
         }
@@ -151,7 +151,7 @@ class TestOrderedStateMachine(unittest.TestCase):
 
     def test_wait_for(self):
         state_tasks = {
-            state: asyncio.async(self.osm.wait_for(state),
+            state: asyncio.ensure_future(self.osm.wait_for(state),
                                  loop=self.loop)
             for state in States
         }
@@ -180,7 +180,7 @@ class TestOrderedStateMachine(unittest.TestCase):
 
     def test_wait_for_checks_immediately(self):
         state_tasks = {
-            state: asyncio.async(self.osm.wait_for(state),
+            state: asyncio.ensure_future(self.osm.wait_for(state),
                                  loop=self.loop)
             for state in States
         }

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1840,7 +1840,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=CoroutineMock()
             ))
 
-            task = asyncio.async(self.stream.send_iq_and_wait_for_reply(
+            task = asyncio.ensure_future(self.stream.send_iq_and_wait_for_reply(
                 unittest.mock.sentinel.iq
             ))
             with self.assertWarnsRegex(
@@ -2898,7 +2898,7 @@ class TestStanzaStream(StanzaStreamTestBase):
     def test_send_and_wait_for_sent_emits_deprecation_warning(self):
         iq = make_test_iq()
 
-        task = asyncio.async(self.stream.send_and_wait_for_sent(iq))
+        task = asyncio.ensure_future(self.stream.send_and_wait_for_sent(iq))
         with self.assertWarnsRegex(
                 DeprecationWarning,
                 r"send_and_wait_for_sent is deprecated and will be removed in 1.0"):
@@ -3002,7 +3002,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream._send_immediately(iq))
+            task = asyncio.ensure_future(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
@@ -3049,7 +3049,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream._send_immediately(iq))
+            task = asyncio.ensure_future(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
@@ -3102,7 +3102,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream._send_immediately(iq))
+            task = asyncio.ensure_future(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
@@ -3144,7 +3144,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base._enqueue
             ))
 
-            task = asyncio.async(self.stream._send_immediately(
+            task = asyncio.ensure_future(self.stream._send_immediately(
                 iq,
                 timeout=0.001))
             run_coroutine(asyncio.sleep(0.01))
@@ -3178,7 +3178,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream._send_immediately(
+            task = asyncio.ensure_future(self.stream._send_immediately(
                 iq,
                 timeout=0.001))
             run_coroutine(asyncio.sleep(0.01))
@@ -3225,7 +3225,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream._send_immediately(iq))
+            task = asyncio.ensure_future(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
@@ -3267,7 +3267,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 new=base.iq_response_map,
             ))
 
-            task = asyncio.async(self.stream._send_immediately(iq))
+            task = asyncio.ensure_future(self.stream._send_immediately(iq))
             run_coroutine(asyncio.sleep(0.01))
 
             self.assertFalse(task.done())
@@ -3491,7 +3491,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
+        task = asyncio.ensure_future(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3529,7 +3529,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
+        task = asyncio.ensure_future(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3563,7 +3563,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
+        task = asyncio.ensure_future(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3590,7 +3590,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
+        task = asyncio.ensure_future(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -3623,7 +3623,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.start(self.xmlstream)
 
-        task = asyncio.async(self.stream._send_immediately(iq, cb=cb))
+        task = asyncio.ensure_future(self.stream._send_immediately(iq, cb=cb))
 
         run_coroutine(self.sent_stanzas.get())
         self.assertFalse(task.done())
@@ -4018,7 +4018,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
 
         @asyncio.coroutine
         def starter():
-            sm_start_future = asyncio.async(self.stream.start_sm())
+            sm_start_future = asyncio.ensure_future(self.stream.start_sm())
             self.stream._enqueue(iq_sent)
 
         self.stream.start(self.xmlstream)
@@ -5371,7 +5371,7 @@ class TestStanzaToken(unittest.TestCase):
         )
 
     def test__set_state_still_idempotent_with_await(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5387,7 +5387,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_returns_on_SENT_WITHOUT_SM(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5398,7 +5398,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_returns_on_ACKED(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5410,7 +5410,7 @@ class TestStanzaToken(unittest.TestCase):
                          "requires Python 3.5+")
     def test_await_returns_on_ACKED_plainly_even_with_exception(
             self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5421,7 +5421,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_waits_while_SENT(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5437,7 +5437,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_raises_ConnectionError_on_DISCONNECTED(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5451,7 +5451,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_raises_RuntimeError_on_DROPPED(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5465,7 +5465,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_raises_RuntimeError_on_ABORTED(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5479,7 +5479,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_aborts_if_cancelled(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5496,7 +5496,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_raises_ValueError_on_failed(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5510,7 +5510,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_reraises_exception_from_failed(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5526,7 +5526,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_next_await_raises_usual_abort_error_after_cancel(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 
@@ -5547,7 +5547,7 @@ class TestStanzaToken(unittest.TestCase):
     @unittest.skipUnless(CAN_AWAIT_STANZA_TOKEN,
                          "requires Python 3.5+")
     def test_await_does_not_abort_if_already_inflight(self):
-        task = asyncio.async(self.token.__await__())
+        task = asyncio.ensure_future(self.token.__await__())
         run_coroutine(asyncio.sleep(0.01))
         self.assertFalse(task.done())
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -94,7 +94,7 @@ class TestTaskPool(unittest.TestCase):
         with contextlib.ExitStack() as stack:
             async_ = stack.enter_context(
                 unittest.mock.patch(
-                    "asyncio.async"
+                    "asyncio.ensure_future"
                 )
             )
 
@@ -123,7 +123,7 @@ class TestTaskPool(unittest.TestCase):
         with contextlib.ExitStack() as stack:
             async_ = stack.enter_context(
                 unittest.mock.patch(
-                    "asyncio.async"
+                    "asyncio.ensure_future"
                 )
             )
 

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -887,7 +887,7 @@ class TestXMLStreamMock(XMLTestCase):
         fun = unittest.mock.MagicMock()
         fun.return_value = None
 
-        ec_future = asyncio.async(self.xmlstream.error_future())
+        ec_future = asyncio.ensure_future(self.xmlstream.error_future())
 
         self.xmlstream.on_closing.connect(fun)
 
@@ -921,7 +921,7 @@ class TestXMLStreamMock(XMLTestCase):
             ))
 
     def test_close_and_wait(self):
-        task = asyncio.async(self.xmlstream.close_and_wait())
+        task = asyncio.ensure_future(self.xmlstream.close_and_wait())
 
         run_coroutine(self.xmlstream.run_test(
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,14 +63,14 @@ class Testbackground_task(unittest.TestCase):
         del self.coro
 
     def test_enter_starts_coroutine(self):
-        with unittest.mock.patch("asyncio.async") as async_:
+        with unittest.mock.patch("asyncio.ensure_future") as async_:
             self.cm.__enter__()
 
         async_.assert_called_with(self.started_coro)
         self.assertFalse(async_().cancel.mock_calls)
 
     def test_exit_cancels_coroutine(self):
-        with unittest.mock.patch("asyncio.async") as async_:
+        with unittest.mock.patch("asyncio.ensure_future") as async_:
             self.cm.__enter__()
             self.cm.__exit__(None, None, None)
 
@@ -82,7 +82,7 @@ class Testbackground_task(unittest.TestCase):
         except:
             exc_info = sys.exc_info()
 
-        with unittest.mock.patch("asyncio.async") as async_:
+        with unittest.mock.patch("asyncio.ensure_future") as async_:
             self.cm.__enter__()
             result = self.cm.__exit__(*exc_info)
 
@@ -291,7 +291,7 @@ class TestLazyTask(unittest.TestCase):
 
         fut = utils.LazyTask(self.coro)
 
-        result = run_coroutine(asyncio.async(fut))
+        result = run_coroutine(asyncio.ensure_future(fut))
 
         self.assertEqual(result, unittest.mock.sentinel.result)
 
@@ -300,7 +300,7 @@ class TestLazyTask(unittest.TestCase):
 
         fut = utils.LazyTask(self.coro)
 
-        result2 = run_coroutine(asyncio.async(fut))
+        result2 = run_coroutine(asyncio.ensure_future(fut))
         result1 = run_coroutine(fut)
 
         self.assertEqual(result1, result2)
@@ -312,7 +312,7 @@ class TestLazyTask(unittest.TestCase):
         fut = utils.LazyTask(self.coro)
         cb = unittest.mock.Mock(["__call__"])
 
-        with unittest.mock.patch("asyncio.async") as async_:
+        with unittest.mock.patch("asyncio.ensure_future") as async_:
             fut.add_done_callback(cb)
             async_.assert_called_once_with(unittest.mock.ANY)
 


### PR DESCRIPTION
Closes #161 

Made the changes specified in #161, all tests for aioxmpp test runner passed with the asyncio.ensure_future instead of asyncio.async. 

I have only executed the tests found in the project, I am unsure if this is enough to know if the change is working or not. Let me know if anything needs to be changed or added.