### PR TITLE
xso: fix assignment of enum members when only allow_coerce is true

### DIFF
--- a/aioxmpp/xso/types.py
+++ b/aioxmpp/xso/types.py
@@ -874,10 +874,11 @@ class EnumCDataType(AbstractCDataType):
                 isinstance(value, Unknown)):
             return value
 
+        if isinstance(value, self.enum_class):
+            return value
+
         if self.allow_coerce:
             if self.deprecate_coerce:
-                if isinstance(value, self.enum_class):
-                    return value
                 stacklevel = (4 if self.deprecate_coerce is True
                               else self.deprecate_coerce)
                 warnings.warn(
@@ -894,9 +895,6 @@ class EnumCDataType(AbstractCDataType):
                 if self.pass_unknown:
                     return value
                 raise
-
-        if isinstance(value, self.enum_class):
-            return value
 
         if self.pass_unknown:
             value = self.nested_type.coerce(value)

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -178,6 +178,10 @@ Version 0.11
 * *Possible breaking change*: Renamed :meth:`aioxmpp.xso.XSO.unparse_to_sax` to
   :meth:`~aioxmpp.xso.XSO.xso_serialise_to_sax`.
 
+* Fix assignment of enumeration members to descriptors using
+  :class:`aioxmpp.xso.EnumCDataType` with `allow_coerce` set to true but
+  `deprecate_coerce` set to false.
+
 .. _api-changelog-0.10:
 
 Version 0.10


### PR DESCRIPTION
Previously, the code would force coercion of the value through
the *nested* type (in most cases, String) first even if the value
was already an enumeration member. This obviously breaks because
the enumeration member is an instance of the Enumeration and not of
any other type.

This bug occurs only if deprecate_coerce is *false*, because
otherwise there was an additional check for enum membership in the
code path.