### PR TITLE
Feature/sm location format

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -157,6 +157,9 @@ Version 0.11
   have your changes apply to all security layers anymore. Since this behaviour
   was never documented or intended, there is no transition period for this.
 
+* Fix incorrect parsing of :xep:`198` location specifier. We always required a
+  port number, while the standards allows omit the port number.
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/tests/xso/test_types.py
+++ b/tests/xso/test_types.py
@@ -950,6 +950,19 @@ class TestConnectionLocation(unittest.TestCase):
             t.parse("[fe80::]:5222")
         )
 
+    def test_parse_ipv6_without_port_number(self):
+        t = xso.ConnectionLocation()
+        self.assertEqual(
+            (ipaddress.IPv6Address("fe80::"), 5222),
+            t.parse("[fe80::]")
+        )
+
+    def test_invalid_ipv6(self):
+        t = xso.ConnectionLocation()
+        with self.assertRaises(ValueError):
+            t.parse("fe80:::5222")
+
+
     def test_reject_non_integer_port_number(self):
         t = xso.ConnectionLocation()
         with self.assertRaises(ValueError):
@@ -960,11 +973,6 @@ class TestConnectionLocation(unittest.TestCase):
         with self.assertRaises(ValueError):
             t.parse("[fe80::]:1000000")
 
-    def test_reject_missing_colon(self):
-        t = xso.ConnectionLocation()
-        with self.assertRaises(ValueError):
-            t.parse("foo.bar")
-
     def test_parse_ipv4(self):
         t = xso.ConnectionLocation()
         self.assertEqual(
@@ -972,11 +980,25 @@ class TestConnectionLocation(unittest.TestCase):
             t.parse("10.0.0.1:5223")
         )
 
+    def test_parse_ipv4_without_port_number(self):
+        t = xso.ConnectionLocation()
+        self.assertEqual(
+            (ipaddress.IPv4Address("10.0.0.1"), 5222),
+            t.parse("10.0.0.1")
+        )
+
     def test_parse_hostname(self):
         t = xso.ConnectionLocation()
         self.assertEqual(
             ("foo.bar.example", 5234),
             t.parse("foo.bar.example:5234")
+        )
+
+    def test_parse_hostname_without_port_number(self):
+        t = xso.ConnectionLocation()
+        self.assertEqual(
+            ("foo.bar.example", 5222),
+            t.parse("foo.bar.example")
         )
 
     def test_format_ipv6(self):


### PR DESCRIPTION
Support omission of port number in connection location specifier

This is in line with the standard (XEP-0198 § 3):

> The <enabled/> element MAY include a 'location' attribute to
> specify the server's preferred IP address or hostname
> (optionally with a port) for reconnection, in the form
> specified in Section 4.9.3.19 of RFC 6120 (i.e.,
> "domainpart:port", where IPv6 addresses are enclosed in square
> brackets "[...]" as described in RFC 5952 [6])

Fixes #290. Thanks @Terbau.