### PR TITLE
hashes: Implement a service and support hashes-used

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -76,6 +76,10 @@ Version 0.11
   used to enqueue the reply to the IQ before the handler has returned.
   This allows sequencing other actions after the reply has been sent.
 
+* :mod:`aioxmpp.hashes` now supports the `hashes-used` element and has a
+  service that handles registering the disco features and can determine
+  which hash functions are supported by us and another entity.
+
 .. _api-changelog-0.10:
 
 Version 0.10


### PR DESCRIPTION
* Support for the hash-used element (used e.g. by jingle file transfer) in addition to hash

* A service that automatically registeres the disco features corresponding to supported hash functions and has tooling to determine hash functions supported in common with another entity.