### PR TITLE
disco: add flush_cache method

### DIFF
--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -515,6 +515,8 @@ class DiscoClient(service.Service):
     .. autoattribute:: items_cache_size
        :annotation: = 100
 
+    .. automethod:: flush_cache
+
     Usage example, assuming that you have a :class:`.node.Client` `client`::
 
       import aioxmpp.disco as disco
@@ -593,6 +595,17 @@ class DiscoClient(service.Service):
         except Exception:
             return
         self.on_info_result(jid, node, result)
+
+    def flush_cache(self):
+        """
+        Clear the cache.
+
+        This clears the internal cache in a way which lets existing queries
+        continue, but the next query for each target will behave as if
+        `require_fresh` had been set to true.
+        """
+        self._info_pending.clear()
+        self._items_pending.clear()
 
     @asyncio.coroutine
     def send_and_decode_info_query(self, jid, node):

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -341,6 +341,8 @@ Version 0.10
 * Fix a bug in :meth:`aioxmpp.JID.fromstr` which would incorrectly parse and
   then reject some valid JIDs.
 
+* Add :meth:`aioxmpp.DiscoClient.flush_cache`.
+
 .. _api-changelog-0.9:
 
 Version 0.9


### PR DESCRIPTION
Useful if you do, say, scans of a lot of MUCs and want to have a point at which the cache is flushed for the next round, without sacrificing the caching while scanning.