### PR TITLE
protocol: add support for multiple and late-created features_future:s

### DIFF
--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -190,18 +190,29 @@ class XMLStream(asyncio.Protocol):
     XML stream implementation. This is an streaming :class:`asyncio.Protocol`
     which translates the received bytes into XSOs.
 
-    `to` must be a domain :class:`~aioxmpp.JID` which identifies the
-    domain to which the stream shall connect.
+    :param to: Domain of the server the stream connects to.
+    :type to: :class:`~aioxmpp.JID`
+    :param features_future: Future which will receive the first stream
+        features received by the peer.
+    :type features_future: :class:`asyncio.Future`
+    :param sorted_attributes: Sort attributes deterministically on output
+        (debug option; not part of the public interface)
+    :type sorted_attributes: :class:`bool`
+    :param base_logger: Parent logger for this stream
+    :type base_logger: :class:`logging.Logger`
 
-    `features_future` must be a :class:`asyncio.Future` instance; the XML
-    stream will set the first :class:`~aioxmpp.nonza.StreamFeatures` node
-    it receives as the result of the future. The future will also receive any
-    pre-stream-features exception.
+    `to` must identify the remote server to connect to. This is used as the
+    ``to`` attribute on the stream header.
 
-    `sorted_attributes` is mainly for unittesting purposes; this is an argument
-    to the :class:`~aioxmpp.xml.XMPPXMLGenerator` and slows down the XML
-    serialization, but produces deterministic results, which is important for
-    testing. Generally, it is preferred to leave this argument at its default.
+    `features_future` must be a future. The XML stream will set the first
+    :class:`~aioxmpp.nonza.StreamFeatures` node it receives as the result of
+    the future. The future will also receive any pre-stream-features
+    exception.
+
+    `sorted_attributes` is a testing/debugging option to enable sorted output
+    of the XML attributes emitted on the stream. See
+    :class:`~aioxmpp.xml.XMPPXMLGenerator` for details. Do not use outside of
+    unit testing code, as it has a negative performance impact.
 
     `base_logger` may be a :class:`logging.Logger` instance to use. The XML
     stream will create a child called ``XMLStream`` at that logger and use that

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -261,6 +261,10 @@ class XMLStream(asyncio.Protocol):
 
     .. automethod:: mute
 
+    Waiting for stream state changes:
+
+    .. automethod:: error_future
+
     Monitoring stream aliveness:
 
     .. autoattribute:: deadtime_soft_limit

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,7 +3,7 @@
 Changelog
 #########
 
-.. _api-cahngelog-0.11:
+.. _api-changelog-0.12:
 
 Version 0.12
 ============
@@ -21,6 +21,8 @@ Version 0.12
 
 * Fix :func:`aioxmpp.jid_escape` double escaping sequences in some
   circumstances.
+
+.. _api-changelog-0.11:
 
 Version 0.11
 ============

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -651,6 +651,19 @@ class TestXMLStreamMock(XMLTestCase):
                 stimulus=XMLStreamMock.Receive(obj)
             ))
 
+    def test_receive_stream_features_into_future(self):
+        fut = self.xmlstream.features_future()
+        obj = nonza.StreamFeatures()
+
+        run_coroutine(self.xmlstream.run_test(
+            [
+            ],
+            stimulus=XMLStreamMock.Receive(obj)
+        ))
+
+        self.assertTrue(fut.done())
+        self.assertIs(fut.result(), obj)
+
     def test_no_termination_on_missing_action(self):
         obj = self.Cls()
 
@@ -883,6 +896,7 @@ class TestXMLStreamMock(XMLTestCase):
         fun.return_value = None
 
         ec_future = asyncio.ensure_future(self.xmlstream.error_future())
+        features_future = self.xmlstream.features_future()
 
         self.xmlstream.on_closing.connect(fun)
 
@@ -894,6 +908,8 @@ class TestXMLStreamMock(XMLTestCase):
 
         self.assertTrue(ec_future.done())
         self.assertIs(exc, ec_future.exception())
+        self.assertTrue(features_future.done())
+        self.assertIs(exc, features_future.exception())
 
         fun.assert_called_once_with(exc)
 
@@ -928,6 +944,7 @@ class TestXMLStreamMock(XMLTestCase):
 
     def test_abort(self):
         fut = self.xmlstream.error_future()
+        ffut = self.xmlstream.features_future()
 
         obj = self.Cls()
 
@@ -945,6 +962,12 @@ class TestXMLStreamMock(XMLTestCase):
         self.assertTrue(fut.done())
         self.assertIsInstance(
             fut.exception(),
+            ConnectionError
+        )
+
+        self.assertTrue(ffut.done())
+        self.assertIsInstance(
+            ffut.exception(),
             ConnectionError
         )
 


### PR DESCRIPTION
The idea behind this is that this allows us to create an XMLStream
early and configure it (e.g. with future language settings, or
namespaces or whatever) before passing it down to the place where
the actual stream negotiation happens.

While we could instead pass down the future, that would be more
error-prone (and less flexible) than passing down the XMLStream
itself.
