### PR TITLE
Make legacy session negotiation optional if supported by the server

### DIFF
--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -889,11 +889,16 @@ class Client:
             self.logger.debug("stream management started")
 
         try:
-            features[rfc3921.SessionFeature]
+            session_feature = features[rfc3921.SessionFeature]
         except KeyError:
             pass  # yay
         else:
-            yield from self._negotiate_legacy_session()
+            if not session_feature.optional:
+                yield from self._negotiate_legacy_session()
+            else:
+                self.logger.debug(
+                    "skipping optional legacy session negotiation"
+                )
 
         self.established_event.set()
 

--- a/aioxmpp/rfc3921.py
+++ b/aioxmpp/rfc3921.py
@@ -32,8 +32,6 @@ This module was introduced to ensure compatibility with legacy XMPP servers
 
 """
 
-
-
 from . import stanza, nonza, xso
 
 from .utils import namespaces
@@ -69,3 +67,7 @@ class SessionFeature(xso.XSO):
     UNKNOWN_ATTR_POLICY = xso.UnknownAttrPolicy.DROP
 
     TAG = (namespaces.rfc3921_session, "session")
+
+    optional = xso.ChildFlag(
+        (namespaces.rfc3921_session, "optional")
+    )

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -323,6 +323,15 @@ Version 0.10
 * :mod:`aioxmpp.misc` provides XSO definitions for the :xep:`379`
   ``preauth`` element.
 
+* Support for ``<optional/>`` element in :rfc:`3921` ``<session/>`` negotiation
+  feature; the feature is not needed with modern servers, but since legacy
+  clients require it, they still announce it. The feature introduces a new
+  round-trip for no gain. An `rfc-draft by Dave Cridland
+  <https://tools.ietf.org/html/draft-cridland-xmpp-session-01>`_ standardises
+  the ``<optional/>`` element which allows a server to tell the client that it
+  doesn’t require the session negotiation step. :mod:`aioxmpp` now understands
+  this and will skip that step, saving a round-trip with most modern servers.
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -2818,6 +2818,27 @@ class TestClient(xmltestutils.XMLTestCase):
 
         run_coroutine(asyncio.sleep(0))
 
+    def test_do_not_negotiate_legacy_session_if_optional(self):
+        feature = rfc3921.SessionFeature()
+        feature.optional = True
+        self.features[...] = feature
+
+        iqreq = stanza.IQ(type_=structs.IQType.SET)
+        iqreq.payload = rfc3921.Session()
+        iqreq.id_ = "autoset"
+
+        iqresp = stanza.IQ(type_=structs.IQType.RESULT)
+        iqresp.id_ = "autoset"
+
+        self.client.start()
+        run_coroutine(self.xmlstream.run_test(
+            self.resource_binding,
+        ))
+
+        run_coroutine(asyncio.sleep(0))
+
+        self.assertTrue(self.client.established)
+
     def test_negotiate_legacy_session_after_stream_management(self):
         self.features[...] = rfc3921.SessionFeature()
         self.features[...] = nonza.StreamManagementFeature()

--- a/tests/test_rfc3921.py
+++ b/tests/test_rfc3921.py
@@ -111,4 +111,14 @@ class TestSessionFeature(unittest.TestCase):
             xso.UnknownAttrPolicy.DROP
         )
 
+    def test_optional(self):
+        self.assertIsInstance(
+            rfc3921.SessionFeature.optional,
+            xso.ChildFlag
+        )
+        self.assertEqual(
+            rfc3921.SessionFeature.optional.tag,
+            (namespaces.rfc3921_session, "optional")
+        )
+
 # foo


### PR DESCRIPTION
Fixes #180.