### PR TITLE
Fix various documentation errors

### DIFF
--- a/aioxmpp/ibr/__init__.py
+++ b/aioxmpp/ibr/__init__.py
@@ -19,6 +19,38 @@
 # <http://www.gnu.org/licenses/>.
 #
 ########################################################################
+"""
+:mod:`~aioxmpp.ibr` --- In-Band Registration (:xep:`0077`)
+##########################################################
+
+This module implements in-band registration.
+
+Registration Functions
+======================
+
+The module level registration functions work on an
+:class:`aioxmpp.protocol.XMLStream` and before authentication. They
+allow to register a new account with a server.
+
+.. autofunction:: get_registration_fields
+
+.. autofunction:: register
+
+Helper Function
+===============
+
+.. autofunction:: get_used_fields
+
+Service
+=======
+
+.. autoclass:: RegistrationService
+
+XSO Definitions
+===============
+
+.. autoclass:: Query
+"""
 
 from .service import RegistrationService, get_registration_fields, register
 from .service import get_used_fields

--- a/aioxmpp/ibr/service.py
+++ b/aioxmpp/ibr/service.py
@@ -72,7 +72,7 @@ def register(xmlstream,
     Create a new account on the server.
 
     :param query_xso: XSO with the information needed for the registration.
-    :type query_xso: :class:`xso.Query`
+    :type query_xso: :class:`~aioxmpp.ibr.Query`
 
     :param xmlstream: Specifies the stream connected to the server where
                       the account will be created.
@@ -101,7 +101,7 @@ def get_used_fields(payload):
     xso.Query.
 
     :param payload: Query object o be
-    :type payload: :class:`xso.Query`
+    :type payload: :class:`~aioxmpp.ibr.Query`
     :return: :attr:`list`
     """
     return [
@@ -110,22 +110,21 @@ def get_used_fields(payload):
         if descriptor.__get__(payload, type(payload)) is not None
     ]
 
+
 class RegistrationService(Service):
     """
-    Service implementing XMPP In-Band Registration(:xep:`0077`).
+    Service implementing the XMPP In-Band Registration(:xep:`0077`)
+    use cases for registered entities.
 
-    This 'service' implements the possibility for an entity to register with a
-    XMPP server, cancel an existing registration, or change a password.
+    This service allows an already registered and authenticated entity
+    to request information about the registration, cancel an existing
+    registration, or change a password.
 
     .. automethod:: get_client_info
 
     .. automethod:: change_pass
 
     .. automethod:: cancel_registration
-
-    .. automethod:: get_registration_fields
-
-    .. automethod:: register
 
     """
 
@@ -135,7 +134,7 @@ class RegistrationService(Service):
         A query is sent to the server to obtain the client's data stored at the
         server.
 
-        :return: :class:`xso.Query`
+        :return: :class:`~aioxmpp.ibr.Query`
         """
         iq = aioxmpp.IQ(
             to=self.client.local_jid.bare().replace(localpart=None),

--- a/aioxmpp/ibr/xso.py
+++ b/aioxmpp/ibr/xso.py
@@ -26,18 +26,13 @@ from aioxmpp.utils import namespaces
 
 namespaces.xep0077_in_band = "jabber:iq:register"
 
-"""
-XSO Definitions
-===============
-
-.. autoclass:: Query
-"""
-
 
 @aioxmpp.IQ.as_payload_class
 class Query(xso.XSO):
     """
     :xep:`077` In-Band Registraion query :class:`~aioxmpp.xso.XSO`.
+
+    It has the following fields described in the XEP document:
 
     .. attribute:: username
 

--- a/docs/api/public/index.rst
+++ b/docs/api/public/index.rst
@@ -38,6 +38,7 @@ functionality or provide backwards compatibility.
    hashes
    httpupload
    im
+   ibr
    mdr
    muc
    ping

--- a/docs/api/public/version.rst
+++ b/docs/api/public/version.rst
@@ -1,0 +1,1 @@
+.. automodule:: aioxmpp.version

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -11,10 +11,36 @@ This section defines terms used throughout the :mod:`aioxmpp` documentation.
      set of members along with their addresses and possibly additional features
      such as archive access method.
 
+   Conversation Implementation
+     A module consisting of service that implements
+     :class:`aioxmpp.im.conversation.AbstractConversationService`
+     together with implementations of
+     :class:`aioxmpp.im.conversation.AbstractConversation` and
+     :class:`aioxmpp.im.conversation.AbstractConversationMember`.
+     This adds support for one concrete type of conversation to
+     aioxmpp.  Currently, the following conversation implementations
+     exist: :class:`aioxmpp.im.p2p` and :class:`aioxmpp.muc`.
+
    Conversation Member
-     Representation of an entity which takes part in a :term:`Conversation`. The
-     actual definition of "taking part in a conversation" depends on the
-     specific medium used.
+     Representation of an :term:`entity <Entity>` which takes part in a
+     :term:`conversation <Conversation>`. The actual definition of
+     "taking part in a conversation" depends on the specific medium
+     used. Conversation members are represented in aioxmpp as
+     instances of
+     :class:`aioxmpp.im.conversation.AbstractConversationMember`.
+
+   Conversation Service
+     A service implementing
+     :class:`aioxmpp.im.conversation.AbstractConversationService`.
+     This allows to create and manage :term:`conversations <Conversation>`.
+
+   Entity
+     An endpoint in the Jabber network, anything that can be addressed by
+     a :term:`JID`. (Compare :rfc:`6122` section 2.1)
+
+   JID
+     Jabber Identifier. The unique address of an :term:`entity
+     <Entity>` in the Jabber network. (Compare :rfc:`6122` section 2).
 
    Tracking Service
      A :term:`Service` which provides functionality for updating

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Contents:
    user-guide/index.rst
    api/index.rst
    dev-guide/index.rst
+   glossary.rst
 
 .. _features:
 


### PR DESCRIPTION
* include api/pulblic/ibr.rst in the toctree
  * make the ibr documentation render properly
* add api/public/version.rst
* add the glossary to the toctree

Note: My sphinx does not seem to be happy with the references generated by `` :xep:`xxx` ``. It emits warnings like
 >  /home/sebi/progs/projects/aioxmpp/docs/user-guide/quickstart.rst:411: WARNING: 4 column based index found. It might be a bug of extensions you use: [('single', 'XMPP Extension Protocols (XEPs); XEP 0092', 'index-3', '')]
