### PR TITLE
muc: treat remote server unreachability like timeout self-ping

### DIFF
--- a/aioxmpp/muc/self_ping.py
+++ b/aioxmpp/muc/self_ping.py
@@ -174,6 +174,10 @@ class MUCPinger:
         * :class:`aioxmpp.errors.XMPPError`, ``feature-not-implemented``:
           *positive*
         * :class:`aioxmpp.errors.XMPPError`, ``item-not-found``: *inconclusive*
+        * :class:`aioxmpp.errors.XMPPError`, ``remote-server-not-found``:
+          *inconclusive*
+        * :class:`aioxmpp.errors.XMPPError`, ``remote-server-timeout``:
+          *inconclusive*
         * :class:`aioxmpp.errors.XMPPError`: *negative*
         * :class:`asyncio.TimeoutError`: *inconclusive*
         * Any other exception: *inconclusive*
@@ -197,7 +201,10 @@ class MUCPinger:
                 self._on_fresh()
                 return
 
-            if exc.condition == aioxmpp.errors.ErrorCondition.ITEM_NOT_FOUND:
+            if exc.condition in [
+                    aioxmpp.errors.ErrorCondition.ITEM_NOT_FOUND,
+                    aioxmpp.errors.ErrorCondition.REMOTE_SERVER_NOT_FOUND,
+                    aioxmpp.errors.ErrorCondition.REMOTE_SERVER_TIMEOUT]:
                 self._logger.debug(
                     "%s: ping reply has inconclusive error: %s",
                     self.ping_address,

--- a/tests/muc/test_self_ping.py
+++ b/tests/muc/test_self_ping.py
@@ -622,6 +622,36 @@ class TestMUCPinger(unittest.TestCase):
             self.listener.on_fresh.assert_not_called()
             self.listener.on_exited.assert_not_called()
 
+    def test__interpret_result_emits_nothing_for_remote_server_not_found(self):
+        for type_ in [aioxmpp.errors.XMPPCancelError,
+                      aioxmpp.errors.XMPPWaitError,
+                      aioxmpp.errors.XMPPAuthError,
+                      aioxmpp.errors.XMPPModifyError]:
+            fut = asyncio.Future()
+            fut.set_exception(
+                type_(aioxmpp.errors.ErrorCondition.REMOTE_SERVER_NOT_FOUND)
+            )
+
+            self.p._interpret_result(fut)
+
+            self.listener.on_fresh.assert_not_called()
+            self.listener.on_exited.assert_not_called()
+
+    def test__interpret_result_emits_nothing_for_remote_server_not_found(self):
+        for type_ in [aioxmpp.errors.XMPPCancelError,
+                      aioxmpp.errors.XMPPWaitError,
+                      aioxmpp.errors.XMPPAuthError,
+                      aioxmpp.errors.XMPPModifyError]:
+            fut = asyncio.Future()
+            fut.set_exception(
+                type_(aioxmpp.errors.ErrorCondition.REMOTE_SERVER_TIMEOUT)
+            )
+
+            self.p._interpret_result(fut)
+
+            self.listener.on_fresh.assert_not_called()
+            self.listener.on_exited.assert_not_called()
+
     def test__interpret_result_emits_nothing_for_timeout(self):
         fut = asyncio.Future()
         fut.set_exception(


### PR DESCRIPTION
If the remote server is unreachable network-wise, we cannot know
whether we have been removed. In addition, a rejoin will fail
deterministically.

It is thus better to stay in the undecided pinging state (treat it
like a timeout): this will allow us to wait for a rejoin until we
know more about the current state and the server is actually
reachable again.

See-Also: https://github.com/xsf/xeps/pull/834
See-Also: #312