### PR TITLE
disco: add method to update names of an identity without removing/readding it

### DIFF
--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -54,6 +54,8 @@ class Node(object):
 
     .. automethod:: register_identity
 
+    .. automethod:: set_identity_names
+
     .. automethod:: unregister_identity
 
     To access the declared features and identities, use:
@@ -214,6 +216,26 @@ class Node(object):
         key = category, type_
         if key in self._identities:
             raise ValueError("identity already claimed: {!r}".format(key))
+        self._identities[key] = names
+        self.on_info_changed()
+
+    def set_identity_names(self, category, type_, names={}):
+        """
+        Update the names of an identity.
+
+        :param category: The category of the identity to update.
+        :type category: :class:`str`
+        :param type_: The type of the identity to update.
+        :type type_: :class:`str`
+        :param names: The new internationalised names to set for the identity.
+        :type names: :class:`~.abc.Mapping` from
+            :class:`.structs.LanguageTag` to :class:`str`
+        :raises ValueError: if no identity with the given category and type
+            is currently registered.
+        """
+        key = category, type_
+        if key not in self._identities:
+            raise ValueError("identity not registered: {!r}".format(key))
         self._identities[key] = names
         self.on_info_changed()
 

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -383,7 +383,7 @@ class DiscoServer(service.Service, Node):
 
        Upon construction, the :class:`DiscoServer` adds a default identity with
        category ``"client"`` and type ``"bot"`` to the root
-       :class:`.disco.Node`. This is to comply with :xep:`30`, which specifies
+       :class:`~.disco.Node`. This is to comply with :xep:`30`, which specifies
        that at least one identity must always be returned. Otherwise, the
        service would be forced to send a malformed response or reply with
        ``<feature-not-implemented/>``.
@@ -473,7 +473,7 @@ class DiscoServer(service.Service, Node):
         .. seealso::
 
            :meth:`mount_node`
-              for a way for mounting :class:`Node` instances.
+              for a way for mounting :class:`~.disco.Node` instances.
 
         """
         del self._node_mounts[mountpoint]

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -341,6 +341,8 @@ Version 0.10
 * Fix a bug in :meth:`aioxmpp.JID.fromstr` which would incorrectly parse and
   then reject some valid JIDs.
 
+* Add :meth:`aioxmpp.disco.Node.set_identity_names`
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -288,6 +288,60 @@ class TestNode(unittest.TestCase):
             set(n.iter_identities(unittest.mock.sentinel.stanza))
         )
 
+    def test_set_identity_names_updates_text_and_emits_cb(self):
+        n = disco_service.Node()
+
+        n.register_identity(
+            "client", "pc",
+            names={
+                structs.LanguageTag.fromstr("en"): "default identity",
+                structs.LanguageTag.fromstr("de"): "Standardidentität",
+            }
+        )
+
+        cb = unittest.mock.Mock()
+        n.on_info_changed.connect(cb)
+
+        n.set_identity_names(
+            "client", "pc",
+            names={
+                structs.LanguageTag.fromstr("en"): "test identity",
+                structs.LanguageTag.fromstr("de"): "Testidentität",
+            }
+        )
+
+        cb.assert_called_with()
+
+        self.assertSetEqual(
+            {
+                ("client", "pc",
+                 structs.LanguageTag.fromstr("en"), "test identity"),
+                ("client", "pc",
+                 structs.LanguageTag.fromstr("de"), "Testidentität"),
+            },
+            set(n.iter_identities(unittest.mock.sentinel.stanza))
+        )
+
+    def test_set_identity_names_rejects_if_identity_not_registered(self):
+        n = disco_service.Node()
+
+        cb = unittest.mock.Mock()
+        n.on_info_changed.connect(cb)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"identity not registered"):
+
+            n.set_identity_names(
+                "client", "pc",
+                names={
+                    structs.LanguageTag.fromstr("en"): "test identity",
+                    structs.LanguageTag.fromstr("de"): "Testidentität",
+                }
+            )
+
+        cb.assert_not_called()
+
     def test_unregister_identity_prohibits_removal_of_last_identity(self):
         n = disco_service.Node()
 


### PR DESCRIPTION
Currently, there’s no way (if you want to use the default "client"/"bot" identity) to set names for it without first adding a new identity, removing the default identity, then adding the identity you actually want and remove the identity you added first (due to limitations applied by the Node class).

This fixes that by allowing to update the names of an existing identity.