### PR TITLE
Make ChildTextMap accept either a tag or an XSO

### DIFF
--- a/aioxmpp/xso/__init__.py
+++ b/aioxmpp/xso/__init__.py
@@ -547,52 +547,9 @@ from .model import (  # NOQA
     lang_attr,
     capture_events,
     events_to_sax,
+    AbstractTextChild,
 )
 
-
-class AbstractTextChild(XSO):
-    """
-    One of the recurring patterns when using :mod:`xso` is the use of a XSO
-    subclass to represent an XML node which has only character data and an
-    ``xml:lang`` attribute.
-
-    The `text` and `lang` arguments to the constructor can be used to
-    initialize the attributes.
-
-    This class provides exactly that. It inherits from :class:`XSO`.
-
-    .. attribute:: lang
-
-       The ``xml:lang`` of the node, as :class:`~.structs.LanguageTag`.
-
-    .. attribute:: text
-
-       The textual content of the node (XML character data).
-
-    Example use as base class::
-
-      class Subject(xso.AbstractTextChild):
-          TAG = (namespaces.client, "subject")
-
-    The full example can also be found in the source code of
-    :class:`.stanza.Subject`.
-
-    """
-
-    lang = LangAttr()
-    text = Text(default=None)
-
-    def __init__(self, text=None, lang=None):
-        super().__init__()
-        self.text = text
-        self.lang = lang
-
-    def __eq__(self, other):
-        try:
-            other_key = (other.lang, other.text)
-        except AttributeError:
-            return NotImplemented
-        return (self.lang, self.text) == other_key
 
 from .model import _PropBase
 NO_DEFAULT = _PropBase.NO_DEFAULT

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -52,6 +52,9 @@ Version 0.11
 
 * :mod:`aioxmpp.ibb` (:xep:`47`) Support for In-Band Bytestreams.
 
+* :class:`aioxmpp.xso.ChildTextMap` can now also be constructed from a
+  tag, an appropriate XSO is then constructed on the fly.
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/tests/xso/test___init__.py
+++ b/tests/xso/test___init__.py
@@ -22,6 +22,7 @@
 import unittest
 
 import aioxmpp.structs as structs
+import aioxmpp.xso.model as xso_model
 import aioxmpp.xso as xso
 
 
@@ -81,72 +82,6 @@ class Testnormalize_tag(unittest.TestCase):
             xso.normalize_tag((1, 2))
 
 
-class TestAbstractTextChild(unittest.TestCase):
-    def test_is_xso(self):
-        self.assertTrue(issubclass(
-            xso.AbstractTextChild,
-            xso.XSO
-        ))
-
-    def test_has_no_tag(self):
-        self.assertFalse(hasattr(xso.AbstractTextChild, "TAG"))
-
-    def test_lang_attr(self):
-        self.assertIsInstance(
-            xso.AbstractTextChild.lang.xq_descriptor,
-            xso.LangAttr
-        )
-
-    def test_text_attr(self):
-        self.assertIsInstance(
-            xso.AbstractTextChild.text.xq_descriptor,
-            xso.Text
-        )
-        self.assertIsNone(
-            xso.AbstractTextChild.text.default
-        )
-
-    def test_init_default(self):
-        atc = xso.AbstractTextChild()
-        self.assertIsNone(atc.lang)
-        self.assertFalse(atc.text)
-
-    def test_init_args(self):
-        atc = xso.AbstractTextChild(
-            "foo",
-            lang=structs.LanguageTag.fromstr("de-DE"))
-        self.assertEqual(atc.text, "foo")
-        self.assertEqual(atc.lang, structs.LanguageTag.fromstr("de-DE"))
-
-    def test_equality(self):
-        atc1 = xso.AbstractTextChild()
-        atc2 = xso.AbstractTextChild()
-
-        self.assertTrue(atc1 == atc2)
-        self.assertFalse(atc1 != atc2)
-
-        atc1.text = "foo"
-
-        self.assertFalse(atc1 == atc2)
-        self.assertTrue(atc1 != atc2)
-
-        atc2.text = "foo"
-        atc2.lang = structs.LanguageTag.fromstr("de-DE")
-
-        self.assertFalse(atc1 == atc2)
-        self.assertTrue(atc1 != atc2)
-
-        atc1.lang = atc2.lang
-
-        self.assertTrue(atc1 == atc2)
-        self.assertFalse(atc1 != atc2)
-
-    def test_equality_handles_incorrect_peer_type_gracefully(self):
-        atc = xso.AbstractTextChild()
-        self.assertFalse(atc is None)
-        self.assertFalse(atc == "foo")
-
-
 class TestNO_DEFAULT(unittest.TestCase):
     def test_unequal_to_things(self):
         NO_DEFAULT = xso.NO_DEFAULT
@@ -183,3 +118,9 @@ class TestNO_DEFAULT(unittest.TestCase):
     def test___gt__raises(self):
         with self.assertRaises(TypeError):
             xso.NO_DEFAULT > xso.NO_DEFAULT
+
+
+class TestAbstractTextChild(unittest.TestCase):
+    def test_moved(self):
+        self.assertTrue(xso.AbstractTextChild,
+                        xso_model.AbstractTextChild)

--- a/tests/xso/test_model.py
+++ b/tests/xso/test_model.py
@@ -6024,31 +6024,77 @@ class TestChildValueMultiMap(unittest.TestCase):
 
 
 class TestChildTextMap(unittest.TestCase):
