### PR TITLE
Allow IQ handlers to respond early

### DIFF
--- a/aioxmpp/service.py
+++ b/aioxmpp/service.py
@@ -729,7 +729,7 @@ class Service(metaclass=Meta):
                         self.__client.stream,
                         obj.__get__(self, type(self)),
                         *additional_args,
-                        **kwargs,
+                        **kwargs
                     )
                 )
 

--- a/aioxmpp/service.py
+++ b/aioxmpp/service.py
@@ -886,7 +886,7 @@ def add_handler_spec(f, handler_spec, *, kwargs=None):
     :type kwargs: :class:`dict`
 
     :raises ValueError: if the handler was registered with
-       different `kwarg`s before
+       different `kwargs` before
 
     This uses a private attribute, whose exact name is an implementation
     detail. The `handler_spec` is stored in a :class:`dict` bound to the

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -927,7 +927,19 @@ class StanzaStream:
             self.on_stream_destroyed(exc)
             self._established = False
 
-    def _iq_request_coro_done(self, request, task):
+    def _send_iq_reply(self, request, result):
+        if isinstance(result, errors.XMPPError):
+            response = request.make_reply(type_=structs.IQType.ERROR)
+            response.error = stanza.Error.from_exception(result)
+        else:
+            response = request.make_reply(type_=structs.IQType.RESULT)
+            response.payload = result
+        self._enqueue(response)
+
+    def _iq_request_coro_done_remove_task(self, task):
+        self._iq_request_tasks.remove(task)
+
+    def _iq_request_coro_done_send_reply(self, request, task):
         """
         Called when an IQ request handler coroutine returns. `request` holds
         the IQ request which triggered the excecution of the coroutine and
@@ -935,23 +947,26 @@ class StanzaStream:
 
         Compose a response and send that response.
         """
-        self._iq_request_tasks.remove(task)
         try:
             payload = task.result()
         except errors.XMPPError as err:
-            response = request.make_reply(type_=structs.IQType.ERROR)
-            response.error = stanza.Error.from_exception(err)
+            self._send_iq_reply(request, err)
         except Exception:
             response = request.make_reply(type_=structs.IQType.ERROR)
             response.error = stanza.Error(
                 condition=errors.ErrorCondition.UNDEFINED_CONDITION,
                 type_=structs.ErrorType.CANCEL,
             )
+            self._enqueue(response)
             self._logger.exception("IQ request coroutine failed")
         else:
-            response = request.make_reply(type_=structs.IQType.RESULT)
-            response.payload = payload
-        self._enqueue(response)
+            self._send_iq_reply(request, payload)
+
+    def _iq_request_coro_done_check(self, task):
+        try:
+            task.result()
+        except Exception:
+            self._logger.exception("IQ request coroutine failed")
 
     def _process_incoming_iq(self, stanza_obj):
         """
@@ -986,7 +1001,7 @@ class StanzaStream:
             self._logger.debug("iq is request")
             key = (stanza_obj.type_, type(stanza_obj.payload))
             try:
-                coro = self._iq_request_map[key]
+                coro, with_send_reply = self._iq_request_map[key]
             except KeyError:
                 self._logger.warning(
                     "unhandleable IQ request: from=%r, type_=%r, payload=%r",
@@ -1001,17 +1016,34 @@ class StanzaStream:
                 self._enqueue(response)
                 return
 
+            args = [stanza_obj]
+            if with_send_reply:
+
+                def send_reply(result=None):
+                    nonlocal task, stanza_obj, send_reply_callback
+                    if task.done():
+                        raise RuntimeError(
+                            "send_reply called after the handler is done")
+                    if task.remove_done_callback(send_reply_callback) == 0:
+                        raise RuntimeError(
+                            "send_reply called more than once")
+                    task.add_done_callback(self._iq_request_coro_done_check)
+                    self._send_iq_reply(stanza_obj, result)
+
+                args.append(send_reply)
+
             try:
-                awaitable = coro(stanza_obj)
+                awaitable = coro(*args)
             except Exception as exc:
                 awaitable = asyncio.Future()
                 awaitable.set_exception(exc)
 
             task = asyncio.ensure_future(awaitable)
-            task.add_done_callback(
-                functools.partial(
-                    self._iq_request_coro_done,
-                    stanza_obj))
+            send_reply_callback = functools.partial(
+                self._iq_request_coro_done_send_reply,
+                stanza_obj)
+            task.add_done_callback(self._iq_request_coro_done_remove_task)
+            task.add_done_callback(send_reply_callback)
             self._iq_request_tasks.append(task)
             self._logger.debug("started task to handle request: %r", task)
 
@@ -1352,7 +1384,8 @@ class StanzaStream:
             stacklevel=2)
         return self.register_iq_request_handler(type_, payload_cls, coro)
 
-    def register_iq_request_handler(self, type_, payload_cls, cb):
+    def register_iq_request_handler(self, type_, payload_cls, cb, *,
+                                    with_send_reply=False):
         """
         Register a coroutine function or a function returning an awaitable to
         run when an IQ request is received.
