### PR TITLE
version: always emit name and version or return service-unavailable

### DIFF
--- a/tests/version/test_e2e.py
+++ b/tests/version/test_e2e.py
@@ -52,8 +52,24 @@ class TestVersion(TestCase):
 
     @blocking_timed
     @asyncio.coroutine
-    def test_version_query_against_aioxmpp(self):
+    def test_version_query_returns_service_unavailable_if_unconfigured(self):
         b_version = self.b.summon(aioxmpp.version.VersionServer)
+
+        with self.assertRaises(aioxmpp.errors.XMPPCancelError) as ctx:
+            yield from aioxmpp.version.query_version(
+                self.a.stream,
+                self.b.local_jid,
+            )
+
+        self.assertEqual(ctx.exception.condition,
+                         (namespaces.stanzas, "service-unavailable"))
+
+    @blocking_timed
+    @asyncio.coroutine
+    def test_version_query_with_results(self):
+        b_version = self.b.summon(aioxmpp.version.VersionServer)
+        b_version.name = "aioxmpp"
+        b_version.version = aioxmpp.__version__
 
         result = yield from aioxmpp.version.query_version(
             self.a.stream,


### PR DESCRIPTION
Fixes #168.

``version`` is now generated as per ``self._version or "unspecified"`` and if ``name`` is None, ``service-unavailable`` is returned. Also, the defaults for both are set to None now.