-    def test_init(self):
-        base = unittest.mock.Mock()
+    def test_init_cls(self):
         with contextlib.ExitStack() as stack:
-            stack.enter_context(unittest.mock.patch.object(
+            cvm = stack.enter_context(unittest.mock.patch.object(
                 xso_model.ChildValueMap,
                 "__init__",
-                new=base.ChildValueMap
             ))
 
-            stack.enter_context(unittest.mock.patch(
+            tcm = stack.enter_context(unittest.mock.patch(
                 "aioxmpp.xso.types.TextChildMap",
-                new=base.TextChildMap
             ))
 
-            obj = xso_model.ChildTextMap(base.xso)
+            xso_ = unittest.mock.Mock(spec=xso_model.XMLStreamClass)
 
-        calls = list(base.mock_calls)
+            obj = xso_model.ChildTextMap(xso_)
+
         self.assertSequenceEqual(
-            calls,
+            list(tcm.mock_calls),
             [
-                unittest.mock.call.TextChildMap(base.xso),
-                unittest.mock.call.ChildValueMap(
-                    base.TextChildMap(),
-                    mapping_type=structs.LanguageMap,
-                ),
+                unittest.mock.call(xso_),
+            ]
+        )
+
+        self.assertSequenceEqual(
+            list(cvm.mock_calls),
+            [unittest.mock.call(
+                tcm(),
+                mapping_type=structs.LanguageMap,
+            ),
+            ]
+        )
+
+        self.assertIsInstance(
+            obj,
+            xso_model.ChildTextMap
+        )
+
+    def test_init_tag(self):
+        with contextlib.ExitStack() as stack:
+            cvm = stack.enter_context(unittest.mock.patch.object(
+                xso_model.ChildValueMap,
+                "__init__",
+            ))
+
+            tcm = stack.enter_context(unittest.mock.patch(
+                "aioxmpp.xso.types.TextChildMap",
+            ))
+
+            obj = xso_model.ChildTextMap(("foo", "bar"))
+
+        self.assertSequenceEqual(
+            tcm.mock_calls,
+            [
+                unittest.mock.call(unittest.mock.ANY),
+            ]
+        )
+
+        (_, (xso_,), _), = tcm.mock_calls
+
+        self.assertTrue(
+            issubclass(xso_,
+                       xso_model.AbstractTextChild)
+        )
+
+        self.assertEqual(xso_.TAG, ("foo", "bar"))
+
+        self.assertSequenceEqual(
+            list(cvm.mock_calls),
+            [unittest.mock.call(
+                tcm(),
+                mapping_type=structs.LanguageMap,
+            ),
             ]
         )
 
@@ -7130,3 +7176,69 @@ class TestXSOEnumMixin(unittest.TestCase):
             Mixed.BAD_REQUEST,
             Mixed.BAD_REQUEST.value,
         )
+
+
+class TestAbstractTextChild(unittest.TestCase):
+    def test_is_xso(self):
+        self.assertTrue(issubclass(
+            xso.AbstractTextChild,
+            xso.XSO
+        ))
+
+    def test_has_no_tag(self):
+        self.assertFalse(hasattr(xso.AbstractTextChild, "TAG"))
+
+    def test_lang_attr(self):
+        self.assertIsInstance(
+            xso.AbstractTextChild.lang.xq_descriptor,
+            xso.LangAttr
+        )
+
+    def test_text_attr(self):
+        self.assertIsInstance(
+            xso.AbstractTextChild.text.xq_descriptor,
+            xso.Text
+        )
+        self.assertIsNone(
+            xso.AbstractTextChild.text.default
+        )
+
+    def test_init_default(self):
+        atc = xso.AbstractTextChild()
+        self.assertIsNone(atc.lang)
+        self.assertFalse(atc.text)
+
+    def test_init_args(self):
+        atc = xso.AbstractTextChild(
+            "foo",
+            lang=structs.LanguageTag.fromstr("de-DE"))
+        self.assertEqual(atc.text, "foo")
+        self.assertEqual(atc.lang, structs.LanguageTag.fromstr("de-DE"))
+
+    def test_equality(self):
+        atc1 = xso.AbstractTextChild()
+        atc2 = xso.AbstractTextChild()
+
+        self.assertTrue(atc1 == atc2)
+        self.assertFalse(atc1 != atc2)
+
+        atc1.text = "foo"
+
+        self.assertFalse(atc1 == atc2)
+        self.assertTrue(atc1 != atc2)
+
+        atc2.text = "foo"
+        atc2.lang = structs.LanguageTag.fromstr("de-DE")
+
+        self.assertFalse(atc1 == atc2)
+        self.assertTrue(atc1 != atc2)
+
+        atc1.lang = atc2.lang
+
+        self.assertTrue(atc1 == atc2)
+        self.assertFalse(atc1 != atc2)
+
+    def test_equality_handles_incorrect_peer_type_gracefully(self):
+        atc = xso.AbstractTextChild()
+        self.assertFalse(atc is None)
+        self.assertFalse(atc == "foo")


### PR DESCRIPTION
ChildTextMap now can be constructed from either an XSO or a tag.
If a tag is given a matching XSO is constructed on the fly.

Merging this PR closes #264.