### PR TITLE
Simplify service ordering

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -76,6 +76,34 @@ Version 0.11
   used to enqueue the reply to the IQ before the handler has returned.
   This allows sequencing other actions after the reply has been sent.
 
+* **Breaking change:** The way the toposort of services is handled was
+  simplified: We no longer keep a toposort of all service
+  classes. *This implies that :class:`Service` subclasses are no
+  longer ordered objects.* However, we still guarantee a runtime error
+  when a dependency loop is declared – if a class uses only one of
+  `ORDER_BEFORE` respective `ORDER_AFTER` it cannot introduce a
+  dependency loop; only when a class uses both we have to do an
+  exhaustive search of the dependent nodes. This search touches only a
+  few nodes instead of the whole graph and is only triggered for very
+  few service classes.
+
+  Summon has been creating an independent toposort of only the
+  required classes anyway, so we use this for deriving ordering
+  indices for filter chains from now on – this also allows simpler
+  extension, modification of the filter order (e.g. ``-index`` orders
+  in reverse).
+
+  Methods for determining transitive dependency (and independency)
+  have been added to the service classes:
+  :meth:`aioxmpp.Service.orders_after`,
+  :meth:`aioxmpp.Service.orders_after_any`,
+  :meth:`aioxmpp.Service.independent_from`. These search the class
+  graph and are therefore not efficient (and the results may change
+  when new classes are defined).
+
+  Tests should always prefer to test the declared attributes when
+  checking for correct dependencies.
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/tests/adhoc/test_service.py
+++ b/tests/adhoc/test_service.py
@@ -71,9 +71,9 @@ class TestAdHocClient(unittest.TestCase):
         ))
 
     def test_depends_on_disco(self):
-        self.assertLess(
+        self.assertIn(
             aioxmpp.disco.DiscoClient,
-            adhoc_service.AdHocClient,
+            adhoc_service.AdHocClient.ORDER_AFTER,
         )
 
     def test_detect_support_using_disco(self):

--- a/tests/avatar/test_service.py
+++ b/tests/avatar/test_service.py
@@ -335,19 +335,19 @@ class TestAvatarService(unittest.TestCase):
         ))
 
     def test_service_order(self):
-        self.assertGreater(
-            avatar_service.AvatarService,
+        self.assertIn(
             aioxmpp.DiscoClient,
+            avatar_service.AvatarService.ORDER_AFTER,
         )
 
-        self.assertGreater(
-            avatar_service.AvatarService,
+        self.assertIn(
             aioxmpp.DiscoServer,
+            avatar_service.AvatarService.ORDER_AFTER,
         )
 
-        self.assertGreater(
-            avatar_service.AvatarService,
+        self.assertIn(
             aioxmpp.PubSubClient,
+            avatar_service.AvatarService.ORDER_AFTER,
         )
 
     def test_metadata_cache_size(self):

--- a/tests/blocking/test_service.py
+++ b/tests/blocking/test_service.py
@@ -69,9 +69,9 @@ class TestBlockingClient(unittest.TestCase):
         ))
 
     def test_service_order(self):
-        self.assertGreater(
-            blocking.BlockingClient,
-            aioxmpp.DiscoClient
+        self.assertIn(
+            aioxmpp.DiscoClient,
+            blocking.BlockingClient.ORDER_AFTER,
         )
 
     def test_get_initial_blocklist_is_depsignal_handler(self):

--- a/tests/carbons/test_service.py
+++ b/tests/carbons/test_service.py
@@ -58,9 +58,9 @@ class TestCarbonsClient(unittest.TestCase):
         ))
 
     def test_requires_DiscoClient(self):
