### PR TITLE
Fix RFC 6120 error condition handling

### DIFF
--- a/aioxmpp/__init__.py
+++ b/aioxmpp/__init__.py
@@ -104,6 +104,7 @@ from .errors import ( # NOQA
     XMPPContinueError,
     XMPPModifyError,
     XMPPWaitError,
+    ErrorCondition,
 )
 from .stanza import Presence, IQ, Message  # NOQA
 from .structs import (  # NOQA

--- a/aioxmpp/adhoc/service.py
+++ b/aioxmpp/adhoc/service.py
@@ -28,6 +28,7 @@ import random
 # from datetime import timedelta
 
 import aioxmpp.disco
+import aioxmpp.errors
 import aioxmpp.disco.xso as disco_xso
 import aioxmpp.service
 import aioxmpp.structs
@@ -262,7 +263,7 @@ class AdHocServer(aioxmpp.service.Service, aioxmpp.disco.Node):
             info = self._commands[stanza.payload.node]
         except KeyError:
             raise aioxmpp.errors.XMPPCancelError(
-                (namespaces.stanzas, "item-not-found"),
+                aioxmpp.errors.ErrorCondition.ITEM_NOT_FOUND,
                 text="no such command: {!r}".format(
                     stanza.payload.node
                 )
@@ -270,7 +271,7 @@ class AdHocServer(aioxmpp.service.Service, aioxmpp.disco.Node):
 
         if not info.is_allowed_for(stanza.from_):
             raise aioxmpp.errors.XMPPCancelError(
-                (namespaces.stanzas, "forbidden"),
+                aioxmpp.errors.ErrorCondition.FORBIDDEN,
             )
 
         return (yield from info.handler(stanza))

--- a/aioxmpp/avatar/service.py
+++ b/aioxmpp/avatar/service.py
@@ -823,8 +823,8 @@ class AvatarService(service.Service):
             # transparently map feature-not-implemented and
             # item-not-found to be equivalent unset avatar
             if e.condition in (
-                    (namespaces.stanzas, "feature-not-implemented"),
-                    (namespaces.stanzas, "item-not-found")):
+                    aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED,
+                    aioxmpp.ErrorCondition.ITEM_NOT_FOUND):
                 return []
             raise
 

--- a/aioxmpp/connector.py
+++ b/aioxmpp/connector.py
@@ -241,7 +241,7 @@ class STARTTLSConnector(BaseConnector):
 
                 protocol.send_stream_error_and_close(
                     stream,
-                    condition=(namespaces.streams, "policy-violation"),
+                    condition=errors.StreamErrorCondition.POLICY_VIOLATION,
                     text=message,
                 )
 

--- a/aioxmpp/disco/service.py
+++ b/aioxmpp/disco/service.py
@@ -449,7 +449,7 @@ class DiscoServer(service.Service, Node):
             node = self._node_mounts[request.node]
         except KeyError:
             raise errors.XMPPModifyError(
-                condition=(namespaces.stanzas, "item-not-found")
+                condition=errors.ErrorCondition.ITEM_NOT_FOUND
             )
 
         response = node.as_info_xso(iq)
@@ -457,7 +457,7 @@ class DiscoServer(service.Service, Node):
 
         if not response.identities:
             raise errors.XMPPModifyError(
-                condition=(namespaces.stanzas, "item-not-found"),
+                condition=errors.ErrorCondition.ITEM_NOT_FOUND,
             )
 
         return response
@@ -473,7 +473,7 @@ class DiscoServer(service.Service, Node):
             node = self._node_mounts[request.node]
         except KeyError:
             raise errors.XMPPModifyError(
-                condition=(namespaces.stanzas, "item-not-found")
+                condition=errors.ErrorCondition.ITEM_NOT_FOUND
             )
 
         response = disco_xso.ItemsQuery()

--- a/aioxmpp/errors.py
+++ b/aioxmpp/errors.py
@@ -232,6 +232,12 @@ class StreamErrorCondition(structs.CompatibilityMixin,
                            xso.XSOEnumMixin,
                            enum.Enum):
     """
+    Enumeration to represent a :rfc:`6120` stream  error condition. Please
+    see :rfc:`6120`, section 4.9.3, for the semantics of the individual
+    conditions.
+
+    .. versionadded:: 0.10
+
     .. attribute:: BAD_FORMAT
         :annotation: = (namespaces.streams, "bad-format")
 
@@ -362,8 +368,9 @@ class XMPPError(StanzaError):
     """
     Exception representing an error defined in the XMPP protocol.
 
-    :param condition: The :rfc:`6120` defined error condition.
-    :type condition: :class:`aioxmpp.ErrorCondition`
+    :param condition: The :rfc:`6120` defined error condition as enumeration
+        member or :class:`aioxmpp.xso.XSO`
+    :type condition: :class:`aioxmpp.ErrorCondition` or :class:`aioxmpp.xso.XSO`
     :param text: Optional human-readable text explaining the error
     :type text: :class:`str`
     :param application_defined_condition: Object describing the error in more
@@ -382,7 +389,7 @@ class XMPPError(StanzaError):
     .. deprecated:: 0.10
 
         Starting with aioxmpp 1.0, namespace-localpart tuples will not be
-        accepted anymore.
+        accepted anymore. See the changelog for notes on the transition.
 
     .. attribute:: condition_obj
 

--- a/aioxmpp/errors.py
+++ b/aioxmpp/errors.py
@@ -28,6 +28,8 @@ Exception classes mapping to XMPP stream errors
 
 .. autoclass:: StreamError
 
+.. autoclass:: StreamErrorCondition
+
 Exception classes mapping to XMPP stanza errors
 ===============================================
 
@@ -36,6 +38,8 @@ Exception classes mapping to XMPP stanza errors
 .. autoclass:: XMPPError
 
 .. currentmodule:: aioxmpp
+
+.. autoclass:: ErrorCondition
 
 .. autoclass:: XMPPAuthError
 
@@ -79,16 +83,20 @@ Other exceptions
 .. autoclass:: GatherError
 
 """
+import enum
 import gettext
+import warnings
 
 from . import xso, i18n, structs
+
+from .utils import namespaces
 
 
 def format_error_text(
         condition,
         text=None,
         application_defined_condition=None):
-    error_tag = xso.tag_to_str(condition)
+    error_tag = xso.tag_to_str(condition.value)
     if application_defined_condition is not None:
         error_tag += "/{}".format(
             xso.tag_to_str(application_defined_condition.TAG)
@@ -98,10 +106,250 @@ def format_error_text(
     return error_tag
 
 
+class ErrorCondition(structs.CompatibilityMixin, xso.XSOEnumMixin, enum.Enum):
+    """
+    Enumeration to represent a :rfc:`6120` stanza error condition. Please
+    see :rfc:`6120`, section 8.3.3, for the semantics of the individual
+    conditions.
+
+    .. versionadded:: 0.10
+
+    .. attribute:: BAD_REQUEST
+        :annotation: = namespaces.stanzas, "bad-request"
+
+    .. attribute:: CONFLICT
+        :annotation: = namespaces.stanzas, "conflict"
+
+    .. attribute:: FEATURE_NOT_IMPLEMENTED
+        :annotation: = namespaces.stanzas, "feature-not-implemented"
+
+    .. attribute:: FORBIDDEN
+        :annotation: = namespaces.stanzas, "forbidden"
+
+    .. attribute:: GONE
+        :annotation: = namespaces.stanzas, "gone"
+
+        .. attribute:: xso_class
+
+            .. attribute:: new_address
+
+                The text content of the ``<gone/>`` element represtenting the
+                URI at which the entity can now be found.
+
+                May be :data:`None` if there is no such URI.
+
+    .. attribute:: INTERNAL_SERVER_ERROR
+        :annotation: = namespaces.stanzas, "internal-server-error"
+
+    .. attribute:: ITEM_NOT_FOUND
+        :annotation: = namespaces.stanzas, "item-not-found"
+
+    .. attribute:: JID_MALFORMED
+        :annotation: = namespaces.stanzas, "jid-malformed"
+
+    .. attribute:: NOT_ACCEPTABLE
+        :annotation: = namespaces.stanzas, "not-acceptable"
+
+    .. attribute:: NOT_ALLOWED
+        :annotation: = namespaces.stanzas, "not-allowed"
+
+    .. attribute:: NOT_AUTHORIZED
+        :annotation: = namespaces.stanzas, "not-authorized"
+
+    .. attribute:: POLICY_VIOLATION
+        :annotation: = namespaces.stanzas, "policy-violation"
+
+    .. attribute:: RECIPIENT_UNAVAILABLE
+        :annotation: = namespaces.stanzas, "recipient-unavailable"
+
+    .. attribute:: REDIRECT
+        :annotation: = namespaces.stanzas, "redirect"
+
+        .. attribute:: xso_class
+
+            .. attribute:: new_address
+
+                The text content of the ``<redirect/>`` element represtenting
+                the URI at which the entity can currently be found.
+
+                May be :data:`None` if there is no such URI.
+
+    .. attribute:: REGISTRATION_REQUIRED
+        :annotation: = namespaces.stanzas, "registration-required"
+
+    .. attribute:: REMOTE_SERVER_NOT_FOUND
+        :annotation: = namespaces.stanzas, "remote-server-not-found"
+
+    .. attribute:: REMOTE_SERVER_TIMEOUT
+        :annotation: = namespaces.stanzas, "remote-server-timeout"
+
+    .. attribute:: RESOURCE_CONSTRAINT
+        :annotation: = namespaces.stanzas, "resource-constraint"
+
+    .. attribute:: SERVICE_UNAVAILABLE
+        :annotation: = namespaces.stanzas, "service-unavailable"
+
+    .. attribute:: SUBSCRIPTION_REQUIRED
+        :annotation: = namespaces.stanzas, "subscription-required"
+
+    .. attribute:: UNDEFINED_CONDITION
+        :annotation: = namespaces.stanzas, "undefined-condition"
+
+    .. attribute:: UNEXPECTED_REQUEST
+        :annotation: = namespaces.stanzas, "unexpected-request"
+
+    """
+
+    BAD_REQUEST = (namespaces.stanzas, "bad-request")
+    CONFLICT = (namespaces.stanzas, "conflict")
+    FEATURE_NOT_IMPLEMENTED = (namespaces.stanzas, "feature-not-implemented")
+    FORBIDDEN = (namespaces.stanzas, "forbidden")
+    GONE = (namespaces.stanzas, "gone")
+    INTERNAL_SERVER_ERROR = (namespaces.stanzas, "internal-server-error")
+    ITEM_NOT_FOUND = (namespaces.stanzas, "item-not-found")
+    JID_MALFORMED = (namespaces.stanzas, "jid-malformed")
+    NOT_ACCEPTABLE = (namespaces.stanzas, "not-acceptable")
+    NOT_ALLOWED = (namespaces.stanzas, "not-allowed")
+    NOT_AUTHORIZED = (namespaces.stanzas, "not-authorized")
+    POLICY_VIOLATION = (namespaces.stanzas, "policy-violation")
+    RECIPIENT_UNAVAILABLE = (namespaces.stanzas, "recipient-unavailable")
+    REDIRECT = (namespaces.stanzas, "redirect")
+    REGISTRATION_REQUIRED = (namespaces.stanzas, "registration-required")
+    REMOTE_SERVER_NOT_FOUND = (namespaces.stanzas, "remote-server-not-found")
+    REMOTE_SERVER_TIMEOUT = (namespaces.stanzas, "remote-server-timeout")
+    RESOURCE_CONSTRAINT = (namespaces.stanzas, "resource-constraint")
+    SERVICE_UNAVAILABLE = (namespaces.stanzas, "service-unavailable")
+    SUBSCRIPTION_REQUIRED = (namespaces.stanzas, "subscription-required")
+    UNDEFINED_CONDITION = (namespaces.stanzas, "undefined-condition")
+    UNEXPECTED_REQUEST = (namespaces.stanzas, "unexpected-request")
+
+
+ErrorCondition.GONE.xso_class.new_address = xso.Text()
+ErrorCondition.REDIRECT.xso_class.new_address = xso.Text()
+
+
+class StreamErrorCondition(structs.CompatibilityMixin,
+                           xso.XSOEnumMixin,
+                           enum.Enum):
+    """
+    .. attribute:: BAD_FORMAT
+        :annotation: = (namespaces.streams, "bad-format")
+
+    .. attribute:: BAD_NAMESPACE_PREFIX
+        :annotation: = (namespaces.streams, "bad-namespace-prefix")
+
+    .. attribute:: CONFLICT
+        :annotation: = (namespaces.streams, "conflict")
+
+    .. attribute:: CONNECTION_TIMEOUT
+        :annotation: = (namespaces.streams, "connection-timeout")
+
+    .. attribute:: HOST_GONE
+        :annotation: = (namespaces.streams, "host-gone")
+
+    .. attribute:: HOST_UNKNOWN
+        :annotation: = (namespaces.streams, "host-unknown")
+
+    .. attribute:: IMPROPER_ADDRESSING
+        :annotation: = (namespaces.streams, "improper-addressing")
+
+    .. attribute:: INTERNAL_SERVER_ERROR
+        :annotation: = (namespaces.streams, "internal-server-error")
+
+    .. attribute:: INVALID_FROM
+        :annotation: = (namespaces.streams, "invalid-from")
+
+    .. attribute:: INVALID_NAMESPACE
+        :annotation: = (namespaces.streams, "invalid-namespace")
+
+    .. attribute:: INVALID_XML
+        :annotation: = (namespaces.streams, "invalid-xml")
+
+    .. attribute:: NOT_AUTHORIZED
+        :annotation: = (namespaces.streams, "not-authorized")
+
+    .. attribute:: NOT_WELL_FORMED
+        :annotation: = (namespaces.streams, "not-well-formed")
+
+    .. attribute:: POLICY_VIOLATION
+        :annotation: = (namespaces.streams, "policy-violation")
+
+    .. attribute:: REMOTE_CONNECTION_FAILED
+        :annotation: = (namespaces.streams, "remote-connection-failed")
+
+    .. attribute:: RESET
+        :annotation: = (namespaces.streams, "reset")
+
+    .. attribute:: RESOURCE_CONSTRAINT
+        :annotation: = (namespaces.streams, "resource-constraint")
+
+    .. attribute:: RESTRICTED_XML
+        :annotation: = (namespaces.streams, "restricted-xml")
+
+    .. attribute:: SEE_OTHER_HOST
+        :annotation: = (namespaces.streams, "see-other-host")
+
+    .. attribute:: SYSTEM_SHUTDOWN
+        :annotation: = (namespaces.streams, "system-shutdown")
+
+    .. attribute:: UNDEFINED_CONDITION
+        :annotation: = (namespaces.streams, "undefined-condition")
+
+    .. attribute:: UNSUPPORTED_ENCODING
+        :annotation: = (namespaces.streams, "unsupported-encoding")
+
+    .. attribute:: UNSUPPORTED_FEATURE
+        :annotation: = (namespaces.streams, "unsupported-feature")
+
+    .. attribute:: UNSUPPORTED_STANZA_TYPE
+        :annotation: = (namespaces.streams, "unsupported-stanza-type")
+
+    .. attribute:: UNSUPPORTED_VERSION
+        :annotation: = (namespaces.streams, "unsupported-version")
+
+    """
+
+    BAD_FORMAT = (namespaces.streams, "bad-format")
+    BAD_NAMESPACE_PREFIX = (namespaces.streams, "bad-namespace-prefix")
+    CONFLICT = (namespaces.streams, "conflict")
+    CONNECTION_TIMEOUT = (namespaces.streams, "connection-timeout")
+    HOST_GONE = (namespaces.streams, "host-gone")
+    HOST_UNKNOWN = (namespaces.streams, "host-unknown")
+    IMPROPER_ADDRESSING = (namespaces.streams, "improper-addressing")
+    INTERNAL_SERVER_ERROR = (namespaces.streams, "internal-server-error")
+    INVALID_FROM = (namespaces.streams, "invalid-from")
+    INVALID_NAMESPACE = (namespaces.streams, "invalid-namespace")
+    INVALID_XML = (namespaces.streams, "invalid-xml")
+    NOT_AUTHORIZED = (namespaces.streams, "not-authorized")
+    NOT_WELL_FORMED = (namespaces.streams, "not-well-formed")
+    POLICY_VIOLATION = (namespaces.streams, "policy-violation")
+    REMOTE_CONNECTION_FAILED = (namespaces.streams, "remote-connection-failed")
+    RESET = (namespaces.streams, "reset")
+    RESOURCE_CONSTRAINT = (namespaces.streams, "resource-constraint")
+    RESTRICTED_XML = (namespaces.streams, "restricted-xml")
+    SEE_OTHER_HOST = (namespaces.streams, "see-other-host")
+    SYSTEM_SHUTDOWN = (namespaces.streams, "system-shutdown")
+    UNDEFINED_CONDITION = (namespaces.streams, "undefined-condition")
+    UNSUPPORTED_ENCODING = (namespaces.streams, "unsupported-encoding")
+    UNSUPPORTED_FEATURE = (namespaces.streams, "unsupported-feature")
+    UNSUPPORTED_STANZA_TYPE = (namespaces.streams, "unsupported-stanza-type")
+    UNSUPPORTED_VERSION = (namespaces.streams, "unsupported-version")
+
+
 class StreamError(ConnectionError):
     def __init__(self, condition, text=None):
+        if not isinstance(condition, StreamErrorCondition):
+            condition = StreamErrorCondition(condition)
+            warnings.warn(
+                "as of aioxmpp 1.0, stream error conditions must be members of "
+                "the aioxmpp.errors.StreamErrorCondition enumeration",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         super().__init__("stream error: {}".format(
-            format_error_text(condition, text)))
+            format_error_text(condition, text))
+        )
         self.condition = condition
         self.text = text
 
@@ -112,6 +360,49 @@ class StanzaError(Exception):
 
 class XMPPError(StanzaError):
     """
+    Exception representing an error defined in the XMPP protocol.
+
+    :param condition: The :rfc:`6120` defined error condition.
+    :type condition: :class:`aioxmpp.ErrorCondition`
+    :param text: Optional human-readable text explaining the error
+    :type text: :class:`str`
+    :param application_defined_condition: Object describing the error in more
+        detail
+    :type application_defined_condition: :class:`aioxmpp.xso.XSO`
+
+    .. versionchanged:: 0.10
+
+        As of 0.10, `condition` should either be a
+        :class:`aioxmpp.ErrorCondition` enumeration member or an XSO
+        representing one of the error conditions.
+
+        For compatibility, namespace-localpart tuples indicating the tag of
+        the defined error condition are still accepted.
+
+    .. deprecated:: 0.10
+
+        Starting with aioxmpp 1.0, namespace-localpart tuples will not be
+        accepted anymore.
+
+    .. attribute:: condition_obj
+
+        The :class:`aioxmpp.XSO` which represents the error condition.
+
+        .. versionadded:: 0.10
+
+    .. autoattribute:: condition
+
+    .. attribute:: text
+
+        Optional human-readable text describing the error further.
+
+        This is :data:`None` if the text is omitted.
+
+    .. attribute:: application_defined_condition
+
+        Optional :class:`aioxmpp.XSO` which further defines the error
+        condition.
+
     Relevant subclasses:
 
     .. autosummary::
@@ -130,13 +421,31 @@ class XMPPError(StanzaError):
                  condition,
                  text=None,
                  application_defined_condition=None):
