### PR TITLE
JSON containers, XSO cleanup

### DIFF
--- a/aioxmpp/misc/__init__.py
+++ b/aioxmpp/misc/__init__.py
@@ -64,6 +64,23 @@ Chat Markers (:xep:`333`)
 
 .. attribute:: aioxmpp.Message.xep0333_marker
 
+
+JSON Containers (:xep:`335`)
+============================
+
+:xep:`335` defines a standard way to transport JSON data in XMPP. The
+:class:`JSONContainer` is an XSO class which represents the ``<json/>`` element
+specified in :xep:`335`.
+
+:mod:`aioxmpp` also provides an :class:`~aioxmpp.xso.AbstractElementType` called
+:class:`JSONContainerType` which can be used to extract JSON data from an
+element using the :class:`JSONContainer` format.
+
+.. autoclass:: JSONContainer
+
+.. autoclass:: JSONContainerType
+
+
 Pre-Authenticated Roster Subcription (:xep:`379`)
 =================================================
 
@@ -79,4 +96,5 @@ from .delay import Delay  # NOQA
 from .forwarding import Forwarded  # NOQA
 from .oob import OOBExtension  # NOQA
 from .markers import ReceivedMarker, DisplayedMarker, AcknowledgedMarker  # NOQA
+from .json import JSONContainer, JSONContainerType  # NOQA
 from .pars import Preauth  # NOQA

--- a/aioxmpp/misc/json.py
+++ b/aioxmpp/misc/json.py
@@ -1,0 +1,60 @@
+import aioxmpp.xso as xso
+import aioxmpp.pubsub.xso
+
+from aioxmpp.utils import namespaces
+
+
+namespaces.xep0335_json = "urn:xmpp:json:0"
+
+
+@aioxmpp.pubsub.xso.as_payload_class
+class JSONContainer(xso.XSO):
+    """
+    XSO which represents the JSON container specified in :xep:`335`.
+
+    This is a full XSO and not an attribute descriptor. It is registered as
+    pubsub payload by default.
+    """
+
+    TAG = (namespaces.xep0335_json, "json")
+
+    json_data = xso.Text(
+        type_=xso.JSON(),
+    )
+
+    def __init__(self, json_data=None):
+        super().__init__()
+        self.json_data = json_data
+
+
+class JSONContainerType(xso.AbstractElementType):
+    """
+    XSO element type to unwrap JSON container payloads specified in :xep:`335`.
+
+    This type is designed to be used with the ChildValue* descriptors provided
+    in :mod:`aioxmpp.xso`, for example with :class:`aioxmpp.xso.ChildValue` or
+    :class:`aioxmpp.xso.ChildValueList`.
+
+    .. code:: python
+
+        class HTTPRESTMessage(aioxmpp.xso.XSO):
+            TAG = ("https://neverdothis.example", "http-rest")
+
+            method = aioxmpp.xso.Attr("method")
+
+            payload = aioxmpp.xso.ChildValue(
+                type_=aioxmpp.misc.JSONContainerType
+            )
+    """
+
+    @classmethod
+    def get_xso_types(cls):
+        return [JSONContainer]
+
+    @classmethod
+    def unpack(cls, v):
+        return v.json_data
+
+    @classmethod
+    def pack(cls, v):
+        return JSONContainer(v)

--- a/aioxmpp/xso/__init__.py
+++ b/aioxmpp/xso/__init__.py
@@ -273,6 +273,8 @@ vice versa. These types inherit from :class:`AbstractCDataType`.
 
 .. autoclass:: LanguageTag
 
+.. autoclass:: JSON
+
 .. autoclass:: EnumCDataType(enum_class, nested_type=xso.String(), *, allow_coerce=False, deprecate_coerce=False, allow_unknown=True, accept_unknown=True)
 
 .. autofunction:: EnumType(enum_class[, nested_type], *, allow_coerce=False, deprecate_coerce=False, allow_unknown=True, accept_unknown=True)
