### PR TITLE
Remove Message.ext and Presence.ext

### DIFF
--- a/aioxmpp/stanza.py
+++ b/aioxmpp/stanza.py
@@ -721,7 +721,6 @@ class Message(StanzaBase):
     body = xso.ChildTextMap(Body)
     subject = xso.ChildTextMap(Subject)
     thread = xso.Child([Thread])
-    ext = xso.ChildMap([])
 
     def __init__(self, type_, **kwargs):
         super().__init__(**kwargs)
@@ -873,7 +872,6 @@ class Presence(StanzaBase):
         default=0
     )
 
-    ext = xso.ChildMap([])
     unhandled_children = xso.Collector()
 
     def __init__(self, *,

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -26,6 +26,11 @@ Version 0.11
 * :meth:`aioxmpp.PEPClient.publish` now supports setting the `access_model` via
   a `publish_options` precondition.
 
+* *Breaking change* Remove the undocumented and unused descriptors
+  :attr:`aioxmpp.Message.ext` and :attr:`aioxmpp.Presence.ext`. If your code
+  relies on them you can instead patch a descriptor to the class (with
+  a prefix that uniquely identifies your extension).
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/tests/test_stanza.py
+++ b/tests/test_stanza.py
@@ -255,11 +255,6 @@ class TestMessage(unittest.TestCase):
             structs.MessageType.NORMAL,
         )
 
-    def test_ext_attr(self):
-        self.assertIsInstance(
-            stanza.Message.ext,
-            xso.ChildMap)
-
     def test_body_attr(self):
         self.assertIsInstance(
             stanza.Message.body,
@@ -500,11 +495,6 @@ class TestPresence(unittest.TestCase):
             0,
             stanza.Presence.priority.default
         )
-
-    def test_ext_attr(self):
-        self.assertIsInstance(
-            stanza.Presence.ext,
-            xso.ChildMap)
 
     def test_error_attr(self):
         self.assertIsInstance(


### PR DESCRIPTION
Those descriptors are undocumented and probably unused. They can easily be replaced by patching descriptors to the classes instead, which results in more readable code.