### PR TITLE
xso: fix parser error handling

### DIFF
--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -2536,26 +2536,26 @@ def enforce_unknown_child_policy(policy, ev_args, error_handler=None):
 
 
 def guard(dest, ev_args):
-    next(dest)
     depth = 1
-    while True:
-        ev = yield
-        if ev[0] == "start":
-            depth += 1
-        elif ev[0] == "end":
-            depth -= 1
-        try:
-            dest.send(ev)
-        except StopIteration as exc:
-            return exc.value
-        except Exception as exc:
-            error = exc
-            break
-    while depth > 0:
-        ev_type, *_ = yield
-        if ev_type == "end":
-            depth -= 1
-    raise error
+    try:
+        next(dest)
+        while True:
+            ev = yield
+            if ev[0] == "start":
+                depth += 1
+            elif ev[0] == "end":
+                depth -= 1
+            try:
+                dest.send(ev)
+            except StopIteration as exc:
+                return exc.value
+    finally:
+        while depth > 0:
+            ev_type, *_ = yield
+            if ev_type == "end":
+                depth -= 1
+            elif ev_type == "start":
+                depth += 1
 
 
 def lang_attr(instance, ctx):

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -52,6 +52,20 @@ Version 0.11
 
 * :mod:`aioxmpp.ibb` (:xep:`47`) Support for In-Band Bytestreams.
 
+* Fix incorrect error handling in :mod:`aioxmpp.xso` when a supressing
+  :meth:`aioxmpp.xso.XSO.xso_error_handler` is in use.
+
+  Under certain circumstances, it is possible that the handling of supressed
+  error causes another error later on because the parsing stack mis-counts the
+  depth in which it is inside the XML tree. This makes elements appear in the
+  wrong place, typically leading to further errors.
+
+  In the worst case, using a supressing
+  :meth:`~aioxmpp.xso.XSO.xso_error_handler` in specific circumstances can be
+  vulnerable to denial of service and data injection into the XML stream.
+
+  (A CVE will be allocated for this.)
+
 .. _api-changelog-0.10:
 
 Version 0.10


### PR DESCRIPTION
**Needs backport to 0.10!**

guard() was incorrectly counting the depth when either of the following was true:

- the error occured inside the first "start" event on which guard() is used: in that case, guard() would fail to swallow the corresponding "end" event.

- after an error, further elements appear in the stream before the guard()-ed element is over. in that case, guard() would fail to account for the "start" events caused by those events, and thus let its depth counter go entirely out-of-sync with the XML tree

If this flaw is combined with the use of a supressing ``xso_error_handler``, it is possible to make elements appear higher up in the XML stream tree than they actually are; this implies that it is possible to inject elements in the XML stream.

It requires very specific circumstances for an application to be vulnerable. Example of a vulnerable XSO definition is:

```python
class Baz(aioxmpp.xso.XSO):
    TAG = ("https://xmlns.zombofant.net/aioxmpp/test", "baz")

class Bar(aioxmpp.xso.XSO):
    TAG = ("https://xmlns.zombofant.net/aioxmpp/test", "bar")

    validated = aioxmpp.xso.Attr(
        "foo",
        type_=aioxmpp.xso.JID()
    )

    children = aioxmpp.xso.ChildList([Baz])

@aioxmpp.IQ.as_payload_class
class Foo(aioxmpp.xso.XSO):
    TAG = ("https://xmlns.zombofant.net/aioxmpp/test", "foo")

    child = aioxmpp.xso.Child([Bar])

    def xso_error_handler(self, descriptor, ev_args, exc_info):
        return True
```

If an attacker sends (formatted for readability):

```xml
<iq ... type='result'>
  <foo xmlns='https://xmlns.zombofant.net/aioxmpp/test'>
    <bar foo='&quot;@bar'><baz/><baz/><baz/></bar>
  </foo>
</iq>
```

to an application which has the above XSO definition loaded, it will see the "end" event of the ``</iq>`` *on the stream level*, breaking the XML stream (because it expects a "start" event instead of an "end" event).

More sophisticated attacks could be used to make an element appear on the stream level instead, which would open the possibility of injecting, for example, ``<message>`` stanzas remotely into the stream of a vulnerable aioxmpp client, with arbitrary sender.