@@ -507,6 +509,7 @@ from .types import (  # NOQA
     JID,
     ConnectionLocation,
     LanguageTag,
+    JSON,
     TextChildMap,
     EnumType,
     EnumCDataType,

--- a/aioxmpp/xso/__init__.py
+++ b/aioxmpp/xso/__init__.py
@@ -119,6 +119,8 @@ repeated that detailed on the other classes. Refer to the documentation of the
 
 .. autoclass:: ChildText(tag, *[, child_policy=UnknownChildPolicy.FAIL][, attr_policy=UnknownAttrPolicy.FAIL][, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, default][, erroneous_as_absent=False])
 
+.. autoclass:: ChildValue(type_)
+
 .. autoclass:: Text(*[, type_=xso.String()][, validator=None][, validate=ValidateMode.FROM_RECV][, default][, erroneous_as_absent=False])
 
 Non-scalar descriptors
@@ -526,6 +528,7 @@ from .model import (  # NOQA
     UnknownTopLevelTag,
     Attr,
     LangAttr,
+    ChildValue,
     Child,
     ChildFlag,
     ChildList,

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -1873,7 +1873,7 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
                         # assignment failed due to recoverable error, treat as
                         # absent
                         attr_map[key] = prop
-                except:
+                except Exception:
                     prop.mark_incomplete(obj)
                     _mark_attributes_incomplete(attr_map.values(), obj)
                     logger.debug("while parsing XSO %s (%r)", cls,
@@ -1889,7 +1889,7 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
             for key, prop in attr_map.items():
                 try:
                     prop.handle_missing(obj, ctx)
-                except:
+                except Exception:
                     logger.debug("while parsing XSO %s", cls,
                                  exc_info=True)
                     # true means suppress
@@ -1941,7 +1941,7 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
                             handler.from_events(obj, ev_args, ctx),
                             ev_args
                         )
-                    except:
+                    except Exception:
                         logger.debug("while parsing XSO %s", type(obj),
                                      exc_info=True)
                         # true means suppress
@@ -1958,7 +1958,7 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
                         obj,
                         collected_text
                     )
-                except:
+                except Exception:
                     logger.debug("while parsing XSO", exc_info=True)
                     # true means suppress
                     if not obj.xso_error_handler(
@@ -2383,7 +2383,7 @@ class SAXDriver(xml.sax.handler.ContentHandler):
         except StopIteration as err:
             self._emit(err.value)
             self._dest = None
-        except:
+        except:  # NOQA
             self._dest = None
             raise
 
@@ -2646,7 +2646,7 @@ def capture_events(receiver, dest):
                 except StopIteration as _e:
                     _r = _e.value
                     break
-    except:
+    except:  # NOQA
         dest.clear()
         raise
     return _r

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -465,6 +465,32 @@ class _ChildPropBase(_PropBase):
         self._classes.add(cls)
 
 
+class ChildValue(_ChildPropBase):
+    """
+    Descriptor represeting a child element as parsed using an element type.
+
+    :param type_: The element type to use to parse the child element.
+    :type type_: :class:`aioxmpp.xso.AbstractElementType`
+
+    The descriptor value will be the unpacked child element value. Upon
+    serialisation, the descriptor
+    """
+
+    def __init__(self, type_):
+        super().__init__(type_.get_xso_types())
+        self.type_ = type_
+
+    def from_events(self, instance, ev_args, ctx):
+        xso = (yield from super()._process(instance, ev_args, ctx))
+        value = self.type_.unpack(xso)
+        self._set_from_recv(instance, value)
+
+    def to_sax(self, instance, dest):
+        value = self.__get__(instance, type(instance))
+        packed = self.type_.pack(value)
+        packed.unparse_to_sax(dest)
+
+
 class Child(_ChildPropBase):
     """
     When assigned to a class’ attribute, it collects any child which matches

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -307,7 +307,7 @@ class _PropBase(metaclass=PropBaseMeta):
         instance._xso_contents[self] = value
 
     def __set__(self, instance, value):
-        if     (self.default != value and
+        if (self.default != value and
                 self.validate.from_code and
                 self.validator and
                 not self.validator.validate(value)):
@@ -318,7 +318,7 @@ class _PropBase(metaclass=PropBaseMeta):
         self.__set__(instance, value)
 
     def _set_from_recv(self, instance, value):
-        if     (self.default != value and
+        if (self.default != value and
                 self.validate.from_recv and
                 self.validator and
                 not self.validator.validate(value)):
@@ -1683,7 +1683,7 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
                 continue
 
             if base.TEXT_PROPERTY is not None:
-                if     (text_property is not None and
+                if (text_property is not None and
                         base.TEXT_PROPERTY.xq_descriptor is not text_property):
                     raise TypeError("multiple text properties in inheritance")
                 text_property = base.TEXT_PROPERTY.xq_descriptor
@@ -1709,8 +1709,9 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
                         raise TypeError("ambiguous Attr properties inherited")
 
             if base.COLLECTOR_PROPERTY is not None:
-                if     (collector_property is not None and
-                        base.COLLECTOR_PROPERTY.xq_descriptor is not collector_property):
+                if (collector_property is not None and
+                        base.COLLECTOR_PROPERTY.xq_descriptor is not
+                        collector_property):
                     raise TypeError("multiple collector properties in "
                                     "inheritance")
                 collector_property = base.COLLECTOR_PROPERTY.xq_descriptor
@@ -1756,7 +1757,7 @@ class XMLStreamClass(xso_query.Class, abc.ABCMeta):
             except ValueError:
                 raise TypeError("TAG attribute has incorrect format")
 
-        if     (tag is not None and
+        if (tag is not None and
                 "DECLARE_NS" not in namespace and
                 not any(hasattr(base, "DECLARE_NS") for base in bases)):
             if tag[0] is None:

--- a/aioxmpp/xso/types.py
+++ b/aioxmpp/xso/types.py
@@ -33,6 +33,7 @@ import base64
 import binascii
 import decimal
 import ipaddress
+import json
 import numbers
 import re
 import unicodedata
@@ -637,6 +638,41 @@ class LanguageTag(AbstractCDataType):
     def coerce(self, v):
         if not isinstance(v, structs.LanguageTag):
             raise TypeError("{!r} is not a LanguageTag", v)
+        return v
+
+
+class JSON(AbstractCDataType):
+    """
+    Character data type for JSON structured data.
+
+    .. versionadded:: 0.11
+
+    Upon deserialisation, character data is parsed as JSON using :mod:`json`.
+    On serialisation, the value is serialised as JSON. This implies that the
+    data must be JSON serialisable, but there is no check for that in
+    :meth:`coerce`, as this check would be (a) expensive to do for nested data
+    structures and (b) impossible to do for mutable data structures.
+
+    Example:
+
+    .. code-block:: python
+
+        class JSONContainer(aioxmpp.xso.XSO):
+            TAG = ("urn:xmpp:json:0", "json")
+
+            data = aioxmpp.xso.Text(
+                type_=aioxmpp.xso.JSON()
+            )
+
+    """
+
+    def parse(self, v):
+        return json.loads(v)
+
+    def format(self, v):
+        return json.dumps(v)
+
+    def coerce(self, v):
         return v
 
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -144,6 +144,8 @@ Version 0.11
 
 * :class:`aioxmpp.xso.ChildValue`
 
+* :class:`aioxmpp.misc.JSONContainer`, :class:`aioxmpp.misc.JSONContainerType`
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -142,6 +142,8 @@ Version 0.11
 
 * :class:`aioxmpp.utils.proxy_property`
 
+* :class:`aioxmpp.xso.ChildValue`
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,6 +129,7 @@ From XMPP Extension Proposals (XEPs)
 * :xep:`300` (Use of Cryptographic Hash Functions in XMPP),
   see :mod:`aioxmpp.hashes`
 * :xep:`333` (Chat Markers), schema-only, see :mod:`aioxmpp.misc`
+* :xep:`335` (JSON Containers), see :mod:`aioxmpp.misc`
 * :xep:`363` (HTTP Upload), see :mod:`aioxmpp.httpupload`
 * :xep:`368` (SRV records for XMPP over TLS)
 * :xep:`379` (Pre-Authenticared Roster Subscription), schema-only, see

--- a/tests/misc/test_json.py
+++ b/tests/misc/test_json.py
@@ -1,0 +1,108 @@
+import contextlib
+import unittest
+
+import aioxmpp.pubsub.xso
+import aioxmpp.xso as xso
+import aioxmpp.misc as misc_xso
+
+from aioxmpp.utils import namespaces
+
+
+class TestNamespaces(unittest.TestCase):
+    def test_xep0335_json(self):
+        self.assertEqual(
+            namespaces.xep0335_json,
+            "urn:xmpp:json:0"
+        )
+
+
+class TestJSONContainer(unittest.TestCase):
+    def test_is_xso(self):
+        self.assertTrue(issubclass(
+            misc_xso.JSONContainer,
+            xso.XSO,
+        ))
+
+    def test_tag(self):
+        self.assertEqual(
+            misc_xso.JSONContainer.TAG,
+            ("urn:xmpp:json:0", "json")
+        )
+
+    def test_json_data(self):
+        self.assertIsInstance(
+            misc_xso.JSONContainer.json_data,
+            xso.Text,
+        )
+        self.assertIsInstance(
+            misc_xso.JSONContainer.json_data.type_,
+            xso.JSON
+        )
+
+    def test_init(self):
+        jc = misc_xso.JSONContainer()
+        self.assertIsNone(jc.json_data)
+
+    def test_init_with_data(self):
+        jc = misc_xso.JSONContainer(unittest.mock.sentinel.data)
+        self.assertEqual(jc.json_data, unittest.mock.sentinel.data)
+
+    def test_is_pubsub_payload(self):
+        self.assertIn(
+            misc_xso.JSONContainer.TAG,
+            aioxmpp.pubsub.xso.Item.CHILD_MAP,
+        )
+
+
+class TestJSONContainerType(unittest.TestCase):
+    def test_is_element_type(self):
+        self.assertTrue(issubclass(
+            misc_xso.JSONContainerType,
+            xso.AbstractElementType,
+        ))
+
+    def test_advertises_JSONContainer_xso_on_class(self):
+        self.assertIn(
+            misc_xso.JSONContainer,
+            misc_xso.JSONContainerType.get_xso_types()
+        )
+
+    def test_advertises_JSONContainer_xso_on_instance(self):
+        self.assertIn(
+            misc_xso.JSONContainer,
+            misc_xso.JSONContainerType().get_xso_types()
+        )
+
+    def test_unpack_extracts_json_data_attribute_via_class(self):
+        m = unittest.mock.Mock(spec=misc_xso.JSONContainer)
+
+        self.assertEqual(
+            misc_xso.JSONContainerType.unpack(m),
+            m.json_data,
+        )
+
+    def test_unpack_extracts_json_data_attribute_via_instance(self):
+        m = unittest.mock.Mock(spec=misc_xso.JSONContainer)
+
+        self.assertEqual(
+            misc_xso.JSONContainerType().unpack(m),
+            m.json_data,
+        )
+
+    def test_pack_creates_JSONContainer_with_data_via_class(self):
+        with contextlib.ExitStack() as stack:
+            JSONContainer = stack.enter_context(unittest.mock.patch(
+                "aioxmpp.misc.json.JSONContainer",
+                return_value=unittest.mock.sentinel.obj
+            ))
+
+            result = misc_xso.JSONContainerType.pack(
+                unittest.mock.sentinel.data,
+            )
+
+        self.assertEqual(
+            result,
+            unittest.mock.sentinel.obj,
+        )
+
+        JSONContainer.assert_called_once_with(unittest.mock.sentinel.data)

--- a/tests/xso/test_model.py
+++ b/tests/xso/test_model.py
@@ -68,6 +68,18 @@ def make_instance_mock(mapping={}):
     return instance
 
 
+def unparse_to_node(xso, parent):
+    handler = lxml.sax.ElementTreeContentHandler(
+        makeelement=parent.makeelement)
+    handler.startDocument()
+    handler.startElementNS((None, "root"), None)
+    xso.unparse_to_sax(handler)
+    handler.endElementNS((None, "root"), None)
+    handler.endDocument()
+
+    parent.extend(handler.etree.getroot())
+
+
 class TestXMLStreamClass(unittest.TestCase):
     def setUp(self):
         self.ctx = xso_model.Context()
@@ -1954,7 +1966,7 @@ class TestCapturingXMLStreamClass(unittest.TestCase):
 class TestXSO(XMLTestCase):
     def _unparse_test(self, obj, tree):
         parent = etree.Element("foo")
-        obj.unparse_to_node(parent)
+        unparse_to_node(obj, parent)
         self.assertSubtreeEqual(
             tree,
             parent,
@@ -3652,7 +3664,7 @@ class TestChildValue(XMLTestCase):
         instance.thing = "some value"
 
         parent = etree.Element("root")
-        instance.unparse_to_node(parent)
+        unparse_to_node(instance, parent)
 
         self.assertSubtreeEqual(
             etree.fromstring(

--- a/tests/xso/test_types.py
+++ b/tests/xso/test_types.py
@@ -1117,6 +1117,56 @@ class TestLanguageTag(unittest.TestCase):
                 t.coerce(value)
 
 
+class TestJSON(unittest.TestCase):
+    def test_is_cdata_type(self):
+        self.assertTrue(issubclass(
+            xso.JSON,
+            xso.AbstractCDataType,
+        ))
+
+    def test_parse_loads_as_json_via_instance(self):
+        j = xso.JSON()
+
+        with contextlib.ExitStack() as stack:
+            loads = stack.enter_context(unittest.mock.patch(
+                "json.loads",
+                return_value=unittest.mock.sentinel.parsed,
+            ))
+
+            result = j.parse(
+                unittest.mock.sentinel.cdata,
+            )
+
+        loads.assert_called_once_with(unittest.mock.sentinel.cdata)
+
+        self.assertEqual(result, unittest.mock.sentinel.parsed)
+
+    def test_format_dumps_as_json_via_instance(self):
+        j = xso.JSON()
+
+        with contextlib.ExitStack() as stack:
+            dumps = stack.enter_context(unittest.mock.patch(
+                "json.dumps",
+                return_value=unittest.mock.sentinel.serialised,
+            ))
+
+            result = j.format(
+                unittest.mock.sentinel.data,
+            )
+
+        dumps.assert_called_once_with(unittest.mock.sentinel.data)
+
+        self.assertEqual(result, unittest.mock.sentinel.serialised)
+
+    def test_coerce_passes_everything_via_instance(self):
+        value = object()
+
+        self.assertIs(
+            xso.JSON().coerce(value),
+            value,
+        )
+
+
 class TestTextChildMap(unittest.TestCase):
     def test_is_element_type(self):
         self.assertTrue(issubclass(


### PR DESCRIPTION
This PR mainly provides an "implementation" of XEP-0335, that is, adds an XSO for JSON containers. It is automatically registered as registered payload on PubSub items.

This mixes a few concerns, but it felt stupid to split the XSO changes which I needed for JSON stuff out into a separate PR; the other XSO changes are merely cleanup, fully following the "when touching it, clean it up" directive.

Fixes #271, starts work on #279.