### PR TITLE
e2etest: add test for pubsub get_items_by_id

### DIFF
--- a/aioxmpp/e2etest/provision.py
+++ b/aioxmpp/e2etest/provision.py
@@ -63,6 +63,12 @@ class Quirk(enum.Enum):
 
        The quirk does not need to be set if the environment does not provide a
        MUC implementation at all.
+
+    .. attribute:: PUBSUB_GET_ITEMS_BY_ID_BROKEN
+       :annotation: https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#broken-pubsub-get-multiple-by-id
+
+       Indicates that the "Get Items by Id" operation in the PubSub service used
+       is broken when more than one item is requested.
     """
 
     MUC_REWRITES_MESSAGE_ID = \
@@ -73,6 +79,8 @@ class Quirk(enum.Enum):
         "https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#muc-no-333"
     BROKEN_MUC = \
         "https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#broken-muc"
+    PUBSUB_GET_MULTIPLE_ITEMS_BY_ID_BROKEN = \
+        "https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#broken-pubsub-get-multiple-by-id"  # NOQA: E501
 
 
 def fix_quirk_str(s):

--- a/tests/pubsub/test_e2e.py
+++ b/tests/pubsub/test_e2e.py
@@ -35,6 +35,8 @@ from aioxmpp.e2etest import (
     blocking_timed,
     require_feature_subset,
     require_pep,
+    skip_with_quirk,
+    Quirk,
 )
 
 
@@ -119,6 +121,7 @@ class TestOwnerUseCases(TestCase):
         self.assertEqual(len(items.payload.items), 0)
 
     @blocking_timed
+    @skip_with_quirk(Quirk.PUBSUB_GET_MULTIPLE_ITEMS_BY_ID_BROKEN)
     def test_publish_multiple_and_get_by_id(self):
         # configure the node for multiple items
         config = yield from self.pubsub.get_node_config(

--- a/utils/prosody-cfg/0.10/e2etest.ini
+++ b/utils/prosody-cfg/0.10/e2etest.ini
@@ -7,4 +7,4 @@ pin_store=.travis-pinstore.json
 pin_type=0
 no_verfiy=true
 block_features={"localhost": ["http://jabber.org/protocol/pubsub#*"]}
-quirks=["https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#muc-no-333"]
+quirks=["https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#muc-no-333", "https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#broken-pubsub-get-multiple-by-id"]

--- a/utils/prosody-cfg/0.11/link.sh
+++ b/utils/prosody-cfg/0.11/link.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-ln -s "$(pwd)/../prosody-modules/mod_storage_memory" plugins/
 ln -s "$(pwd)/../prosody-modules/mod_http_upload" plugins/

--- a/utils/prosody-cfg/0.9/e2etest.ini
+++ b/utils/prosody-cfg/0.9/e2etest.ini
@@ -7,4 +7,4 @@ pin_store=.travis-pinstore.json
 pin_type=0
 no_verfiy=true
 block_features={"localhost": ["http://jabber.org/protocol/pubsub#*"]}
-quirks=["https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#muc-no-333"]
+quirks=["https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#muc-no-333", "https://zombofant.net/xmlns/aioxmpp/e2etest/quirks#broken-pubsub-get-multiple-by-id"]


### PR DESCRIPTION
This broke for mirror-client in muclumbus, so I figured an e2etest is nice to have. (The breakage was caused by prosody though.)