### PR TITLE
security_layer: handle ValueError from aiosasl

### DIFF
--- a/aioxmpp/security_layer.py
+++ b/aioxmpp/security_layer.py
@@ -981,7 +981,7 @@ class PasswordSASLProvider(SASLProvider):
                 try:
                     mechanism_worked = yield from self._execute(
                         intf, mechanism, token)
-                except aiosasl.AuthenticationFailure as err:
+                except (ValueError, aiosasl.AuthenticationFailure) as err:
                     if password_signalled_abort:
                         # immediately re-raise
                         raise
@@ -1183,6 +1183,10 @@ def negotiate_sasl(transport, xmlstream,
         try:
             result = yield from sasl_provider.execute(
                 jid, features, xmlstream, transport)
+        except ValueError as err:
+            raise errors.StreamNegotiationFailure(
+                "invalid credentials: {}".format(err)
+            ) from err
         except aiosasl.AuthenticationFailure as err:
             last_auth_error = err
             continue

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -406,6 +406,9 @@ Version 0.10
   :func:`aioxmpp.security_layer.negotiate_sasl` has been deprecated in favour
   of :class:`aioxmpp.protocol.XMLStream`\ -level handling of timeouts.
 
+* Handle :class:`ValueError` raised by :mod:`aiosasl` when the credentials are
+  malformed.
+
 .. _api-changelog-0.9:
 
 Version 0.9


### PR DESCRIPTION
This allows the application to react to malformed credentials.

Follow up work will be done in #217.