### PR TITLE
xso: rename unparse_to_sax to xso_serialise_to_sax

### DIFF
--- a/aioxmpp/xml.py
+++ b/aioxmpp/xml.py
@@ -772,7 +772,7 @@ class XMLStreamWriter:
 
         """
         with self._writer.buffer():
-            xso.unparse_to_sax(self._writer)
+            xso.xso_serialise_to_sax(self._writer)
 
     def abort(self):
         """
@@ -1121,7 +1121,7 @@ def serialize_single_xso(x):
     gen = XMPPXMLGenerator(buf,
                            short_empty_elements=True,
                            sorted_attributes=True)
-    x.unparse_to_sax(gen)
+    x.xso_serialise_to_sax(gen)
     return buf.getvalue().decode("utf8")
 
 
@@ -1132,7 +1132,7 @@ def write_single_xso(x, dest):
     gen = XMPPXMLGenerator(dest,
                            short_empty_elements=True,
                            sorted_attributes=True)
-    x.unparse_to_sax(gen)
+    x.xso_serialise_to_sax(gen)
 
 
 def read_xso(src, xsomap):

--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -488,7 +488,7 @@ class ChildValue(_ChildPropBase):
     def to_sax(self, instance, dest):
         value = self.__get__(instance, type(instance))
         packed = self.type_.pack(value)
-        packed.unparse_to_sax(dest)
+        packed.xso_serialise_to_sax(dest)
 
 
 class Child(_ChildPropBase):
@@ -584,7 +584,7 @@ class Child(_ChildPropBase):
         obj = self.__get__(instance, type(instance))
         if obj is None:
             return
-        obj.unparse_to_sax(dest)
+        obj.xso_serialise_to_sax(dest)
 
 
 class ChildList(_ChildPropBase):
@@ -640,7 +640,7 @@ class ChildList(_ChildPropBase):
         """
 
         for obj in self.__get__(instance, type(instance)):
-            obj.unparse_to_sax(dest)
+            obj.xso_serialise_to_sax(dest)
 
 
 class Collector(_PropBase):
@@ -1103,7 +1103,7 @@ class ChildMap(_ChildPropBase):
 
         for items in self.__get__(instance, type(instance)).values():
             for obj in items:
-                obj.unparse_to_sax(dest)
+                obj.xso_serialise_to_sax(dest)
 
 
 class ChildLangMap(ChildMap):
@@ -1380,7 +1380,7 @@ class ChildValueList(_ChildPropBase):
 
     def to_sax(self, instance, dest):
         for value in self.__get__(instance, type(instance)):
-            self.type_.pack(value).unparse_to_sax(dest)
+            self.type_.pack(value).xso_serialise_to_sax(dest)
 
 
 class ChildValueMap(_ChildPropBase):
@@ -1440,7 +1440,7 @@ class ChildValueMap(_ChildPropBase):
 
     def to_sax(self, instance, dest):
         for item in self.__get__(instance, type(instance)).items():
-            self.type_.pack(item).unparse_to_sax(dest)
+            self.type_.pack(item).xso_serialise_to_sax(dest)
 
     def from_events(self, instance, ev_args, ctx):
         obj = yield from self._process(instance, ev_args, ctx)
@@ -1490,7 +1490,7 @@ class ChildValueMultiMap(_ChildPropBase):
 
     def to_sax(self, instance, dest):
         for key, value in self.__get__(instance, type(instance)).items():
-            self.type_.pack((key, value)).unparse_to_sax(dest)
+            self.type_.pack((key, value)).xso_serialise_to_sax(dest)
 
     def from_events(self, instance, ev_args, ctx):
         obj = yield from self._process(instance, ev_args, ctx)
@@ -2192,7 +2192,7 @@ class XSO(metaclass=XMLStreamClass):
 
     The following methods are available on instances of :class:`XSO`:
 
-    .. automethod:: unparse_to_sax
+    .. automethod:: xso_serialise_to_sax
 
     The following **class methods** are provided by the metaclass:
 
@@ -2299,7 +2299,17 @@ class XSO(metaclass=XMLStreamClass):
         child, that child will not be added to the object.
         """
 
-    def unparse_to_sax(self, dest):
+    def xso_serialise_to_sax(self, dest):
+        """
+        Serialise the XSO to a SAX handler.
+
+        :param dest: SAX handler to send the events to
+
+        .. versionchanged:: 0.11
+
+            The method was renamed from unparse_to_sax to
+            xso_serialise_to_sax.
+        """
         # XXX: if anyone has an idea on how to optimize this, this is a hotspot
         # when serialising XML
         # things which do not suffice or even change anything:
@@ -2331,7 +2341,7 @@ class XSO(metaclass=XMLStreamClass):
             makeelement=parent.makeelement)
         handler.startDocument()
         handler.startElementNS((None, "root"), None)