@@ -1363,6 +1396,9 @@ class StanzaStream:
             :class:`~xso.XSO`)
         :type payload_cls: :class:`~.XMLStreamClass`
         :param cb: Function or coroutine function to invoke
+        :param with_send_reply: Whether to pass a function to send a reply
+             to `cb` as second argument.
+        :type with_send_reply: :class:`bool`
         :raises ValueError: if there is already a coroutine registered for this
                             target
         :raises ValueError: if `type_` is not a request IQ type
@@ -1409,6 +1445,15 @@ class StanzaStream:
             less readable code. For the sake of readability, it is recommended
             prefer coroutine functions.
 
+        .. versionadded:: 0.11
+
+            When the argument `with_send_reply` is true `cb` will be
+            called with two arguments: the IQ stanza to handle and a
+            unary function `send_reply(result=None)` that sends a
+            response to the IQ request and prevents that an automatic
+            response is sent. If `result` is an instance of
+            :class:`~aioxmpp.XMPPError` an error result is generated.
+
         .. versionchanged:: 0.10
 
             Accepts an awaitable as last argument in addition to coroutine
@@ -1448,7 +1493,7 @@ class StanzaStream:
         if key in self._iq_request_map:
             raise ValueError("only one listener is allowed per tag")
 
-        self._iq_request_map[key] = cb
+        self._iq_request_map[key] = cb, with_send_reply
         self._logger.debug(
             "iq request coroutine registered: type=%r, payload=%r",
             type_, payload_cls)
@@ -2620,7 +2665,7 @@ class StanzaStream:
 
 
 @contextlib.contextmanager
-def iq_handler(stream, type_, payload_cls, coro):
+def iq_handler(stream, type_, payload_cls, coro, *, with_send_reply=False):
     """
     Context manager to temporarily register a coroutine to handle IQ requests
     on a :class:`StanzaStream`.
@@ -2633,10 +2678,17 @@ def iq_handler(stream, type_, payload_cls, coro):
                         :class:`~xso.XSO`)
     :type payload_cls: :class:`~.XMLStreamClass`
     :param coro: Coroutine to register
+    :param with_send_reply: Whether to pass a function to send the reply
+                            early to `cb`.
+    :type with_send_reply: :class:`bool`
 
     The coroutine is registered when the context is entered and unregistered
     when the context is exited. Running coroutines are not affected by exiting
     the context manager.
+
+    .. versionadded:: 0.11
+
+       The `with_send_reply` argument.
 
     .. versionadded:: 0.8
     """
@@ -2645,6 +2697,7 @@ def iq_handler(stream, type_, payload_cls, coro):
         type_,
         payload_cls,
         coro,
+        with_send_reply=with_send_reply,
     )
     try:
         yield

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -944,6 +944,7 @@ class StanzaStream:
                 response = request.make_reply(type_=structs.IQType.RESULT)
                 response.payload = result
         except Exception:
+            self._logger.exception("invalid payload for an IQ response")
             response = self._compose_undefined_condition(
                 request
             )

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -1453,7 +1453,8 @@ class StanzaStream:
 
             Using a non-coroutine function for `cb` will generally lead to
             less readable code. For the sake of readability, it is recommended
-            prefer coroutine functions.
+            to prefer coroutine functions when strong ordering guarantees are
+            not needed.
 
         .. versionadded:: 0.11
 
@@ -1463,6 +1464,10 @@ class StanzaStream:
             response to the IQ request and prevents that an automatic
             response is sent. If `result` is an instance of
             :class:`~aioxmpp.XMPPError` an error result is generated.
+
+            This is useful when the handler function needs to execute
+            actions which happen after the IQ result has been sent,
+            for example, sending other stanzas.
 
         .. versionchanged:: 0.10
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -52,6 +52,13 @@ Version 0.11
 
 * :mod:`aioxmpp.ibb` (:xep:`47`) Support for In-Band Bytestreams.
 
