### PR TITLE
Use assertRaisesRegex instead of assertRaisesRegexp for Python 3.11 compatibility.

### DIFF
--- a/tests/entitycaps/test_caps115.py
+++ b/tests/entitycaps/test_caps115.py
@@ -853,11 +853,11 @@ class TestImplementation(unittest.TestCase):
         )
 
     def test_put_keys_raises_ValueError_if_no_keys_passed(self):
-        with self.assertRaisesRegexp(ValueError, "values to unpack"):
+        with self.assertRaisesRegex(ValueError, "values to unpack"):
             self.i.put_keys(iter([]), unittest.mock.sentinel.presence)
 
     def test_put_keys_raises_ValueError_if_too_many_keys_passed(self):
-        with self.assertRaisesRegexp(ValueError, "too many values"):
+        with self.assertRaisesRegex(ValueError, "too many values"):
             self.i.put_keys(
                 iter([unittest.mock.sentinel.k1, unittest.mock.sentinel.k2]),
                 unittest.mock.sentinel.presence

--- a/tests/ping/test_e2e.py
+++ b/tests/ping/test_e2e.py
@@ -51,7 +51,7 @@ class TestPing(TestCase):
     async def test_ping_raises_error_condition(self):
         ping_svc = self.source.summon(aioxmpp.ping.PingService)
 
-        with self.assertRaisesRegexp(aioxmpp.XMPPCancelError,
+        with self.assertRaisesRegex(aioxmpp.XMPPCancelError,
                                      "service-unavailable"):
             await ping_svc.ping(self.unimplemented.local_jid)
 

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -252,24 +252,24 @@ class Testhash_from_algo(unittest.TestCase):
             )
 
     def test_raise_ValueError_for_MUST_NOT_hashes(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "support of md2 in XMPP is forbidden"):
             hashes.hash_from_algo("md2")
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "support of md4 in XMPP is forbidden"):
             hashes.hash_from_algo("md4")
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "support of md5 in XMPP is forbidden"):
             hashes.hash_from_algo("md5")
 
     def test_raises_NotImplementedError_if_function_not_supported(self):
         _sha1 = hashlib.sha1
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 NotImplementedError,
                 "sha-1 not supported by hashlib") as ctx:
             del hashlib.sha1
@@ -281,7 +281,7 @@ class Testhash_from_algo(unittest.TestCase):
         self.assertIsInstance(ctx.exception.__cause__, AttributeError)
 
     def test_raises_NotImplementedError_if_function_not_defined(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 NotImplementedError,
                 "hash algorithm 'foobar' unknown"):
             hashes.hash_from_algo("foobar")
@@ -349,7 +349,7 @@ class Testalgo_from_hashlib(unittest.TestCase):
             )
 
     def test_raise_ValueError_for_MUST_NOT_hashes(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "support of md5 in XMPP is forbidden"):
             hashes.algo_of_hash(hashlib.md5())
@@ -401,7 +401,7 @@ class Testalgo_from_hashlib(unittest.TestCase):
 
     def test_raise_ValueError_on_unknown(self):
         m = unittest.mock.Mock()
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "unknown hash implementation: <Mock id=.+>"):
             hashes.algo_of_hash(m)


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268