-        self.unparse_to_sax(handler)
+        self.xso_serialise_to_sax(handler)
         handler.endElementNS((None, "root"), None)
         handler.endDocument()
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -175,6 +175,9 @@ Version 0.11
 
 * Support for :xep:`27` schema in :mod:`aioxmpp.misc`
 
+* *Possible breaking change*: Renamed :meth:`aioxmpp.xso.XSO.unparse_to_sax` to
+  :meth:`~aioxmpp.xso.XSO.xso_serialise_to_sax`.
+
 .. _api-changelog-0.10:
 
 Version 0.10

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1908,7 +1908,7 @@ class TestXMPPXMLProcessor(unittest.TestCase):
         f.baz.children.append(Bar("child a"))
         f.baz.children.append(Bar("child b"))
 
-        f.unparse_to_sax(self.proc)
+        f.xso_serialise_to_sax(self.proc)
 
         self.assertEqual(1, len(results))
 

--- a/tests/xso/test_model.py
+++ b/tests/xso/test_model.py
@@ -73,7 +73,7 @@ def unparse_to_node(xso, parent):
         makeelement=parent.makeelement)
     handler.startDocument()
     handler.startElementNS((None, "root"), None)
-    xso.unparse_to_sax(handler)
+    xso.xso_serialise_to_sax(handler)
     handler.endElementNS((None, "root"), None)
     handler.endDocument()
 
@@ -2008,7 +2008,7 @@ class TestXSO(XMLTestCase):
         sink = unittest.mock.MagicMock()
 
         obj = Cls()
-        obj.unparse_to_sax(sink)
+        obj.xso_serialise_to_sax(sink)
 
         self.assertSequenceEqual(
             [
@@ -2956,7 +2956,7 @@ class TestChild(XMLTestCase):
         obj = self.ClsA()
         obj.test_child = unittest.mock.MagicMock()
         self.ClsA.test_child.to_sax(obj, dest)
-        obj.test_child.unparse_to_sax.assert_called_once_with(dest)
+        obj.test_child.xso_serialise_to_sax.assert_called_once_with(dest)
 
     def test_to_sax_unset(self):
         dest = unittest.mock.MagicMock()
@@ -3613,7 +3613,7 @@ class TestChildValue(XMLTestCase):
         self.assertEqual(obj.value, "value")
 
     def test_to_sax_packs_value_and_saxifies_it(self):
-        packed_xso = unittest.mock.Mock(["unparse_to_sax"])
+        packed_xso = unittest.mock.Mock(["xso_serialise_to_sax"])
 
         type_mock = unittest.mock.Mock(["pack", "get_xso_types"])
         type_mock.get_xso_types.return_value = []
@@ -3630,7 +3630,7 @@ class TestChildValue(XMLTestCase):
         prop.to_sax(instance, unittest.mock.sentinel.dest)
 
         type_mock.pack.assert_called_once_with(unittest.mock.sentinel.value)
-        packed_xso.unparse_to_sax.assert_called_once_with(
+        packed_xso.xso_serialise_to_sax.assert_called_once_with(
             unittest.mock.sentinel.dest
         )
 
@@ -5653,7 +5653,7 @@ class TestChildValueList(unittest.TestCase):
             base.mock_calls,
             [
                 unittest.mock.call.pack(10),
-                unittest.mock.call.pack().unparse_to_sax(base.dest)
+                unittest.mock.call.pack().xso_serialise_to_sax(base.dest)
             ]
         )
 
@@ -5952,7 +5952,7 @@ class TestChildValueMap(unittest.TestCase):
             base.mock_calls,
             [
                 unittest.mock.call.pack((10, 20)),
-                unittest.mock.call.pack().unparse_to_sax(base.dest)
+                unittest.mock.call.pack().xso_serialise_to_sax(base.dest)
             ]
         )
 
@@ -6232,11 +6232,11 @@ class TestChildValueMultiMap(unittest.TestCase):
             base.mock_calls,
             [
                 unittest.mock.call.pack(("x", "foo")),
-                unittest.mock.call.pack().unparse_to_sax(base.dest),
+                unittest.mock.call.pack().xso_serialise_to_sax(base.dest),
                 unittest.mock.call.pack(("x", "bar")),
-                unittest.mock.call.pack().unparse_to_sax(base.dest),
+                unittest.mock.call.pack().xso_serialise_to_sax(base.dest),
                 unittest.mock.call.pack(("z", "baz")),
-                unittest.mock.call.pack().unparse_to_sax(base.dest),
+                unittest.mock.call.pack().xso_serialise_to_sax(base.dest),
             ]
         )
 


### PR DESCRIPTION
The old name used the weird non-verb "unparse". The new name uses
the proper `xso_` prefix reserved for library methods and attributes
on XSOs.