### PR TITLE
muc: always emit on_presence_change on presence updates

### DIFF
--- a/aioxmpp/muc/service.py
+++ b/aioxmpp/muc/service.py
@@ -1288,8 +1288,7 @@ class Room(aioxmpp.im.conversation.AbstractConversation):
                     reason,
                 )
             )
-        elif (existing.presence_state != info.presence_state or
-                existing.presence_status != info.presence_status):
+        else:
             to_emit.append((self.on_presence_changed,
                             (existing, None, stanza),
                             {}))

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -53,6 +53,22 @@ Version 0.12.2
 
   Again reported by `@zak333 <https://github.com/zak333>`_, thanks.
 
+Version 0.12.3
+--------------
+
+* *Potentially breaking change*: :meth:`aioxmpp.muc.Room.on_presence_changed`
+  now emits for *all* normal (non-unavailable, non-roster-management) presence
+  stanzas received from an occupant.
+
+  Previously, the signal would only emit for cases where the presence show or
+  the status text had changed. This, however, made it impossible for user code
+  to stay up-to-date with the contents of custom extensions transmitted via
+  presence stanzas.
+
+  This was reported on
+  `GitHub as issue #341 <https://github.com/horazont/aioxmpp/issues/341>`_ by
+  `@raj2569 <https://github.com/raj2569>`_.
+
 .. _api-changelog-0.11:
 
 Version 0.11


### PR DESCRIPTION
Without this, there is no simple way for users of the Room object
to obtain presence updates from occupants. While they could
install a global presence filter, that is highly undesirable.

The previous code would only emit on_presence_changed if the `show`
or `status` of the presence had changed. However, with custom
presence payloads, other attributes can be as or even more
interesting than that.

Fixes #341.