-        self.assertLess(
+        self.assertIn(
             aioxmpp.DiscoClient,
-            carbons_service.CarbonsClient,
+            carbons_service.CarbonsClient.ORDER_AFTER,
         )
 
     def test__check_for_feature_uses_disco(self):

--- a/tests/entitycaps/test_service.py
+++ b/tests/entitycaps/test_service.py
@@ -608,13 +608,13 @@ class TestService(unittest.TestCase):
         self.assertTrue(self.s._xep390_feature.enabled)
 
     def test_after_disco(self):
-        self.assertLess(
+        self.assertIn(
             disco.DiscoServer,
-            entitycaps_service.EntityCapsService
+            entitycaps_service.EntityCapsService.ORDER_AFTER
         )
-        self.assertLess(
+        self.assertIn(
             disco.DiscoClient,
-            entitycaps_service.EntityCapsService
+            entitycaps_service.EntityCapsService.ORDER_AFTER
         )
 
     def test_handle_outbound_presence_is_decorated(self):

--- a/tests/im/test_p2p.py
+++ b/tests/im/test_p2p.py
@@ -222,15 +222,15 @@ class TestService(unittest.TestCase):
         del self.cc
 
     def test_depends_on_conversation_service(self):
-        self.assertLess(
+        self.assertIn(
             im_service.ConversationService,
-            p2p.Service,
+            p2p.Service.ORDER_AFTER,
         )
 
     def test_depends_on_dispatcher_service(self):
-        self.assertLess(
+        self.assertIn(
             im_dispatcher.IMDispatcher,
-            p2p.Service,
+            p2p.Service.ORDER_AFTER,
         )
 
     def test_get_conversation_creates_conversation(self):

--- a/tests/pep/test_service.py
+++ b/tests/pep/test_service.py
@@ -71,9 +71,15 @@ class TestPEPClient(unittest.TestCase):
         self.assertTrue(issubclass(pep.PEPClient, aioxmpp.service.Service))
 
     def test_depends_on_entity_caps(self):
-        self.assertLess(
+        self.assertIn(
             aioxmpp.EntityCapsService,
-            pep.PEPClient,
+            pep.PEPClient.ORDER_AFTER,
+        )
+
+    def test_depends_on_pubsub(self):
+        self.assertIn(
+            aioxmpp.PubSubClient,
+            pep.PEPClient.ORDER_AFTER,
         )
 
     def test_check_for_pep(self):

--- a/tests/pubsub/test_service.py
+++ b/tests/pubsub/test_service.py
@@ -57,9 +57,9 @@ class TestService(unittest.TestCase):
         ))
 
     def test_orders_behind_disco(self):
-        self.assertGreater(
-            pubsub_service.PubSubClient,
+        self.assertIn(
             aioxmpp.DiscoClient,
+            pubsub_service.PubSubClient.ORDER_AFTER,
         )
 
     def setUp(self):

--- a/tests/shim/test_service.py
+++ b/tests/shim/test_service.py
@@ -59,9 +59,9 @@ class TestService(unittest.TestCase):
         del self.disco
 
     def test_orders_before_disco_service(self):
-        self.assertLess(
+        self.assertIn(
             aioxmpp.DiscoServer,
-            shim_service.SHIMService,
+            shim_service.SHIMService.ORDER_AFTER,
         )
 
     def test_init(self):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -3521,6 +3521,9 @@ class TestClient(xmltestutils.XMLTestCase):
                 super().__init__(*args, **kwargs)
                 getattr(svc_init, type(self).__name__)(*args, **kwargs)
 
+        # account for already present services
+        order = len(self.client._services)
+
         svc2 = self.client.summon(Svc2)
 
         self.assertSequenceEqual(
@@ -3532,13 +3535,15 @@ class TestClient(xmltestutils.XMLTestCase):
                         "aioxmpp.node.Client"
                     ),
                     dependencies={},
+                    service_order_index=order,
                 ),
                 unittest.mock.call.Svc2(
                     self.client,
                     logger_base=logging.getLogger(
                         "aioxmpp.node.Client"
                     ),
-                    dependencies={Svc3: unittest.mock.ANY}
+                    dependencies={Svc3: unittest.mock.ANY},
+                    service_order_index=order+1,
                 ),
             ],
         )
@@ -3571,7 +3576,8 @@ class TestClient(xmltestutils.XMLTestCase):
                     ),
                     dependencies={
                         Svc2: unittest.mock.ANY,
-                    }
+                    },
+                    service_order_index=order+2,
                 ),
             ],
             svc_init.mock_calls


### PR DESCRIPTION
* The Service classes no longer define `__lt__` and `__gt__`

* There now is a property `order_index` and sorting (summoned)
  Service *instances* by the `order_index` will give a topological
  sort with respect to their dependencies.

* This removes code duplication between summon and the Service
  class toposort.

* Declaring dependency loops is still caught at class declaration
  time.

* The asymptotic and actual run-time for the acyclicity checks has
  been improved.