### PR TITLE
muc: Always strip the resource part of the direct_jid of a member

### DIFF
--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -178,6 +178,9 @@ class Occupant(aioxmpp.im.conversation.AbstractConversationMember):
         else:
             self._set_uid_from_direct_jid(self._direct_jid)
 
+            if not self._direct_jid.is_bare:
+                raise ValueError("the jid argument must be a bare JID")
+
     def _set_uid_from_direct_jid(self, jid):
         self._uid = b"xmpp:" + str(jid.bare()).encode("utf-8")
 
@@ -229,7 +232,7 @@ class Occupant(aioxmpp.im.conversation.AbstractConversationMember):
         else:
             affiliation = item.affiliation
             role = item.role
-            jid = item.jid
+            jid = item.bare_jid
 
         return cls(
             occupantjid=presence.from_,
@@ -1029,7 +1032,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
                 if (message.xep0045_muc_user and
                         message.xep0045_muc_user.items):
                     item = message.xep0045_muc_user.items[0]
-                    jid = item.jid or None
+                    jid = item.bare_jid
                     affiliation = item.affiliation or None
                     role = item.role or None
                 else:

--- a/aioxmpp/muc/xso.py
+++ b/aioxmpp/muc/xso.py
@@ -384,6 +384,21 @@ class ItemBase(xso.XSO):
         self.role = role
         self.reason = reason
 
+    @property
+    def bare_jid(self):
+        """
+        Return the bare jid of the item or :data:`None` if no JID is
+        given.
+
+        Use this to access the jid unless you really want to know the
+        resource. Usually the information given by the resource is
+        meaningless (the resource is randomly picked by the server).
+        """
+        if self.jid:
+            return self.jid.bare()
+        else:
+            return None
+
 
 class UserActor(ActorBase):
     TAG = (namespaces.xep0045_muc_user, "actor")

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -415,6 +415,11 @@ Version 0.10
   which is used for messages from the bare MUC JID. Such messages are used by
   some implementations for service-originated messages.
 
+* **Minor breaking change**: :attr:`aioxmpp.muc.Occupant.direct_jid`
+  is now always a bare jid. This implies that the resource part of a
+  jid passed in by a muc member item now is always ignored.  Passing a
+  full jid to the constructor now raises a :class:`ValueError`.
+
 .. _api-changelog-0.9:
 
 Version 0.9


### PR DESCRIPTION
Fixes #222.