+* :meth:`aioxmpp.stream.StanzaStream.register_iq_request_handler`
+  and :func:`aioxmpp.service.iq_handler` now
+  support a keyword argument `with_send_reply` which makes them pass
+  an additional argument to the handler, which is a function that can be
+  used to enqueue the reply to the IQ before the handler has returned.
+  This allows sequencing other actions after the reply has been sent.
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/tests/disco/test_service.py
+++ b/tests/disco/test_service.py
@@ -671,12 +671,14 @@ class TestDiscoServer(unittest.TestCase):
                 unittest.mock.call.stream.register_iq_request_handler(
                     structs.IQType.GET,
                     disco_xso.InfoQuery,
-                    s.handle_info_request
+                    s.handle_info_request,
+                    with_send_reply=False,
                 ),
                 unittest.mock.call.stream.register_iq_request_handler(
                     structs.IQType.GET,
                     disco_xso.ItemsQuery,
-                    s.handle_items_request
+                    s.handle_items_request,
+                    with_send_reply=False,
                 )
             ],
             cc.mock_calls

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -704,7 +704,7 @@ class Testmessage_handler(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -813,7 +813,7 @@ class Testpresence_handler(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -829,6 +829,7 @@ class Test_apply_iq_handler(unittest.TestCase):
                 unittest.mock.sentinel.func,
                 unittest.mock.sentinel.type_,
                 unittest.mock.sentinel.payload_cls,
+                with_send_reply=unittest.mock.sentinel.with_send_reply,
             )
 
         iq_handler.assert_called_with(
@@ -836,6 +837,7 @@ class Test_apply_iq_handler(unittest.TestCase):
             unittest.mock.sentinel.type_,
             unittest.mock.sentinel.payload_cls,
             unittest.mock.sentinel.func,
+            with_send_reply=unittest.mock.sentinel.with_send_reply,
         )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -325,7 +325,7 @@ class TestServiceMeta(unittest.TestCase):
     def test_collect_handlers(self):
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
         class Foo(metaclass=service.Meta):
             x = ObjectWithHandlers(
@@ -344,8 +344,8 @@ class TestServiceMeta(unittest.TestCase):
         self.assertCountEqual(
             Foo.SERVICE_HANDLERS,
             (
-                (unittest.mock.sentinel.k1, Foo.x),
-                (unittest.mock.sentinel.k2, Foo.x),
+                (unittest.mock.sentinel.k1, Foo.x, {}),
+                (unittest.mock.sentinel.k2, Foo.x, {}),
             ),
         )
 
@@ -354,7 +354,7 @@ class TestServiceMeta(unittest.TestCase):
     def test_reject_missing_dependencies(self):
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
         with self.assertRaisesRegex(
                 TypeError,
@@ -373,7 +373,7 @@ class TestServiceMeta(unittest.TestCase):
     def test_allow_properly_declared_dependencies(self):
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
         class Other(metaclass=service.Meta):
             pass
@@ -394,7 +394,7 @@ class TestServiceMeta(unittest.TestCase):
     def test_reject_duplicate_handlers_on_different_objects(self):
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
         with self.assertRaisesRegex(
                 TypeError,
@@ -426,7 +426,7 @@ class TestServiceMeta(unittest.TestCase):
     def test_allow_duplicate_handlers_on_different_objects_for_non_unique(self):  # NOQA
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
         class Foo(metaclass=service.Meta):
             x = ObjectWithHandlers(
@@ -456,7 +456,7 @@ class TestServiceMeta(unittest.TestCase):
     def test_reject_inheritance_from_class_with_handlers(self):
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
         class Foo(metaclass=service.Meta):
             x = ObjectWithHandlers(
@@ -575,7 +575,7 @@ class TestService(unittest.TestCase):
 
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
             def __get__(self, instance, owner):
                 if instance is None:
@@ -639,7 +639,7 @@ class TestService(unittest.TestCase):
                 unittest.mock.call().enter_context(
                     handler_cm()
                 )
-                for (handler_cm, args), obj
+                for (handler_cm, args), obj, kwargs
                 in ServiceWithHandlers.SERVICE_HANDLERS
             ]
         )
@@ -736,7 +736,7 @@ class TestService(unittest.TestCase):
 
         class ObjectWithHandlers:
             def __init__(self, handlers=[]):
-                self._aioxmpp_service_handlers = set(handlers)
+                self._aioxmpp_service_handlers = {h: {} for h in handlers}
 
             def __get__(self, instance, owner):
                 if instance is None:
@@ -1242,9 +1242,9 @@ class Testadd_handler_spec(unittest.TestCase):
     def test_preserves_existing_magic_attr(self):
         target = unittest.mock.Mock(spec=[])
         service.automake_magic_attr(target)
-        service.get_magic_attr(target).add(
+        service.get_magic_attr(target)[
             unittest.mock.sentinel.bar
-        )
+        ] = {}
 
         self.assertTrue(
             service.has_magic_attr(target),
@@ -1261,10 +1261,10 @@ class Testadd_handler_spec(unittest.TestCase):
 
         self.assertCountEqual(
             service.get_magic_attr(target),
-            [
-                unittest.mock.sentinel.foo,
-                unittest.mock.sentinel.bar,
-            ]
+            {
+                unittest.mock.sentinel.foo: {},
+                unittest.mock.sentinel.bar: {},
+            }
         )
 
 
@@ -1360,7 +1360,7 @@ class Testiq_handler(unittest.TestCase):
         def coro():
             pass
 
-        coro._aioxmpp_service_handlers = {"foo"}
+        coro._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(coro)
 
@@ -1496,7 +1496,7 @@ class Testinbound_message_filter(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -1572,7 +1572,7 @@ class Testinbound_presence_filter(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -1648,7 +1648,7 @@ class Testoutbound_message_filter(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -1724,7 +1724,7 @@ class Testoutbound_presence_filter(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -1950,7 +1950,7 @@ class Testdepsignal(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -2046,7 +2046,7 @@ class Testdepfilter(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -2303,7 +2303,7 @@ class Testattrsignal(unittest.TestCase):
         def cb():
             pass
 
-        cb._aioxmpp_service_handlers = {"foo"}
+        cb._aioxmpp_service_handlers = {"foo": {}}
 
         self.decorator(cb)
 
@@ -2341,13 +2341,13 @@ class Testis_iq_handler(unittest.TestCase):
 
     def test_return_true_if_token_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_iq_handler,
                  (unittest.mock.sentinel.type_,
                   unittest.mock.sentinel.payload_cls)),
-            )
-        ]
+            ): {}
+        }
 
         self.assertTrue(
             service.is_iq_handler(
@@ -2359,13 +2359,13 @@ class Testis_iq_handler(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_iq_handler,
                  (unittest.mock.sentinel.type2,
                   unittest.mock.sentinel.payload_cls2)),
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_iq_handler(
@@ -2432,12 +2432,12 @@ class Testis_inbound_message_filter(unittest.TestCase):
 
     def test_return_true_if_token_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_inbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertTrue(
             service.is_inbound_message_filter(m)
@@ -2445,12 +2445,12 @@ class Testis_inbound_message_filter(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_inbound_presence_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_inbound_message_filter(m)
@@ -2467,12 +2467,12 @@ class Testis_inbound_presence_filter(unittest.TestCase):
 
     def test_return_true_if_token_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_inbound_presence_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertTrue(
             service.is_inbound_presence_filter(m)
@@ -2480,12 +2480,12 @@ class Testis_inbound_presence_filter(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_inbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_inbound_presence_filter(m)
@@ -2502,12 +2502,12 @@ class Testis_outbound_message_filter(unittest.TestCase):
 
     def test_return_true_if_token_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertTrue(
             service.is_outbound_message_filter(m)
@@ -2515,12 +2515,12 @@ class Testis_outbound_message_filter(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_presence_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_outbound_message_filter(m)
@@ -2537,12 +2537,12 @@ class Testis_outbound_presence_filter(unittest.TestCase):
 
     def test_return_true_if_token_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_presence_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertTrue(
             service.is_outbound_presence_filter(m)
@@ -2550,12 +2550,12 @@ class Testis_outbound_presence_filter(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_outbound_presence_filter(m)
@@ -2669,9 +2669,9 @@ class Testis_depsignal_handler(unittest.TestCase):
                 )
 
 
-                obj._aioxmpp_service_handlers = [
-                    spec,
-                ]
+                obj._aioxmpp_service_handlers = {
+                    spec: {},
+                }
 
                 self.assertTrue(
                     service.is_depsignal_handler(
@@ -2685,12 +2685,12 @@ class Testis_depsignal_handler(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_depsignal_handler(
@@ -2782,12 +2782,12 @@ class Testis_depfilter_handler(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_depfilter_handler(
@@ -2915,9 +2915,9 @@ class Testis_attrsignal_handler(unittest.TestCase):
                         new=unittest.mock.sentinel.async_with_loop)
                 )
 
-                obj._aioxmpp_service_handlers = [
-                    spec,
-                ]
+                obj._aioxmpp_service_handlers = {
+                    spec: {},
+                }
 
                 self.assertTrue(
                     service.is_attrsignal_handler(
@@ -2931,12 +2931,12 @@ class Testis_attrsignal_handler(unittest.TestCase):
 
     def test_return_false_if_token_not_in_magic_attr(self):
         m = unittest.mock.Mock()
-        m._aioxmpp_service_handlers = [
+        m._aioxmpp_service_handlers = {
             service.HandlerSpec(
                 (service._apply_outbound_message_filter,
                  ())
-            )
-        ]
+            ): {}
+        }
 
         self.assertFalse(
             service.is_attrsignal_handler(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2106,7 +2106,6 @@ class Testattrsignal(unittest.TestCase):
         signal = callbacks.Signal()
         sync = callbacks.SyncSignal()
 
-
     class Descriptor(service.Descriptor):
         def init_cm(self, instance):
             raise NotImplementedError
@@ -2348,7 +2347,7 @@ class Testis_iq_handler(unittest.TestCase):
                 (service._apply_iq_handler,
                  (unittest.mock.sentinel.type_,
                   unittest.mock.sentinel.payload_cls)),
-            ): {}
+            ): {"with_send_reply": False}
         }
 
         self.assertTrue(
@@ -2356,6 +2355,44 @@ class Testis_iq_handler(unittest.TestCase):
                 unittest.mock.sentinel.type_,
                 unittest.mock.sentinel.payload_cls,
                 m
+            )
+        )
+
+    def test_return_true_if_token_in_magic_attr_non_standard_args(self):
+        m = unittest.mock.Mock()
+        m._aioxmpp_service_handlers = {
+            service.HandlerSpec(
+                (service._apply_iq_handler,
+                 (unittest.mock.sentinel.type_,
+                  unittest.mock.sentinel.payload_cls)),
+            ): {"with_send_reply": True}
+        }
+
+        self.assertTrue(
+            service.is_iq_handler(
+                unittest.mock.sentinel.type_,
+                unittest.mock.sentinel.payload_cls,
+                m,
+                with_send_reply=True,
+            )
+        )
+
+    def test_return_false_if_token_in_magic_attr_wrong_args(self):
+        m = unittest.mock.Mock()
+        m._aioxmpp_service_handlers = {
+            service.HandlerSpec(
+                (service._apply_iq_handler,
+                 (unittest.mock.sentinel.type_,
+                  unittest.mock.sentinel.payload_cls)),
+            ): {"with_send_reply": False}
+        }
+
+        self.assertFalse(
+            service.is_iq_handler(
+                unittest.mock.sentinel.type_,
+                unittest.mock.sentinel.payload_cls,
+                m,
+                with_send_reply=True,
             )
         )
 
@@ -2670,7 +2707,6 @@ class Testis_depsignal_handler(unittest.TestCase):
                         new=unittest.mock.sentinel.async_with_loop)
                 )
 
-
                 obj._aioxmpp_service_handlers = {
                     spec: {},
                 }
@@ -2804,7 +2840,6 @@ class Testis_attrsignal_handler(unittest.TestCase):
     class DescriptorValue:
         signal = callbacks.Signal()
         sync = callbacks.SyncSignal()
-
 
     class Descriptor(service.Descriptor):
         def init_cm(self, instance):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -672,7 +672,6 @@ class TestStanzaStream(StanzaStreamTestBase):
                 )
             )
 
-
             response_got = run_coroutine(self.sent_stanzas.get())
         self.assertEqual(
             structs.IQType.ERROR,
@@ -704,7 +703,6 @@ class TestStanzaStream(StanzaStreamTestBase):
             nonlocal extracted_send_result
             extracted_send_result = send_result
 
-
         self.stream.register_iq_request_handler(
             structs.IQType.GET,
             FancyTestIQ,
@@ -728,7 +726,6 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.stream.stop()
 
-
     def test_run_iq_request_coro_with_send_reply_twice(self):
         iq = make_test_iq()
         iq.autoset_id()
@@ -743,7 +740,6 @@ class TestStanzaStream(StanzaStreamTestBase):
                 send_result()
             except RuntimeError:
                 ok += 1
-
 
         self.stream.register_iq_request_handler(
             structs.IQType.GET,
@@ -765,7 +761,6 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.assertEqual(ok, 1)
 
         self.stream.stop()
-
 
     def test_run_iq_request_coro_with_send_reply_done_check(self):
         iq = make_test_iq()
@@ -824,7 +819,6 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.stream.stop()
 
         self.stream.stop()
-
 
     def test_run_iq_request_func_with_awaitable_result(self):
         iq = make_test_iq()


### PR DESCRIPTION
This PR does the following things:
* Allow handlers to take additional keyword arguments.
* Use this to add an with_send_reply flag that can be given to IQ handler and then passes an
  as extra argument a function that can be used to send IQ responses *before* the handler function
  terminates. The automatic response will be suppressed by this.