### PR TITLE
xml: fix serialisation of re-ocurring nested namespaces

### DIFF
--- a/aioxmpp/xml.py
+++ b/aioxmpp/xml.py
@@ -312,16 +312,32 @@ class XMPPXMLGenerator:
 
         new_decls = self._ns_decls_floating_in
         new_prefixes = self._ns_prefixes_floating_in
+        old_ns_map = self._curr_ns_map
         self._ns_map_stack.append(
             (
-                self._curr_ns_map.copy(),
+                old_ns_map,
                 set(new_prefixes) - self._ns_auto_prefixes_floating_in,
                 old_counter
             )
         )
 
+        new_ns_map = dict(new_decls)
         cleared_new_prefixes = dict(new_prefixes)
-        for uri, prefix in self._curr_ns_map.items():
+        for uri, prefix in old_ns_map.items():
+            try:
+                new_uri = new_prefixes[prefix]
+            except KeyError:
+                pass
+            else:
+                if new_uri != uri:
+                    # -> the entry must be dropped because the prefix is
+                    # re-assigned
+                    continue
+
+            # use setdefault: new entries (as assigned in new_ns_map =
+            # dict(...)) need to win over old entries
+            new_ns_map.setdefault(uri, prefix)
+
             try:
                 new_uri = cleared_new_prefixes[prefix]
             except KeyError:
@@ -330,7 +346,7 @@ class XMPPXMLGenerator:
                 if new_uri == uri:
                     del cleared_new_prefixes[prefix]
 
-        self._curr_ns_map.update(new_decls)
+        self._curr_ns_map = new_ns_map
         self._ns_decls_floating_in = {}
         self._ns_prefixes_floating_in = {}
         self._ns_auto_prefixes_floating_in.clear()


### PR DESCRIPTION
This fixes an oversight where namespace URIs whose prefix has
been re-bound would not be removed from _curr_ns_map. That leads
to the prefix/namespace not being re-declared if the namespace was
declared further up in the hierarchy, but the prefix used in the
initial declaration was re-bound in-between.

Please see the added test cases for example situations.

Fixes #295.