+        if not isinstance(condition, (ErrorCondition, xso.XSO)):
+            condition = ErrorCondition(condition)
+            warnings.warn(
+                "as of aioxmpp 1.0, error conditions must be members of the "
+                "aioxmpp.ErrorCondition enumeration",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         super().__init__(format_error_text(
-            condition,
+            condition.enum_member,
             text=text,
             application_defined_condition=application_defined_condition))
-        self.condition = condition
+        self.condition_obj = condition.to_xso()
         self.text = text
         self.application_defined_condition = application_defined_condition
+
+    @property
+    def condition(self):
+        """
+        :class:`aioxmpp.ErrorCondition` enumeration member representing the
+        error condition.
+        """
+
+        return self.condition_obj.enum_member
 
 
 class XMPPWarning(XMPPError, UserWarning):

--- a/aioxmpp/errors.py
+++ b/aioxmpp/errors.py
@@ -342,6 +342,9 @@ class StreamErrorCondition(structs.CompatibilityMixin,
     UNSUPPORTED_VERSION = (namespaces.streams, "unsupported-version")
 
 
+StreamErrorCondition.SEE_OTHER_HOST.xso_class.new_address = xso.Text()
+
+
 class StreamError(ConnectionError):
     def __init__(self, condition, text=None):
         if not isinstance(condition, StreamErrorCondition):

--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -281,7 +281,7 @@ def _try_options(options, exceptions,
         except errors.SASLUnavailable as exc:
             protocol.send_stream_error_and_close(
                 xmlstream,
-                condition=(namespaces.streams, "policy-violation"),
+                condition=errors.StreamErrorCondition.POLICY_VIOLATION,
                 text=str(exc),
             )
             exceptions.append(exc)
@@ -289,7 +289,7 @@ def _try_options(options, exceptions,
         except Exception as exc:
             protocol.send_stream_error_and_close(
                 xmlstream,
-                condition=(namespaces.streams, "undefined-condition"),
+                condition=errors.StreamErrorCondition.UNDEFINED_CONDITION,
                 text=str(exc),
             )
             raise
@@ -988,7 +988,7 @@ class Client:
                 try:
                     yield from self._main_impl()
                 except errors.StreamError as err:
-                    if err.condition == (namespaces.streams, "conflict"):
+                    if err.condition == errors.StreamErrorCondition.CONFLICT:
                         self.logger.debug("conflict!")
                         raise
                 except (errors.StreamNegotiationFailure,

--- a/aioxmpp/nonza.py
+++ b/aioxmpp/nonza.py
@@ -86,6 +86,7 @@ Stream management related XSOs
 
 """
 import itertools
+import warnings
 
 from . import xso, errors, stanza
 
@@ -114,46 +115,48 @@ class StreamError(xso.XSO):
         tag=(namespaces.streams, "text"),
         attr_policy=xso.UnknownAttrPolicy.DROP,
         default=None,
-        declare_prefix=None)
-    condition = xso.ChildTag(
-        tags=[
-            "bad-format",
-            "bad-namespace-prefix",
-            "conflict",
-            "connection-timeout",
-            "host-gone",
-            "host-unknown",
-            "improper-addressing",
-            "internal-server-error",
-            "invalid-from",
-            "invalid-namespace",
-            "invalid-xml",
-            "not-authorized",
-            "not-well-formed",
-            "policy-violation",
-            "remote-connection-failed",
-            "reset",
-            "resource-constraint",
-            "restricted-xml",
-            "see-other-host",
-            "system-shutdown",
-            "undefined-condition",
-            "unsupported-encoding",
-            "unsupported-feature",
-            "unsupported-stanza-type",
-            "unsupported-version",
-        ],
-        default_ns=namespaces.streams,
-        allow_none=False,
-        declare_prefix=None,
+        declare_prefix=None
+    )
+
+    condition_obj = xso.Child(
+        [member.xso_class for member in errors.StreamErrorCondition],
+        required=True,
     )
 
     def __init__(self,
-                 condition=(namespaces.streams, "undefined-condition"),
+                 condition=errors.StreamErrorCondition.UNDEFINED_CONDITION,
                  text=None):
         super().__init__()
-        self.condition = condition
+        if not isinstance(condition, errors.StreamErrorCondition):
+            condition = errors.StreamErrorCondition(condition)
+            warnings.warn(
+                "as of aioxmpp 1.0, stream error conditions must be members "
+                "of the aioxmpp.errors.StreamErrorCondition enumeration",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self.condition_obj = condition.xso_class()
         self.text = text
+
+    @property
+    def condition(self):
+        return self.condition_obj.enum_member
+
+    @condition.setter
+    def condition(self, value):
+        if not isinstance(value, errors.StreamErrorCondition):
+            value = errors.StreamErrorCondition(value)
+            warnings.warn(
+                "as of aioxmpp 1.0, stream error conditions must be members "
+                "of the aioxmpp.errors.StreamErrorCondition enumeration",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if self.condition == value:
+            return
+        self.condition_obj = value.xso_class()
 
     @classmethod
     def from_exception(cls, exc):
@@ -165,7 +168,8 @@ class StreamError(xso.XSO):
     def to_exception(self):
         return errors.StreamError(
             condition=self.condition,
-            text=self.text)
+            text=self.text
+        )
 
 
 class StreamFeatures(xso.XSO):
@@ -752,19 +756,16 @@ class SMFailed(SMXSO):
     """
     TAG = (namespaces.stream_management, "failed")
 
-    condition = xso.ChildTag(
-        tags=stanza.STANZA_ERROR_TAGS,
-        default_ns=namespaces.stanzas,
-        allow_none=False,
-        declare_prefix=None,
+    condition = xso.Child(
+        [member.xso_class for member in errors.ErrorCondition],
+        required=True,
     )
 
     def __init__(self,
-                 condition=(namespaces.stanzas, "undefined-condition"),
+                 condition=errors.ErrorCondition.ITEM_NOT_FOUND,
                  **kwargs):
         super().__init__(**kwargs)
-        if condition is not None:
-            self.condition = condition
+        self.condition = condition.to_xso()
 
     def __repr__(self):
         return "<{}.{} condition={!r} at 0x{:x}>".format(

--- a/aioxmpp/nonza.py
+++ b/aioxmpp/nonza.py
@@ -762,7 +762,7 @@ class SMFailed(SMXSO):
     )
 
     def __init__(self,
-                 condition=errors.ErrorCondition.ITEM_NOT_FOUND,
+                 condition=errors.ErrorCondition.UNDEFINED_CONDITION,
                  **kwargs):
         super().__init__(**kwargs)
         self.condition = condition.to_xso()

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -548,7 +548,7 @@ class XMLStream(asyncio.Protocol):
                 return
 
             raise errors.StreamError(
-                condition=(namespaces.streams, "unsupported-stanza-type"),
+                condition=errors.StreamErrorCondition.UNSUPPORTED_STANZA_TYPE,
                 text="unsupported stanza: {}".format(
                     xso.tag_to_str((exc.ev_args[0], exc.ev_args[1]))
                 )) from None
@@ -559,8 +559,9 @@ class XMLStream(asyncio.Protocol):
     def _rx_stream_header(self):
         if self._processor.remote_version != (1, 0):
             raise errors.StreamError(
-                (namespaces.streams, "unsupported-version"),
-                text="unsupported version")
+                errors.StreamErrorCondition.UNSUPPORTED_VERSION,
+                text="unsupported version"
+            )
         self._smachine.state = State.OPEN
 
     def _rx_stream_error(self, err):
@@ -593,7 +594,7 @@ class XMLStream(asyncio.Protocol):
                 # this will raise an appropriate stream error
                 xml.XMPPLexicalHandler.startEntity("foo")
             raise errors.StreamError(
-                condition=(namespaces.streams, "bad-format"),
+                condition=errors.StreamErrorCondition.BAD_FORMAT,
                 text=str(exc)
             )
         except errors.StreamError as exc:
@@ -603,7 +604,7 @@ class XMLStream(asyncio.Protocol):
                 "unexpected exception while parsing stanza"
                 " bubbled up through parser. stream so ded.")
             raise errors.StreamError(
-                condition=(namespaces.streams, "internal-server-error"),
+                condition=errors.StreamErrorCondition.INTERNAL_SERVER_ERROR,
                 text="Internal error while parsing XML. Client logs have more"
                      " details."
             )

--- a/aioxmpp/roster/service.py
+++ b/aioxmpp/roster/service.py
@@ -475,7 +475,7 @@ class RosterClient(aioxmpp.service.Service):
     @asyncio.coroutine
     def handle_roster_push(self, iq):
         if iq.from_ and iq.from_ != self.client.local_jid.bare():
-            raise errors.XMPPAuthError((namespaces.stanzas, "forbidden"))
+            raise errors.XMPPAuthError(errors.ErrorCondition.FORBIDDEN)
 
         request = iq.payload
 

--- a/aioxmpp/stanza.py
+++ b/aioxmpp/stanza.py
@@ -82,37 +82,13 @@ Exceptions
 import base64
 import enum
 import random
+import warnings
 
 from . import xso, errors, structs
 
 from .utils import namespaces
 
 RANDOM_ID_BYTES = 120 // 8
-
-STANZA_ERROR_TAGS = (
-    "bad-request",
-    "conflict",
-    "feature-not-implemented",
-    "forbidden",
-    "gone",
-    "internal-server-error",
-    "item-not-found",
-    "jid-malformed",
-    "not-acceptable",
-    "not-allowed",
-    "not-authorized",
-    "policy-violation",
-    "recipient-unavailable",
-    "redirect",
-    "registration-required",
-    "remote-server-not-found",
-    "remote-server-timeout",
-    "resource-constraint",
-    "service-unavailable",
-    "subscription-required",
-    "undefined-condition",
-    "unexpected-request",
-)
 
 
 def _safe_format_attr(obj, attr_name):
@@ -205,6 +181,13 @@ class Error(xso.XSO):
     An XMPP stanza error. The keyword arguments can be used to initialize the
     attributes of the :class:`Error`.
 
+    :param condition: The error condition
+    :type condition: :class:`aioxmpp.ErrorCondition` or :class:`aioxmpp.xso.XSO`
+    :param type_: The type of the error
+    :type type_: :class:`aioxmpp.ErrorType`
+    :param text: The optional error text
+    :type text: :class:`str` or :data:`None`
+
     .. attribute:: type_
 
        The type attribute of the stanza. The allowed values are enumerated in
@@ -234,6 +217,32 @@ class Error(xso.XSO):
        The standard defined condition which triggered the error. Possible
        values can be determined by looking at the RFC or the source.
 
+       This is a member of the :class:`aioxmpp.ErrorCondition` enumeration.
+
+       .. versionchanged:: 0.10
+
+          Starting with 0.10, the enumeration :class:`aioxmpp.ErrorCondition` is
+          used. Before, tuples equal to the tags of the child elements were
+          used (e.g. ``(namespaces.stanzas, "bad-request")``).
+
+          As of 0.10, setting the tuple equivalents is still supported.
+          However, reading from the attribute always returns the corresponding
+          enumeration members (which still compare equal to their tuple
+          equivalents).
+
+       .. deprecated:: 0.10
+
+          The use of the aforementioned tuple values is deprecated and will
+          lead to :exc:`TypeError` and/or :exc:`ValueError` being raised when
+          they are written to this attribute.
+
+    .. attribute:: condition_obj
+
+        An XSO object representing the child element representing the
+        :rfc:`6120` defined error condition.
+
+        .. versionadded:: 0.10
+
     .. attribute:: text
 
        The descriptive error text which is part of the error stanza, if any
@@ -246,12 +255,18 @@ class Error(xso.XSO):
 
     .. attribute:: application_condition
 
-       A :class:`.xso.XSO.Child` which can be used to register support for
-       application-specific errors.
+       Optional child :class:`~aioxmpp.xso.XSO` which describes the error
+       condition in more application specific detail.
 
     To register a class as application condition, use:
 
     .. automethod:: as_application_condition
+
+    Conversion to and from exceptions is supported with the following methods:
+
+    .. automethod:: to_exception
+
+    .. automethod:: from_exception
 
     """
 
@@ -287,39 +302,97 @@ class Error(xso.XSO):
         declare_prefix=None
     )
 
-    condition = xso.ChildTag(
-        tags=STANZA_ERROR_TAGS,
-        default_ns="urn:ietf:params:xml:ns:xmpp-stanzas",
-        allow_none=False,
-        declare_prefix=None,
+    condition_obj = xso.Child(
+        [member.xso_class for member in errors.ErrorCondition],
+        required=True,
     )
 
     application_condition = xso.Child([], required=False)
 
     def __init__(self,
-                 condition=(namespaces.stanzas, "undefined-condition"),
+                 condition=errors.ErrorCondition.UNDEFINED_CONDITION,
                  type_=structs.ErrorType.CANCEL,
                  text=None):
         super().__init__()
-        self.condition = condition
+        if not isinstance(condition, (errors.ErrorCondition, xso.XSO)):
+            condition = errors.ErrorCondition(condition)
+            warnings.warn(
+                "as of aioxmpp 1.0, error conditions must be members of the "
+                "aioxmpp.ErrorCondition enumeration",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self.condition_obj = condition.to_xso()
         self.type_ = type_
         self.text = text
 
+    @property
+    def condition(self):
+        return self.condition_obj.enum_member
+
+    @condition.setter
+    def condition(self, value):
+        if not isinstance(value, errors.ErrorCondition):
+            value = errors.ErrorCondition(value)
+            warnings.warn(
+                "as of aioxmpp 1.0, error conditions must be members of the "
+                "aioxmpp.ErrorCondition enumeration",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if self.condition == value:
+            return
+
+        self.condition_obj = value.xso_class()
+
     @classmethod
     def from_exception(cls, exc):
-        return cls(
+        """
+        Construct a new :class:`Error` payload from the attributes of the
+        exception.
+
+        :param exc: The exception to convert
+        :type exc: :class:`aioxmpp.errors.XMPPError`
+        :result: Newly constructed error payload
+        :rtype: :class:`Error`
+
+        .. versionchanged:: 0.10
+
+            The :attr:`aioxmpp.XMPPError.application_defined_condition` is now
+            taken over into the result.
+        """
+        result = cls(
             condition=exc.condition,
             type_=exc.TYPE,
             text=exc.text
         )
+        result.application_condition = exc.application_defined_condition
+        return result
 
     def to_exception(self):
+        """
+        Convert the error payload to a :class:`~aioxmpp.errors.XMPPError`
+        subclass.
+
+        :result: Newly constructed exception
+        :rtype: :class:`aioxmpp.errors.XMPPError`
+
+        The exact type of the result depends on the :attr:`type_` (see
+        :class:`~aioxmpp.errors.XMPPError` about the existing subclasses).
+
+        The :attr:`condition_obj`, :attr:`text` and
+        :attr:`application_condition` are transferred to the respective
+        attributes of the :class:`~aioxmpp.errors.XMPPError`.
+        """
         if hasattr(self.application_condition, "to_exception"):
             result = self.application_condition.to_exception(self.type_)
             if isinstance(result, Exception):
                 return result
+
         return self.EXCEPTION_CLS_MAP[self.type_](
-            condition=self.condition,
+            condition=self.condition_obj,
             text=self.text,
             application_defined_condition=self.application_condition,
         )
@@ -347,7 +420,7 @@ class Error(xso.XSO):
             payload = " text={!r}".format(self.text)
 
         return "<{} type={!r}{}>".format(
-            self.condition[1],
+            self.condition.value[1],
             self.type_,
             payload)
 

--- a/aioxmpp/stanza.py
+++ b/aioxmpp/stanza.py
@@ -181,7 +181,7 @@ class Error(xso.XSO):
     An XMPP stanza error. The keyword arguments can be used to initialize the
     attributes of the :class:`Error`.
 
-    :param condition: The error condition
+    :param condition: The error condition as enumeration member or XSO.
     :type condition: :class:`aioxmpp.ErrorCondition` or :class:`aioxmpp.xso.XSO`
     :param type_: The type of the error
     :type type_: :class:`aioxmpp.ErrorType`
@@ -234,7 +234,8 @@ class Error(xso.XSO):
 
           The use of the aforementioned tuple values is deprecated and will
           lead to :exc:`TypeError` and/or :exc:`ValueError` being raised when
-          they are written to this attribute.
+          they are written to this attribute. See the changelog for notes on
+          the transition.
 
     .. attribute:: condition_obj
 

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -944,7 +944,7 @@ class StanzaStream:
         except Exception:
             response = request.make_reply(type_=structs.IQType.ERROR)
             response.error = stanza.Error(
-                condition=(namespaces.stanzas, "undefined-condition"),
+                condition=errors.ErrorCondition.UNDEFINED_CONDITION,
                 type_=structs.ErrorType.CANCEL,
             )
             self._logger.exception("IQ request coroutine failed")
@@ -996,8 +996,7 @@ class StanzaStream:
                 )
                 response = stanza_obj.make_reply(type_=structs.IQType.ERROR)
                 response.error = stanza.Error(
-                    condition=(namespaces.stanzas,
-                               "service-unavailable"),
+                    condition=errors.ErrorCondition.SERVICE_UNAVAILABLE,
                 )
                 self._enqueue(response)
                 return
@@ -1094,15 +1093,13 @@ class StanzaStream:
                     except KeyError:
                         pass
         elif isinstance(exc, stanza.UnknownIQPayload):
-            reply = stanza_obj.make_error(error=stanza.Error(condition=(
-                namespaces.stanzas,
-                "service-unavailable")
+            reply = stanza_obj.make_error(error=stanza.Error(
+                condition=errors.ErrorCondition.SERVICE_UNAVAILABLE
             ))
             self._enqueue(reply)
         elif isinstance(exc, stanza.PayloadParsingError):
-            reply = stanza_obj.make_error(error=stanza.Error(condition=(
-                namespaces.stanzas,
-                "bad-request")
+            reply = stanza_obj.make_error(error=stanza.Error(
+                condition=errors.ErrorCondition.BAD_REQUEST
             ))
             self._enqueue(reply)
 

--- a/aioxmpp/structs.py
+++ b/aioxmpp/structs.py
@@ -94,8 +94,8 @@ class CompatibilityMixin:
             return True
         if self.value == other:
             warnings.warn(
-                "as of aioxmpp 1.0, enums will not compare equal to their "
-                "values",
+                "as of aioxmpp 1.0, {} members will not compare equal to their "
+                "values".format(type(self).__name__),
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/aioxmpp/vcard/service.py
+++ b/aioxmpp/vcard/service.py
@@ -64,8 +64,8 @@ class VCardService(service.Service):
             return (yield from self.client.send(iq))
         except aioxmpp.XMPPCancelError as e:
             if e.condition in (
-                    (namespaces.stanzas, "feature-not-implemented"),
-                    (namespaces.stanzas, "item-not-found")):
+                    aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED,
+                    aioxmpp.ErrorCondition.ITEM_NOT_FOUND):
                 return vcard_xso.VCard()
             else:
                 raise

--- a/aioxmpp/version/service.py
+++ b/aioxmpp/version/service.py
@@ -24,6 +24,7 @@ import typing
 
 import aioxmpp
 import aioxmpp.disco
+import aioxmpp.errors
 import aioxmpp.service
 
 from aioxmpp.utils import namespaces
@@ -172,7 +173,7 @@ class VersionServer(aioxmpp.service.Service):
     def handle_query(self, iq: aioxmpp.IQ) -> version_xso.Query:
         if self._name is None:
             raise aioxmpp.errors.XMPPCancelError(
-                (namespaces.stanzas, "service-unavailable")
+                aioxmpp.errors.ErrorCondition.SERVICE_UNAVAILABLE,
             )
 
         result = version_xso.Query()

--- a/aioxmpp/xml.py
+++ b/aioxmpp/xml.py
@@ -887,7 +887,7 @@ class XMPPXMLProcessor:
 
     def processingInstruction(self, target, foo):
         raise errors.StreamError(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             "processing instructions are not allowed in XMPP"
         )
 
@@ -943,7 +943,7 @@ class XMPPXMLProcessor:
 
         if name != (namespaces.xmlstream, "stream"):
             raise errors.StreamError(
-                (namespaces.streams, "invalid-namespace"),
+                errors.StreamErrorCondition.INVALID_NAMESPACE,
                 "stream has invalid namespace or localname"
             )
 
@@ -954,7 +954,7 @@ class XMPPXMLProcessor:
             )
         except ValueError as exc:
             raise errors.StreamError(
-                (namespaces.streams, "unsupported-version"),
+                errors.StreamErrorCondition.UNSUPPORTED_VERSION,
                 str(exc)
             )
 
@@ -969,14 +969,14 @@ class XMPPXMLProcessor:
             )
         except KeyError:
             raise errors.StreamError(
-                (namespaces.streams, "undefined-condition"),
+                errors.StreamErrorCondition.UNDEFINED_CONDITION,
                 "from attribute required in response header"
             )
         try:
             self.remote_id = attributes.pop((None, "id"))
         except KeyError:
             raise errors.StreamError(
-                (namespaces.streams, "undefined-condition"),
+                errors.StreamErrorCondition.UNDEFINED_CONDITION,
                 "id attribute required in response header"
             )
 
@@ -1048,14 +1048,14 @@ class XMPPLexicalHandler:
     @classmethod
     def comment(cls, data):
         raise errors.StreamError(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             "comments are not allowed in XMPP"
         )
 
     @classmethod
     def startDTD(cls, name, publicId, systemId):
         raise errors.StreamError(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             "DTD declarations are not allowed in XMPP"
         )
 
@@ -1075,7 +1075,7 @@ class XMPPLexicalHandler:
     def startEntity(cls, name):
         if name not in cls.PREDEFINED_ENTITIES:
             raise errors.StreamError(
-                (namespaces.streams, "restricted-xml"),
+                errors.StreamErrorCondition.RESTRICTED_XML,
                 "non-predefined entities are not allowed in XMPP"
             )
 

--- a/aioxmpp/xso/__init__.py
+++ b/aioxmpp/xso/__init__.py
@@ -188,6 +188,10 @@ data. It also provides a class method for late registration of child classes.
 
 .. currentmodule:: aioxmpp.xso
 
+To create an enumeration of XSO classes, the following mixin can be used:
+
+.. autoclass:: XSOEnumMixin
+
 Functions, enumerations and exceptions
 --------------------------------------
 
@@ -538,6 +542,7 @@ from .model import (  # NOQA
     XSOParser,
     SAXDriver,
     XSO,
+    XSOEnumMixin,
     CapturingXSO,
     lang_attr,
     capture_events,

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -2696,6 +2696,10 @@ class XSOEnumMixin:
     strings. Each enumeration member is equipped with an :attr:`xso_class`
     attribute at definition time.
 
+    .. automethod:: to_xso
+
+    .. autoattribute:: enum_member
+
     .. attribute:: xso_class
 
         A :class:`aioxmpp.xso.XSO` *subclass* which has the enumeration members
@@ -2705,10 +2709,19 @@ class XSOEnumMixin:
         The class does not have any XSO descriptors assigned. They can be added
         after class definition.
 
-        The :attr:`xso_class.member_enum` attribute is set to the enum member
-        to which this class belongs. This means that for any XSO instance for
-        any of the enum member classes, the enumeration member can be obtained
-        by accessing the :attr:`member_enum` attribute.
+        .. attribute:: enum_member
+
+            The enumeration member to which the :attr:`xso_class` belongs.
+
+            This allows to use XSOs and enumeration members more exchangably;
+            see :attr:`enum_member` for details.
+
+        .. method:: to_xso
+
+            Return the XSO itself.
+
+            This allows to use XSOs and enumeration members more exchangably;
+            see :meth:`to_xso` for details.
 
     Example usage::
 
@@ -2749,6 +2762,9 @@ class XSOEnumMixin:
         return "".join(map(str.title, self.name.split("_")))
 
     def _create_class(self):
+        def to_xso(self):
+            return self
+
         return XMLStreamClass(
             self._create_name(),
             (XSO,),
@@ -2759,5 +2775,35 @@ class XSOEnumMixin:
                     self.name,
                 ),
                 "enum_member": self,
+                "to_xso": to_xso,
             },
         )
+
+    @property
+    def enum_member(self):
+        """
+        The object (enum member) itself.
+
+        This property exists to make it easier to use the XSO objects and the
+        enumeration members exchangably. The XSO objects also have the
+        :attr:`enum_member` property to obtain the enumeration member to which
+        they belong. Code which is only interested in the enumeration member
+        can thus access the :attr:`enum_member` attribute to "coerce" both
+        (enumeration members and instances of their XSO classes) into
+        enumeration members.
+        """
+        return self
+
+    def to_xso(self):
+        """
+        A new instance of the :attr:`xso_class`.
+
+        This method exists to make it easier to use the XSO objects and the
+        enumeration members exchangably. The XSO objects also have the
+        :meth:`to_xso` method which just returns the XSO unmodified.
+
+        Code which needs an XSO, but does not care about the data, can thus use
+        the :meth:`to_xso` method to "coerce" either (enumeration members and
+        instances of their XSO classes) into XSOs.
+        """
+        return self.xso_class()

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -2713,15 +2713,15 @@ class XSOEnumMixin:
 
             The enumeration member to which the :attr:`xso_class` belongs.
 
-            This allows to use XSOs and enumeration members more exchangably;
-            see :attr:`enum_member` for details.
+            This allows to use XSOs and enumeration members more
+            interchangeably; see :attr:`enum_member` for details.
 
         .. method:: to_xso
 
             Return the XSO itself.
 
-            This allows to use XSOs and enumeration members more exchangably;
-            see :meth:`to_xso` for details.
+            This allows to use XSOs and enumeration members more
+            interchangeably; see :meth:`to_xso` for details.
 
     Example usage::
 
@@ -2785,7 +2785,7 @@ class XSOEnumMixin:
         The object (enum member) itself.
 
         This property exists to make it easier to use the XSO objects and the
-        enumeration members exchangably. The XSO objects also have the
+        enumeration members interchangeably. The XSO objects also have the
         :attr:`enum_member` property to obtain the enumeration member to which
         they belong. Code which is only interested in the enumeration member
         can thus access the :attr:`enum_member` attribute to "coerce" both
@@ -2799,7 +2799,7 @@ class XSOEnumMixin:
         A new instance of the :attr:`xso_class`.
 
         This method exists to make it easier to use the XSO objects and the
-        enumeration members exchangably. The XSO objects also have the
+        enumeration members interchangeably. The XSO objects also have the
         :meth:`to_xso` method which just returns the XSO unmodified.
 
         Code which needs an XSO, but does not care about the data, can thus use

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -424,6 +424,8 @@ Version 0.10
 
 * :mod:`aioxmpp.httpupload`
 
+* :class:`aioxmpp.xso.XSOEnumMixin`
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -426,6 +426,64 @@ Version 0.10
 
 * :class:`aioxmpp.xso.XSOEnumMixin`
 
+* **Considerably breaking change**: Converted stanza and stream error conditions
+  to enumerations based on :class:`aioxmpp.xso.XSOEnumMixin`.
+
+  This is similar to the transition in the 0.7 release. The following
+  attributes, methods and constructors now expect enumeration members instead
+  of tuples:
+
+  * :class:`aioxmpp.stanza.Error`, the `condition` argument
+  * :attr:`aioxmpp.stanza.Error.condition`
+  * :attr:`aioxmpp.nonza.StreamError.condition`
+  * :class:`aioxmpp.errors.XMPPError` (and its subclasses), the `condition`
+    argument
+  * :attr:`aioxmpp.errors.XMPPError.condition`
+
+  To simplify the transition, the enumerations will compare equal to the
+  equivalent tuples until the release of 1.0.
+
+  The affected code locations can be found with the
+  ``utils/find-v0.10-type-transition.sh`` script. It finds all tuples which
+  form error conditions. In addition, :class:`DeprecationWarning` type warnings
+  are emitted in the following cases:
+
+  * Enumeration member compared to tuple
+  * Tuple assigned to attribute or passed to method where an enumeration member
+    is expected
+
+  To make those warnings fatal, use the following code at the start of your
+  application::
+
+        import warnings
+        warnings.filterwarnings(
+            # make the warnings fatal
+            "error",
+            # match only deprecation warnings
+            category=DeprecationWarning,
+            # match only warnings concerning the ErrorCondition and
+            # StreamErrorCondition enumerations
+            message=".+(Stream)?ErrorCondition",
+        )
+
+* The original and complete XSO of the error condition is now available on
+  :attr:`aioxmpp.stanza.Error.condition_obj`. This allows to access additional
+  data in error conditions, such as in the case of the
+  :attr:`aioxmpp.ErrorCondition.GONE` error.
+
+  The same holds for :attr:`aioxmpp.errors.XMPPError.condition_obj`.
+
+* The constructors of :class:`aioxmpp.stanza.Error` and
+  :class:`aioxmpp.errors.XMPPError` (and subclasses) now accept either a
+  member of the :class:`aioxmpp.ErrorCondition` enumeration or an instance of
+  the respective XSO. This allows to attach additional data to error conditions
+  which support this, such as the :attr:`aioxmpp.ErrorCondition.GONE` error.
+
+* :attr:`aioxmpp.errors.XMPPError.application_defined_condition` is now attached
+  to :attr:`aioxmpp.stanza.Error.application_condition` when
+  :meth:`aioxmpp.stanza.Error.from_exception` is used.
+
+
 .. _api-changelog-0.9:
 
 Version 0.9

--- a/tests/adhoc/test_e2e.py
+++ b/tests/adhoc/test_e2e.py
@@ -21,6 +21,7 @@
 ########################################################################
 import asyncio
 
+import aioxmpp
 import aioxmpp.adhoc
 
 from aioxmpp.utils import namespaces
@@ -228,7 +229,7 @@ class TestAdHocServer(TestCase):
     @blocking_timed
     @asyncio.coroutine
     def test_properly_fail_for_unknown_command(self):
-        with self.assertRaises(aioxmpp.errors.XMPPCancelError) as ctx:
+        with self.assertRaises(aioxmpp.XMPPCancelError) as ctx:
             session = yield from self.client_svc.execute(
                 self.server.local_jid,
                 "simple",
@@ -236,5 +237,5 @@ class TestAdHocServer(TestCase):
 
         self.assertEqual(
             ctx.exception.condition,
-            (namespaces.stanzas, "item-not-found")
+            aioxmpp.ErrorCondition.ITEM_NOT_FOUND
         )

--- a/tests/adhoc/test_service.py
+++ b/tests/adhoc/test_service.py
@@ -26,6 +26,7 @@ import unittest.mock
 
 from datetime import timedelta
 
+import aioxmpp
 import aioxmpp.service
 
 import aioxmpp.adhoc.service as adhoc_service
@@ -489,7 +490,7 @@ class TestAdHocServer(unittest.TestCase):
 
         self.assertEqual(
             ctx.exception.condition,
-            (namespaces.stanzas, "item-not-found"),
+            aioxmpp.ErrorCondition.ITEM_NOT_FOUND,
         )
 
         self.assertRegex(
@@ -526,7 +527,7 @@ class TestAdHocServer(unittest.TestCase):
 
         self.assertEqual(
             ctx.exception.condition,
-            (namespaces.stanzas, "forbidden"),
+            aioxmpp.ErrorCondition.FORBIDDEN,
         )
 
         handler.assert_not_called()
@@ -930,7 +931,7 @@ class TestClientSession(unittest.TestCase):
         self.send_iq_and_wait_for_reply.mock_calls.clear()
 
         exc = aioxmpp.errors.XMPPModifyError(
-            (namespaces.stanzas, "bad-request"),
+            aioxmpp.ErrorCondition.BAD_REQUEST,
             text="Bad Session",
             application_defined_condition=adhoc_xso.BadSessionID(),
         )
@@ -961,7 +962,7 @@ class TestClientSession(unittest.TestCase):
         self.send_iq_and_wait_for_reply.mock_calls.clear()
 
         exc = aioxmpp.errors.XMPPCancelError(
-            (namespaces.stanzas, "not-allowed"),
+            aioxmpp.ErrorCondition.NOT_ALLOWED,
             text="Session Expired",
             application_defined_condition=adhoc_xso.SessionExpired(),
         )
@@ -992,7 +993,7 @@ class TestClientSession(unittest.TestCase):
         self.send_iq_and_wait_for_reply.mock_calls.clear()
 
         exc = aioxmpp.errors.XMPPCancelError(
-            (namespaces.stanzas, "feature-not-implemented"),
+            aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED,
         )
         self.send_iq_and_wait_for_reply.side_effect = exc
 
@@ -1019,7 +1020,7 @@ class TestClientSession(unittest.TestCase):
         self.send_iq_and_wait_for_reply.mock_calls.clear()
 
         exc = aioxmpp.errors.XMPPModifyError(
-            (namespaces.stanzas, "bad-request"),
+            aioxmpp.ErrorCondition.BAD_REQUEST,
         )
         self.send_iq_and_wait_for_reply.side_effect = exc
 

--- a/tests/avatar/test_service.py
+++ b/tests/avatar/test_service.py
@@ -1001,7 +1001,7 @@ class TestAvatarService(unittest.TestCase):
             self.vcard.get_vcard.return_value = vcard_mock
 
             self.pubsub.get_items.side_effect = errors.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                errors.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
 
             res = run_coroutine(self.s.get_avatar_metadata(TEST_JID1))
@@ -1039,7 +1039,7 @@ class TestAvatarService(unittest.TestCase):
             self.vcard.get_vcard.return_value = vcard_mock
 
             self.pubsub.get_items.side_effect = errors.XMPPCancelError(
-                (namespaces.stanzas, "item-not-found")
+                errors.ErrorCondition.ITEM_NOT_FOUND
             )
 
             res = run_coroutine(self.s.get_avatar_metadata(TEST_JID2))
@@ -1077,7 +1077,7 @@ class TestAvatarService(unittest.TestCase):
             self.vcard.get_vcard.return_value = vcard_mock
 
             self.pubsub.get_items.side_effect = errors.XMPPCancelError(
-                (namespaces.stanzas, "item-not-found")
+                errors.ErrorCondition.ITEM_NOT_FOUND
             )
 
             res = run_coroutine(self.s.get_avatar_metadata(TEST_JID3))

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -742,7 +742,7 @@ class TestDiscoServer(unittest.TestCase):
             run_coroutine(self.s.handle_info_request(self.request_iq))
 
         self.assertEqual(
-            (namespaces.stanzas, "item-not-found"),
+            errors.ErrorCondition.ITEM_NOT_FOUND,
             ctx.exception.condition
         )
 
@@ -1307,7 +1307,7 @@ class TestDiscoClient(unittest.TestCase):
             ncall += 1
             if ncall == 1:
                 raise errors.XMPPCancelError(
-                    condition=(namespaces.stanzas, "feature-not-implemented"),
+                    condition=errors.ErrorCondition.FEATURE_NOT_IMPLEMENTED
                 )
             else:
                 raise ConnectionError()
@@ -1338,7 +1338,7 @@ class TestDiscoClient(unittest.TestCase):
                 "send_and_decode_info_query",
                 new=CoroutineMock()) as send_and_decode:
             send_and_decode.side_effect = errors.XMPPCancelError(
-                condition=(namespaces.stanzas, "feature-not-implemented"),
+                condition=errors.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
 
             with self.assertRaises(errors.XMPPCancelError):
@@ -1633,7 +1633,7 @@ class TestDiscoClient(unittest.TestCase):
             ncall += 1
             if ncall == 1:
                 raise errors.XMPPCancelError(
-                    condition=(namespaces.stanzas, "feature-not-implemented"),
+                    condition=errors.ErrorCondition.FEATURE_NOT_IMPLEMENTED
                 )
             else:
                 raise ConnectionError()
@@ -1661,7 +1661,7 @@ class TestDiscoClient(unittest.TestCase):
 
         self.cc.send.side_effect = \
             errors.XMPPCancelError(
-                condition=(namespaces.stanzas, "feature-not-implemented"),
+                condition=errors.ErrorCondition.FEATURE_NOT_IMPLEMENTED,
             )
 
         with self.assertRaises(errors.XMPPCancelError):

--- a/tests/im/test_dispatcher.py
+++ b/tests/im/test_dispatcher.py
@@ -299,7 +299,7 @@ class TestIMDispatcher(unittest.TestCase):
                 "enable",
                 new=CoroutineMock()) as enable:
             enable.side_effect = aioxmpp.errors.XMPPError(
-                (namespaces.stanzas, "foo")
+                aioxmpp.ErrorCondition.REMOTE_SERVER_NOT_FOUND
             )
             run_coroutine(self.s.enable_carbons())
 

--- a/tests/muc/test_service.py
+++ b/tests/muc/test_service.py
@@ -27,6 +27,7 @@ import uuid
 
 from datetime import datetime, timedelta
 
+import aioxmpp
 import aioxmpp.callbacks
 import aioxmpp.errors
 import aioxmpp.forms
@@ -2607,7 +2608,7 @@ class TestRoom(unittest.TestCase):
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
             send_iq.side_effect = aioxmpp.errors.XMPPCancelError(
-                condition=(utils.namespaces.stanzas, "forbidden")
+                condition=aioxmpp.ErrorCondition.FORBIDDEN
             )
 
             with self.assertRaises(aioxmpp.errors.XMPPCancelError):
@@ -6270,7 +6271,7 @@ class TestService(unittest.TestCase):
                 new=CoroutineMock()) as send_iq:
             send_iq.return_value = None
             send_iq.side_effect = aioxmpp.errors.XMPPCancelError(
-                condition=(utils.namespaces.stanzas, "forbidden")
+                condition=aioxmpp.ErrorCondition.FORBIDDEN
             )
 
             with self.assertRaises(aioxmpp.errors.XMPPCancelError):

--- a/tests/ping/test_service.py
+++ b/tests/ping/test_service.py
@@ -100,7 +100,7 @@ class TestService(unittest.TestCase):
 
     def test_ping_reraises_XMPPErrors(self):
         exc = aioxmpp.errors.XMPPError(
-            ("condition_ns", "condition_name"),
+            aioxmpp.ErrorCondition.NOT_AUTHORIZED,
         )
         exc.TYPE = unittest.mock.sentinel.type_
         self.cc.send.side_effect = exc

--- a/tests/roster/test_service.py
+++ b/tests/roster/test_service.py
@@ -325,7 +325,7 @@ class TestService(unittest.TestCase):
             run_coroutine(self.s.handle_roster_push(iq))
 
         self.assertEqual(
-            (namespaces.stanzas, "forbidden"),
+            errors.ErrorCondition.FORBIDDEN,
             ctx.exception.condition
         )
 
@@ -349,7 +349,7 @@ class TestService(unittest.TestCase):
             run_coroutine(self.s.handle_roster_push(iq))
 
         self.assertEqual(
-            (namespaces.stanzas, "forbidden"),
+            errors.ErrorCondition.FORBIDDEN,
             ctx.exception.condition
         )
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -615,7 +615,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 ),
                 unittest.mock.call.send_stream_error_and_close(
                     base.protocol,
-                    condition=(namespaces.streams, "policy-violation"),
+                    condition=errors.StreamErrorCondition.POLICY_VIOLATION,
                     text=error_message,
                 )
             ]
@@ -649,7 +649,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
         base.Future.return_value = features_future
         base.send_and_wait_for = CoroutineMock()
         base.send_and_wait_for.side_effect = errors.StreamError(
-            condition=(namespaces.streams, "unsupported-stanza-type"),
+            condition=errors.StreamErrorCondition.UNSUPPORTED_STANZA_TYPE,
         )
 
         error_message = (
@@ -990,7 +990,7 @@ class TestSTARTTLSConnector(unittest.TestCase):
                 ),
                 unittest.mock.call.send_stream_error_and_close(
                     base.protocol,
-                    condition=(namespaces.streams, "policy-violation"),
+                    condition=errors.StreamErrorCondition.POLICY_VIOLATION,
                     text=error_message,
                 )
             ]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -19,30 +19,35 @@
 # <http://www.gnu.org/licenses/>.
 #
 ########################################################################
+import contextlib
+import enum
 import gettext
 import unittest
 import unittest.mock
 
+import aioxmpp
 import aioxmpp.errors as errors
 import aioxmpp.i18n as i18n
+import aioxmpp.structs as structs
+import aioxmpp.xso as xso
 
-from aioxmpp.utils import etree
+from aioxmpp.utils import etree, namespaces
 
 
 class Testformat_error_text(unittest.TestCase):
     def test_only_condition(self):
         self.assertEqual(
-            "{uri:foo}error",
+            "{urn:ietf:params:xml:ns:xmpp-stanzas}internal-server-error",
             errors.format_error_text(
-                condition=("uri:foo", "error")
+                condition=errors.ErrorCondition.INTERNAL_SERVER_ERROR
             )
         )
 
     def test_with_text(self):
         self.assertEqual(
-            "{uri:foo}error ('foobar')",
+            "{urn:ietf:params:xml:ns:xmpp-stanzas}bad-request ('foobar')",
             errors.format_error_text(
-                condition=("uri:foo", "error"),
+                condition=errors.ErrorCondition.BAD_REQUEST,
                 text="foobar",
             )
         )
@@ -52,9 +57,9 @@ class Testformat_error_text(unittest.TestCase):
             TAG = ("uri:bar", "value-error")
 
         self.assertEqual(
-            "{uri:foo}error/{uri:bar}value-error",
+            "{urn:ietf:params:xml:ns:xmpp-stanzas}gone/{uri:bar}value-error",
             errors.format_error_text(
-                condition=("uri:foo", "error"),
+                condition=errors.ErrorCondition.GONE,
                 application_defined_condition=Appcond(),
             )
         )
@@ -64,13 +69,180 @@ class Testformat_error_text(unittest.TestCase):
             TAG = ("uri:bar", "value-error")
 
         self.assertEqual(
-            "{uri:foo}error/{uri:bar}value-error ('that’s not an integer')",
+            "{urn:ietf:params:xml:ns:xmpp-stanzas}undefined-condition/{uri:bar}value-error ('that’s not an integer')",
             errors.format_error_text(
-                condition=("uri:foo", "error"),
+                condition=errors.ErrorCondition.UNDEFINED_CONDITION,
                 application_defined_condition=Appcond(),
                 text="that’s not an integer"
             )
         )
+
+
+class TestErrorCondition(unittest.TestCase):
+    def test_is_enum(self):
+        self.assertTrue(issubclass(errors.ErrorCondition, enum.Enum))
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "does not apply to this version of aioxmpp")
+    def test_uses_compat_mixin(self):
+        self.assertTrue(
+            issubclass(
+                errors.ErrorCondition,
+                structs.CompatibilityMixin,
+            )
+        )
+
+    def test_uses_xso_enum_mixin(self):
+        self.assertTrue(issubclass(errors.ErrorCondition, xso.XSOEnumMixin))
+
+    def test_gone_new_address(self):
+        self.assertIsInstance(
+            errors.ErrorCondition.GONE.xso_class.new_address,
+            xso.Text,
+        )
+        self.assertIsInstance(
+            errors.ErrorCondition.GONE.xso_class.new_address.type_,
+            xso.String,
+        )
+
+    def test_gone_new_address(self):
+        self.assertIsInstance(
+            errors.ErrorCondition.REDIRECT.xso_class.new_address,
+            xso.Text,
+        )
+        self.assertIsInstance(
+            errors.ErrorCondition.REDIRECT.xso_class.new_address.type_,
+            xso.String,
+        )
+
+
+class TestStreamError(unittest.TestCase):
+    def test_init_formats_condition(self):
+        with unittest.mock.patch("aioxmpp.errors.format_error_text") as format_:
+            errors.StreamError(
+                errors.StreamErrorCondition.INTERNAL_SERVER_ERROR,
+                text=unittest.mock.sentinel.text,
+            )
+
+        format_.assert_called_once_with(
+            errors.StreamErrorCondition.INTERNAL_SERVER_ERROR,
+            unittest.mock.sentinel.text,
+        )
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "does not apply to this version of aioxmpp")
+    def test_init_converts_tuple_to_condition_and_warns(self):
+        with contextlib.ExitStack() as stack:
+            format_ = stack.enter_context(unittest.mock.patch(
+                "aioxmpp.errors.format_error_text"
+            ))
+
+            ctx = stack.enter_context(self.assertWarnsRegex(
+                DeprecationWarning,
+                r"as of aioxmpp 1\.0, stream error conditions must be members "
+                r"of the aioxmpp\.errors\.StreamErrorCondition enumeration"
+            ))
+
+            errors.StreamError(
+                (namespaces.streams, "not-authorized"),
+                text=unittest.mock.sentinel.text,
+            )
+
+        format_.assert_called_once_with(
+            errors.StreamErrorCondition.NOT_AUTHORIZED,
+            unittest.mock.sentinel.text,
+        )
+
+        self.assertTrue(
+            ctx.filename.endswith("test_errors.py"),
+        )
+
+
+class TestXMPPError(unittest.TestCase):
+    def test_init_formats_condition(self):
+        with unittest.mock.patch("aioxmpp.errors.format_error_text") as format_:
+            errors.XMPPError(
+                errors.ErrorCondition.INTERNAL_SERVER_ERROR,
+                text=unittest.mock.sentinel.text,
+                application_defined_condition=unittest.mock.sentinel.appcond,
+            )
+
+        format_.assert_called_once_with(
+            errors.ErrorCondition.INTERNAL_SERVER_ERROR,
+            text=unittest.mock.sentinel.text,
+            application_defined_condition=unittest.mock.sentinel.appcond,
+        )
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "does not apply to this version of aioxmpp")
+    def test_init_converts_tuple_to_condition_and_warns(self):
+        with contextlib.ExitStack() as stack:
+            format_ = stack.enter_context(unittest.mock.patch(
+                "aioxmpp.errors.format_error_text"
+            ))
+
+            ctx = stack.enter_context(self.assertWarnsRegex(
+                DeprecationWarning,
+                r"as of aioxmpp 1\.0, error conditions must be members of the "
+                r"aioxmpp\.ErrorCondition enumeration"
+            ))
+
+            errors.XMPPError(
+                (namespaces.stanzas, "bad-request"),
+                text=unittest.mock.sentinel.text,
+                application_defined_condition=unittest.mock.sentinel.appcond,
+            )
+
+        format_.assert_called_once_with(
+            errors.ErrorCondition.BAD_REQUEST,
+            text=unittest.mock.sentinel.text,
+            application_defined_condition=unittest.mock.sentinel.appcond,
+        )
+
+        self.assertTrue(
+            ctx.filename.endswith("test_errors.py"),
+        )
+
+    def test_init_sets_attributes_from_enum_member(self):
+        appcond = unittest.mock.Mock(["TAG"])
+        appcond.TAG = ("a", "b")
+
+        exc = errors.XMPPError(
+            errors.ErrorCondition.INTERNAL_SERVER_ERROR,
+            text=unittest.mock.sentinel.text,
+            application_defined_condition=appcond,
+        )
+
+        self.assertEqual(exc.condition,
+                         errors.ErrorCondition.INTERNAL_SERVER_ERROR)
+        self.assertEqual(exc.text, unittest.mock.sentinel.text)
+        self.assertIsInstance(
+            exc.condition_obj,
+            errors.ErrorCondition.INTERNAL_SERVER_ERROR.xso_class
+        )
+        self.assertEqual(exc.application_defined_condition, appcond)
+
+    def test_init_sets_attributes_from_xso(self):
+        appcond = unittest.mock.Mock(["TAG"])
+        appcond.TAG = ("a", "b")
+
+        condition_obj = errors.ErrorCondition.GONE.to_xso()
+        condition_obj.new_address = "foo"
+
+        exc = errors.XMPPError(
+            condition_obj,
+            text=unittest.mock.sentinel.text,
+            application_defined_condition=appcond,
+        )
+
+        self.assertEqual(exc.condition,
+                         errors.ErrorCondition.GONE)
+        self.assertEqual(exc.text, unittest.mock.sentinel.text)
+        self.assertIs(
+            exc.condition_obj,
+            condition_obj
+        )
+        self.assertEqual(exc.application_defined_condition, appcond)
 
 
 class TestErroneousStanza(unittest.TestCase):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,3 +1,4 @@
+
 ########################################################################
 # File name: test_node.py
 # This file is part of: aioxmpp
@@ -1265,7 +1266,7 @@ class Testconnect_xmlstream(unittest.TestCase):
 
         self.send_stream_error.assert_called_with(
             unittest.mock.sentinel.p1,
-            condition=(namespaces.streams, "policy-violation"),
+            condition=errors.StreamErrorCondition.POLICY_VIOLATION,
             text=str(exc)
         )
 
@@ -1353,7 +1354,7 @@ class Testconnect_xmlstream(unittest.TestCase):
 
         self.send_stream_error.assert_called_with(
             unittest.mock.sentinel.p1,
-            condition=(namespaces.streams, "undefined-condition"),
+            condition=errors.StreamErrorCondition.UNDEFINED_CONDITION,
             text=str(exc)
         )
 
@@ -1596,10 +1597,10 @@ class Testconnect_xmlstream(unittest.TestCase):
         excs = [
             OSError(),
             errors.TLSUnavailable(
-                (namespaces.streams, "policy-violation"),
+                errors.StreamErrorCondition.POLICY_VIOLATION,
             ),
             errors.TLSFailure(
-                (namespaces.streams, "policy-violation"),
+                errors.StreamErrorCondition.POLICY_VIOLATION,
             ),
         ]
 
@@ -2732,7 +2733,7 @@ class TestClient(xmltestutils.XMLTestCase):
         run_coroutine(asyncio.sleep(0))
 
         exc = errors.StreamError(
-            condition=(namespaces.streams, "conflict")
+            condition=errors.StreamErrorCondition.CONFLICT
         )
         # stream would have been terminated normally, so we stop it manually
         # here
@@ -3288,8 +3289,7 @@ class TestClient(xmltestutils.XMLTestCase):
                 response=XMLStreamMock.Receive(
                     stanza.IQ(
                         error=stanza.Error(
-                            condition=(namespaces.stanzas,
-                                       "resource-constraint"),
+                            condition=aioxmpp.ErrorCondition.RESOURCE_CONSTRAINT,
                             text="too many resources",
                             type_=structs.ErrorType.CANCEL,
                         ),

--- a/tests/test_nonza.py
+++ b/tests/test_nonza.py
@@ -1194,7 +1194,7 @@ class TestSMFailed(unittest.TestCase):
     def test_default_init(self):
         obj = nonza.SMFailed()
         self.assertEqual(
-            errors.ErrorCondition.ITEM_NOT_FOUND,
+            errors.ErrorCondition.UNDEFINED_CONDITION,
             obj.condition.enum_member
         )
 

--- a/tests/test_nonza.py
+++ b/tests/test_nonza.py
@@ -21,6 +21,7 @@
 ########################################################################
 import unittest
 
+import aioxmpp
 import aioxmpp.errors as errors
 import aioxmpp.nonza as nonza
 import aioxmpp.xso as xso
@@ -35,14 +36,117 @@ class TestStreamError(unittest.TestCase):
             {}
         )
 
+    def test_condition_obj_attr(self):
+        self.assertIsInstance(
+            nonza.StreamError.condition_obj,
+            xso.Child,
+        )
+        self.assertCountEqual(
+            [
+                member.xso_class
+                for member in errors.StreamErrorCondition
+            ],
+            nonza.StreamError.condition_obj._classes,
+        )
+        self.assertTrue(nonza.StreamError.condition_obj.required)
+
+    def test_initialises_with_undefined_condition(self):
+        e = nonza.StreamError()
+        self.assertIsInstance(
+            e.condition_obj,
+            errors.StreamErrorCondition.UNDEFINED_CONDITION.xso_class,
+        )
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "does not apply to this version of aioxmpp")
+    def test_init_works_with_tuple_and_warns(self):
+        with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"as of aioxmpp 1\.0, stream error conditions must be members "
+                r"of the aioxmpp\.errors\.StreamErrorCondition "
+                r"enumeration") as ctx:
+            e = nonza.StreamError(
+                errors.StreamErrorCondition.INTERNAL_SERVER_ERROR.value
+            )
+
+        self.assertEqual(
+            e.condition,
+            errors.StreamErrorCondition.INTERNAL_SERVER_ERROR,
+        )
+
+        self.assertTrue(ctx.filename.endswith("test_nonza.py"))
+
+    def test_condition_reflects_enum_member_of_object_after_init(self):
+        e = nonza.StreamError()
+
+        self.assertEqual(
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
+            e.condition,
+        )
+
+    def test_condition_reflects_enum_member_of_object_after_change(self):
+        e = nonza.StreamError()
+        e.condition_obj = errors.StreamErrorCondition.HOST_GONE.xso_class()
+
+        self.assertEqual(
+            errors.StreamErrorCondition.HOST_GONE,
+            e.condition,
+        )
+
+    def test_setting_condition_replaces_object(self):
+        e = nonza.StreamError()
+        e.condition = errors.StreamErrorCondition.UNDEFINED_CONDITION
+
+        self.assertEqual(
+            e.condition,
+            errors.StreamErrorCondition.UNDEFINED_CONDITION
+        )
+
+        self.assertIsInstance(
+            e.condition_obj,
+            errors.StreamErrorCondition.UNDEFINED_CONDITION.xso_class,
+        )
+
+    def test_setting_condition_keeps_object_if_condition_matches(self):
+        e = nonza.StreamError()
+        old = e.condition_obj
+        e.condition = errors.StreamErrorCondition.UNDEFINED_CONDITION
+        self.assertIs(e.condition_obj, old)
+
+    @unittest.skipIf(aioxmpp.version_info >= (1, 0, 0),
+                     "does not apply to this version of aioxmpp")
+    def test_accepts_tuple_instead_of_enum_for_condition_and_warns(self):
+        e = nonza.StreamError()
+        with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"as of aioxmpp 1\.0, stream error conditions must be members "
+                r"of the aioxmpp\.errors\.StreamErrorCondition "
+                r"enumeration") as ctx:
+            e.condition = errors.StreamErrorCondition.HOST_GONE.value
+
+        self.assertEqual(
+            errors.StreamErrorCondition.HOST_GONE,
+            e.condition,
+        )
+
+        self.assertIsInstance(
+            e.condition_obj,
+            errors.StreamErrorCondition.HOST_GONE.xso_class,
+        )
+
+        self.assertTrue(ctx.filename.endswith("test_nonza.py"))
+
     def test_from_exception(self):
         obj = nonza.StreamError.from_exception(errors.StreamError(
-            (namespaces.streams, "undefined-condition"),
-            text="foobar"))
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
+            text="foobar"
+        ))
+
         self.assertEqual(
-            (namespaces.streams, "undefined-condition"),
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
             obj.condition
         )
+
         self.assertEqual(
             "foobar",
             obj.text
@@ -50,17 +154,21 @@ class TestStreamError(unittest.TestCase):
 
     def test_to_exception(self):
         obj = nonza.StreamError()
-        obj.condition = (namespaces.streams, "restricted-xml")
+        obj.condition = errors.StreamErrorCondition.RESTRICTED_XML
         obj.text = "foobar"
 
         exc = obj.to_exception()
+
         self.assertIsInstance(
             exc,
-            errors.StreamError)
+            errors.StreamError
+        )
+
         self.assertEqual(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             exc.condition
         )
+
         self.assertEqual(
             "foobar",
             exc.text
@@ -68,21 +176,25 @@ class TestStreamError(unittest.TestCase):
 
     def test_default_init(self):
         obj = nonza.StreamError()
+
         self.assertEqual(
-            (namespaces.streams, "undefined-condition"),
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
             obj.condition
         )
+
         self.assertIsNone(obj.text)
 
     def test_init(self):
         obj = nonza.StreamError(
-            condition=(namespaces.streams, "reset"),
+            condition=errors.StreamErrorCondition.RESET,
             text="foobar"
         )
+
         self.assertEqual(
-            (namespaces.streams, "reset"),
+            errors.StreamErrorCondition.RESET,
             obj.condition
         )
+
         self.assertEqual(
             "foobar",
             obj.text
@@ -1068,18 +1180,29 @@ class TestSMFailed(unittest.TestCase):
             (namespaces.stream_management, "failed")
         )
 
+    def test_condition(self):
+        self.assertIsInstance(
+            nonza.SMFailed.condition,
+            xso.Child,
+        )
+        self.assertCountEqual(
+            [member.xso_class for member in errors.ErrorCondition],
+            nonza.SMFailed.condition._classes,
+        )
+        self.assertTrue(nonza.SMFailed.condition.required)
+
     def test_default_init(self):
         obj = nonza.SMFailed()
         self.assertEqual(
-            (namespaces.stanzas, "undefined-condition"),
-            obj.condition
+            errors.ErrorCondition.ITEM_NOT_FOUND,
+            obj.condition.enum_member
         )
 
     def test_init(self):
         obj = nonza.SMFailed(
-            condition=(namespaces.stanzas, "item-not-found")
+            condition=errors.ErrorCondition.ITEM_NOT_FOUND
         )
         self.assertEqual(
-            (namespaces.stanzas, "item-not-found"),
-            obj.condition
+            errors.ErrorCondition.ITEM_NOT_FOUND,
+            obj.condition.enum_member
         )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1402,10 +1402,12 @@ class TestXMLStream(unittest.TestCase):
             TransportMock.WriteEof(),
             TransportMock.Close()
         ]))
+
         with self.assertRaises(errors.StreamError) as ctx:
             p.reset()
+
         self.assertEqual(
-            (namespaces.streams, "undefined-condition"),
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
             ctx.exception.condition
         )
 
@@ -1484,7 +1486,7 @@ class TestXMLStream(unittest.TestCase):
         args = fun.call_args
         self.assertIsInstance(args[0][0], errors.StreamError)
         self.assertEqual(
-            (namespaces.streams, "policy-violation"),
+            errors.StreamErrorCondition.POLICY_VIOLATION,
             args[0][0].condition
         )
 
@@ -1535,7 +1537,7 @@ class TestXMLStream(unittest.TestCase):
         )
         self.assertEqual(
             exc.condition,
-            (namespaces.streams, "bad-format")
+            errors.StreamErrorCondition.BAD_FORMAT
         )
 
     def test_fail_triggers_error_futures(self):
@@ -1564,7 +1566,7 @@ class TestXMLStream(unittest.TestCase):
 
         self.assertIsInstance(exc, errors.StreamError)
         self.assertEqual(
-            (namespaces.streams, "policy-violation"),
+            errors.StreamErrorCondition.POLICY_VIOLATION,
             exc.condition
         )
 
@@ -1593,7 +1595,7 @@ class TestXMLStream(unittest.TestCase):
 
         self.assertIsInstance(exc, errors.StreamError)
         self.assertEqual(
-            (namespaces.streams, "policy-violation"),
+            errors.StreamErrorCondition.POLICY_VIOLATION,
             exc.condition
         )
 
@@ -2808,14 +2810,14 @@ class Testsend_stream_error_and_close(xmltestutils.XMLTestCase):
     def test_sends_and_closes(self):
         protocol.send_stream_error_and_close(
             self.xmlstream,
-            condition=(namespaces.streams, "connection-timeout"),
+            errors.StreamErrorCondition.CONNECTION_TIMEOUT,
             text="foobar",
             custom_condition=("uri:foo", "bar"))
 
         run_coroutine(self.xmlstream.run_test([
             XMLStreamMock.Send(
                 nonza.StreamError(
-                    condition=(namespaces.streams, "connection-timeout"),
+                    condition=errors.StreamErrorCondition.CONNECTION_TIMEOUT,
                     text="foobar")
             ),
             XMLStreamMock.Close()

--- a/tests/test_stanza.py
+++ b/tests/test_stanza.py
@@ -328,7 +328,7 @@ class TestMessage(unittest.TestCase):
 
     def test_make_error(self):
         e = stanza.Error(
-            condition=(namespaces.stanzas, "feature-not-implemented")
+            condition=errors.ErrorCondition.FEATURE_NOT_IMPLEMENTED
         )
         s = stanza.Message(
             from_=TEST_FROM,
@@ -559,7 +559,7 @@ class TestPresence(unittest.TestCase):
 
     def test_make_error(self):
         e = stanza.Error(
-            condition=(namespaces.stanzas, "gone")
+            condition=errors.ErrorCondition.GONE
         )
         s = stanza.Presence(
             from_=TEST_FROM,
@@ -879,7 +879,7 @@ class TestError(unittest.TestCase):
 
         obj = stanza.Error(
             type_=structs.ErrorType.CONTINUE,
-            condition=(namespaces.stanzas, "undefined-condition")
+            condition=errors.ErrorCondition.UNDEFINED_CONDITION
         )
         obj.application_condition = cond
         cond.to_exception.return_value = Exception()
@@ -901,7 +901,7 @@ class TestError(unittest.TestCase):
 
         obj = stanza.Error(
             type_=structs.ErrorType.CONTINUE,
-            condition=(namespaces.stanzas, "undefined-condition")
+            condition=errors.ErrorCondition.UNDEFINED_CONDITION
         )
         obj.application_condition = cond
 
@@ -929,7 +929,7 @@ class TestError(unittest.TestCase):
 
         obj = stanza.Error(
             type_=structs.ErrorType.CONTINUE,
-            condition=(namespaces.stanzas, "undefined-condition")
+            condition=errors.ErrorCondition.UNDEFINED_CONDITION
         )
         obj.application_condition = cond
         cond.to_exception.return_value = object()
@@ -975,8 +975,7 @@ class TestError(unittest.TestCase):
         )
         obj = stanza.Error(
             type_=structs.ErrorType.MODIFY,
-            condition=(namespaces.stanzas,
-                       "bad-request"),
+            condition=errors.ErrorCondition.BAD_REQUEST,
             text="foobar"
         )
         self.assertEqual(
@@ -1124,7 +1123,7 @@ class TestIQ(unittest.TestCase):
 
     def test_make_error(self):
         e = stanza.Error(
-            condition=(namespaces.stanzas, "bad-request")
+            condition=errors.ErrorCondition.BAD_REQUEST
         )
         s = stanza.IQ(from_=TEST_FROM,
                       to=TEST_TO,

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -230,7 +230,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         iq.payload = None
         iq.error = stanza.Error(
             type_=structs.ErrorType.MODIFY,
-            condition=(namespaces.stanzas, "bad-request"),
+            condition=errors.ErrorCondition.BAD_REQUEST,
         )
 
         fut = asyncio.Future()
@@ -245,7 +245,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         with self.assertRaises(errors.XMPPModifyError) as cm:
             run_coroutine(fut)
         self.assertEqual(
-            (namespaces.stanzas, "bad-request"),
+            errors.ErrorCondition.BAD_REQUEST,
             cm.exception.condition
         )
 
@@ -636,7 +636,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             response_got.type_
         )
         self.assertEqual(
-            (namespaces.stanzas, "service-unavailable"),
+            errors.ErrorCondition.SERVICE_UNAVAILABLE,
             response_got.error.condition
         )
 
@@ -665,7 +665,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             response_got.type_
         )
         self.assertEqual(
-            (namespaces.stanzas, "undefined-condition"),
+            errors.ErrorCondition.UNDEFINED_CONDITION,
             response_got.error.condition
         )
 
@@ -693,7 +693,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             response_got.type_
         )
         self.assertEqual(
-            (namespaces.stanzas, "undefined-condition"),
+            errors.ErrorCondition.UNDEFINED_CONDITION,
             response_got.error.condition
         )
 
@@ -708,7 +708,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         @asyncio.coroutine
         def handle_request(stanza):
             raise errors.XMPPWaitError(
-                condition=(namespaces.stanzas, "gone"),
+                errors.ErrorCondition.GONE,
                 text="foobarbaz",
             )
 
@@ -725,7 +725,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             response_got.type_
         )
         self.assertEqual(
-            (namespaces.stanzas, "gone"),
+            errors.ErrorCondition.GONE,
             response_got.error.condition
         )
         self.assertEqual(
@@ -743,7 +743,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         def handle_request(stanza):
             raise errors.XMPPWaitError(
-                condition=(namespaces.stanzas, "gone"),
+                errors.ErrorCondition.GONE,
                 text="foobarbaz",
             )
 
@@ -760,7 +760,7 @@ class TestStanzaStream(StanzaStreamTestBase):
             response_got.type_
         )
         self.assertEqual(
-            (namespaces.stanzas, "gone"),
+            errors.ErrorCondition.GONE,
             response_got.error.condition
         )
         self.assertEqual(
@@ -2285,7 +2285,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
         self.assertEqual(
             obj.error.condition,
-            (namespaces.stanzas, "bad-request")
+            errors.ErrorCondition.BAD_REQUEST
         )
 
     def test_do_not_respond_to_PayloadParsingError_at_error_iq(self):
@@ -2353,7 +2353,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
         self.assertEqual(
             obj.error.condition,
-            (namespaces.stanzas, "bad-request")
+            errors.ErrorCondition.BAD_REQUEST
         )
 
     def test_do_not_respond_to_PayloadParsingError_at_error_message(self):
@@ -2409,7 +2409,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
         self.assertEqual(
             obj.error.condition,
-            (namespaces.stanzas, "bad-request")
+            errors.ErrorCondition.BAD_REQUEST
         )
 
     def test_do_not_respond_to_PayloadParsingError_at_error_presence(self):
@@ -2464,7 +2464,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         )
         self.assertEqual(
             obj.error.condition,
-            (namespaces.stanzas, "service-unavailable")
+            errors.ErrorCondition.SERVICE_UNAVAILABLE
         )
 
     def test_ignore_UnknownIQPayload_at_error_iq(self):
@@ -2992,7 +2992,7 @@ class TestStanzaStream(StanzaStreamTestBase):
         iq.autoset_id()
         reply = iq.make_reply(type_=structs.IQType.ERROR)
         reply.error = stanza.Error(
-            condition=(namespaces.stanzas, "remote-server-not-found"),
+            condition=errors.ErrorCondition.REMOTE_SERVER_NOT_FOUND,
             text="foo",
         )
 
@@ -3040,7 +3040,7 @@ class TestStanzaStream(StanzaStreamTestBase):
                 run_coroutine(task)
 
             self.assertEqual(ctx.exception.condition,
-                             (namespaces.stanzas, "remote-server-not-found"))
+                             errors.ErrorCondition.REMOTE_SERVER_NOT_FOUND)
             self.assertEqual(ctx.exception.text, "foo")
 
     def test_send_timeout_affects_iq_reply(self):
@@ -4023,7 +4023,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         iq = make_test_iq()
         error_iq = iq.make_reply(type_=structs.IQType.ERROR)
         error_iq.error = stanza.Error(
-            condition=(namespaces.stanzas, "service-unavailable")
+            errors.ErrorCondition.SERVICE_UNAVAILABLE
         )
 
         iq_sent = make_test_iq()
@@ -4282,7 +4282,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         ]
         for err_iq in error_iqs:
             err_iq.error = stanza.Error(
-                condition=(namespaces.stanzas, "service-unavailable")
+                errors.ErrorCondition.SERVICE_UNAVAILABLE
             )
 
         self.stream.start(self.xmlstream)
@@ -4326,7 +4326,7 @@ class TestStanzaStreamSM(StanzaStreamTestBase):
         ]
         for err_iq in error_iqs:
             err_iq.error = stanza.Error(
-                condition=(namespaces.stanzas, "service-unavailable")
+                errors.ErrorCondition.SERVICE_UNAVAILABLE
             )
 
         self.stream.start(self.xmlstream)

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -73,8 +73,8 @@ class TestCompatibilityMixin(unittest.TestCase):
     def _test_eq_with_warning(self, v1, v2):
         with self.assertWarnsRegex(
                 DeprecationWarning,
-                "as of aioxmpp 1.0, enums will not compare equal to their "
-                "values") as ctx:
+                r"as of aioxmpp 1.0, SomeEnum members will not compare equal to"
+                r" their values") as ctx:
             self.assertTrue(v1 == v2)
 
         self.assertIn(
@@ -84,8 +84,8 @@ class TestCompatibilityMixin(unittest.TestCase):
 
         with self.assertWarnsRegex(
                 DeprecationWarning,
-                "as of aioxmpp 1.0, enums will not compare equal to their "
-                "values") as ctx:
+                r"as of aioxmpp 1.0, SomeEnum members will not compare equal to"
+                r" their values") as ctx:
             self.assertFalse(v1 != v2)
 
         self.assertIn(

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -425,7 +425,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
 
@@ -455,7 +455,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
         error.from_ = error.from_.bare()
@@ -486,7 +486,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
         error.id_ = "fnord"
@@ -656,7 +656,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
 
@@ -687,7 +687,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
 
@@ -742,7 +742,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
 
@@ -765,7 +765,7 @@ class TestBasicTrackingService(unittest.TestCase):
 
         error = msg.make_error(aioxmpp.stanza.Error.from_exception(
             aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented")
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
             )
         ))
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1627,7 +1627,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.processingInstruction("foo", "bar")
         self.assertEqual(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             cm.exception.condition
         )
 
@@ -1680,14 +1680,14 @@ class TestXMPPXMLProcessor(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startElementNS((None, "foo"), None, {})
         self.assertEqual(
-            (namespaces.streams, "invalid-namespace"),
+            errors.StreamErrorCondition.INVALID_NAMESPACE,
             cm.exception.condition
         )
 
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startElementNS((namespaces.xmlstream, "bar"), None, {})
         self.assertEqual(
-            (namespaces.streams, "invalid-namespace"),
+            errors.StreamErrorCondition.INVALID_NAMESPACE,
             cm.exception.condition
         )
 
@@ -1699,7 +1699,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startElementNS(self.STREAM_HEADER_TAG, None, attrs)
         self.assertEqual(
-            (namespaces.streams, "undefined-condition"),
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
             cm.exception.condition
         )
 
@@ -1721,7 +1721,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startElementNS(self.STREAM_HEADER_TAG, None, attrs)
         self.assertEqual(
-            (namespaces.streams, "undefined-condition"),
+            errors.StreamErrorCondition.UNDEFINED_CONDITION,
             cm.exception.condition
         )
 
@@ -1733,7 +1733,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
     #     with self.assertRaises(errors.StreamError) as cm:
     #         self.proc.startElementNS(self.STREAM_HEADER_TAG, None, attrs)
     #     self.assertEqual(
-    #         (namespaces.streams, "unsupported-version"),
+    #         errors.StreamErrorCondition.UNSUPPORTED_VERSION,
     #         cm.exception.condition
     #     )
     #     self.assertEqual(
@@ -1760,7 +1760,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startElementNS(self.STREAM_HEADER_TAG, None, attrs)
         self.assertEqual(
-            (namespaces.streams, "unsupported-version"),
+            errors.StreamErrorCondition.UNSUPPORTED_VERSION,
             cm.exception.condition
         )
 
@@ -2135,7 +2135,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
     #     with self.assertRaises(errors.StreamError) as cm:
     #         self.proc.startElementNS((None, "foo"), None, {})
     #     self.assertEqual(
-    #         (namespaces.streams, "policy-violation"),
+    #         errors.StreamErrorCondition.POLICY_VIOLATION,
     #         cm.exception.condition
     #     )
 
@@ -2224,7 +2224,7 @@ class TestXMPPLexicalHandler(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.comment("foobar")
         self.assertEqual(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             cm.exception.condition
         )
         self.proc.endCDATA()
@@ -2233,7 +2233,7 @@ class TestXMPPLexicalHandler(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startDTD("foo", "bar", "baz")
         self.assertEqual(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             cm.exception.condition
         )
         self.proc.endDTD()
@@ -2242,7 +2242,7 @@ class TestXMPPLexicalHandler(unittest.TestCase):
         with self.assertRaises(errors.StreamError) as cm:
             self.proc.startEntity("foo")
         self.assertEqual(
-            (namespaces.streams, "restricted-xml"),
+            errors.StreamErrorCondition.RESTRICTED_XML,
             cm.exception.condition
         )
         self.proc.endEntity("foo")

--- a/tests/vcard/test_service.py
+++ b/tests/vcard/test_service.py
@@ -101,7 +101,8 @@ class TestService(unittest.TestCase):
         with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.side_effect = aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "feature-not-implemented"))
+                aioxmpp.ErrorCondition.FEATURE_NOT_IMPLEMENTED
+            )
             res = run_coroutine(self.s.get_vcard(TEST_JID1))
 
         self.assertIsInstance(res, vcard_xso.VCard)
@@ -110,7 +111,8 @@ class TestService(unittest.TestCase):
         with unittest.mock.patch.object(self.cc, "send",
                                         new=CoroutineMock()) as mock_send:
             mock_send.side_effect = aioxmpp.XMPPCancelError(
-                (namespaces.stanzas, "item-not-found"))
+                aioxmpp.ErrorCondition.ITEM_NOT_FOUND
+            )
             res = run_coroutine(self.s.get_vcard(TEST_JID1))
 
         self.assertIsInstance(res, vcard_xso.VCard)
@@ -120,7 +122,8 @@ class TestService(unittest.TestCase):
             with unittest.mock.patch.object(self.cc, "send",
                                             new=CoroutineMock()) as mock_send:
                 mock_send.side_effect = aioxmpp.XMPPCancelError(
-                    (namespaces.stanzas, "fnord"))
+                    aioxmpp.ErrorCondition.REMOTE_SERVER_NOT_FOUND
+                )
                 res = run_coroutine(self.s.get_vcard(TEST_JID1))
 
     def test_set_vcard(self):

--- a/tests/version/test_e2e.py
+++ b/tests/version/test_e2e.py
@@ -21,6 +21,8 @@
 ########################################################################
 import asyncio
 
+import aioxmpp
+import aioxmpp.errors
 import aioxmpp.version
 
 from aioxmpp.utils import namespaces
@@ -55,14 +57,14 @@ class TestVersion(TestCase):
     def test_version_query_returns_service_unavailable_if_unconfigured(self):
         b_version = self.b.summon(aioxmpp.version.VersionServer)
 
-        with self.assertRaises(aioxmpp.errors.XMPPCancelError) as ctx:
+        with self.assertRaises(aioxmpp.XMPPCancelError) as ctx:
             yield from aioxmpp.version.query_version(
                 self.a.stream,
                 self.b.local_jid,
             )
 
         self.assertEqual(ctx.exception.condition,
-                         (namespaces.stanzas, "service-unavailable"))
+                         aioxmpp.ErrorCondition.SERVICE_UNAVAILABLE)
 
     @blocking_timed
     @asyncio.coroutine

--- a/tests/version/test_service.py
+++ b/tests/version/test_service.py
@@ -213,12 +213,12 @@ class TestVersionServer(unittest.TestCase):
         self.s.version = "foo"
         self.s.os = "bar"
 
-        with self.assertRaises(aioxmpp.errors.XMPPCancelError) as ctx:
+        with self.assertRaises(aioxmpp.XMPPCancelError) as ctx:
             run_coroutine(self.s.handle_query(unittest.mock.sentinel.request))
 
         self.assertEqual(
             ctx.exception.condition,
-            (namespaces.stanzas, "service-unavailable")
+            aioxmpp.ErrorCondition.SERVICE_UNAVAILABLE
         )
 
 

--- a/tests/xso/test_model.py
+++ b/tests/xso/test_model.py
@@ -7026,6 +7026,46 @@ class TestXSOEnumMixin(unittest.TestCase):
             unittest.mock.sentinel.xso_class,
         )
 
+    def test_to_xso_creates_instance(self):
+        with unittest.mock.patch.object(self.m, "xso_class") as class_:
+            class_.return_value = unittest.mock.sentinel.instance
+
+            result = self.m.to_xso()
+
+        class_.assert_called_once_with()
+
+        self.assertEqual(
+            result,
+            unittest.mock.sentinel.instance,
+        )
+
+    def test_to_xso_creates_new_instance_each_time(self):
+        with unittest.mock.patch.object(self.m, "xso_class") as class_:
+            class_.return_value = unittest.mock.sentinel.instance1
+
+            result = self.m.to_xso()
+
+            class_.assert_called_once_with()
+            class_.reset_mock()
+
+            class_.return_value = unittest.mock.sentinel.instance2
+
+            result = self.m.to_xso()
+
+        class_.assert_called_once_with()
+
+        self.assertEqual(
+            result,
+            unittest.mock.sentinel.instance2,
+        )
+
+    def test_enum_member_refers_to_itself(self):
+        self.assertIs(self.m, self.m.enum_member)
+
+    def test_xso_to_xso_returns_object(self):
+        x = self.m.to_xso()
+        self.assertIs(x, x.to_xso())
+
     def test_mixes_well_with_enum(self):
         class Mixed(xso_model.XSOEnumMixin, enum.Enum):
             BAD_REQUEST = (namespaces.stanzas, "bad-request")
@@ -7049,6 +7089,13 @@ class TestXSOEnumMixin(unittest.TestCase):
             Mixed.BAD_REQUEST,
         )
 
+        instance = Mixed.BAD_REQUEST.xso_class()
+
+        self.assertIs(
+            instance,
+            instance.to_xso()
+        )
+
         self.assertTrue(issubclass(Mixed.UNDEFINED_CONDITION.xso_class,
                                    xso_model.XSO))
 
@@ -7065,6 +7112,13 @@ class TestXSOEnumMixin(unittest.TestCase):
         self.assertIs(
             Mixed.UNDEFINED_CONDITION.xso_class().enum_member,
             Mixed.UNDEFINED_CONDITION,
+        )
+
+        instance = Mixed.UNDEFINED_CONDITION.xso_class()
+
+        self.assertIs(
+            instance,
+            instance.to_xso()
         )
 
     def test_mixes_well_with_the_compatibility_mixin(self):


### PR DESCRIPTION
- [x] Enum-ify errors
- [x] Support for additional payloads in error condition elements
- [x] Transport full error condition elements in XMPPError exceptions
- [x] Allow application defined condition elements to be provided to XMPPError exceptions to serialise Error elements fully
- [x] Provide instructions for the transition
- [x] Generate DeprecationWarning for all deprecated uses
- [x] Ensure all deprecated uses are fixed

Fixes #226, fixes #189.