### PR TITLE
Add Python 3.10 to the testing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,7 @@ jobs:
         - '3.7'
         - '3.8'
         - '3.9'
+        - '3.10'
         test-type:
         - e2e
         e2e-software:

--- a/aioxmpp/custom_queue.py
+++ b/aioxmpp/custom_queue.py
@@ -28,7 +28,7 @@ class AsyncDeque:
         super().__init__()
         self._loop = loop
         self._data = collections.deque()
-        self._non_empty = asyncio.Event(loop=self._loop)
+        self._non_empty = asyncio.Event()
         self._non_empty.clear()
 
     def __len__(self):

--- a/aioxmpp/node.py
+++ b/aioxmpp/node.py
@@ -846,8 +846,7 @@ class Client:
         try:
             await self.stream.resume_sm(xmlstream)
         except errors.StreamNegotiationFailure as exc:
-            self.logger.warn("failed to resume stream (%s)",
-                             exc)
+            self.logger.warning("failed to resume stream (%s)", exc)
             return False
         return True
 
@@ -869,7 +868,7 @@ class Client:
             features[nonza.StreamManagementFeature]
         except KeyError:
             if self.stream.sm_enabled:
-                self.logger.warn("server isn’t advertising SM anymore")
+                self.logger.warning("server isn’t advertising SM anymore")
                 self.stream.stop_sm()
             server_can_do_sm = False
 

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -899,7 +899,7 @@ async def send_and_wait_for(xmlstream, send, wait_for,
             ],
             timeout=timeout,
             return_when=asyncio.FIRST_COMPLETED,
-            loop=xmlstream._loop)
+        )
 
         for other_fut in pending:
             other_fut.cancel()

--- a/aioxmpp/protocol.py
+++ b/aioxmpp/protocol.py
@@ -567,8 +567,8 @@ class XMLStream(asyncio.Protocol):
             # these states are fine, common actions below
             pass
         else:
-            self._logger.warn("unexpected eof_received (in %s state)",
-                              self._smachine.state)
+            self._logger.warning("unexpected eof_received (in %s state)",
+                                 self._smachine.state)
             # common actions below
 
         self._smachine.state = State.CLOSING_STREAM_FOOTER_RECEIVED
@@ -937,6 +937,8 @@ def send_stream_error_and_close(
         condition=condition,
         text=text))
     if custom_condition is not None:
-        logger.warn("custom_condition argument to send_stream_error_and_close"
-                    " not implemented")
+        logger.warning(
+            "custom_condition argument to send_stream_error_and_close"
+            " not implemented",
+        )
     xmlstream.close()

--- a/aioxmpp/stream.py
+++ b/aioxmpp/stream.py
@@ -794,7 +794,7 @@ class StanzaStream:
 
         self._sm_enabled = False
 
-        self._broker_lock = asyncio.Lock(loop=loop)
+        self._broker_lock = asyncio.Lock()
 
         self.app_inbound_presence_filter = AppFilter()
         self.service_inbound_presence_filter = callbacks.Filter()

--- a/aioxmpp/testutils.py
+++ b/aioxmpp/testutils.py
@@ -453,7 +453,7 @@ class TransportMock(InteractivityMock,
         while not self._queue.empty() or self._actions:
             done, pending = await asyncio.wait(
                 [
-                    self._queue.get(),
+                    asyncio.ensure_future(self._queue.get()),
                     self._done
                 ],
                 return_when=asyncio.FIRST_COMPLETED
@@ -665,7 +665,7 @@ class XMLStreamMock(InteractivityMock):
         while not self._queue.empty() or self._actions:
             done, pending = await asyncio.wait(
                 [
-                    self._queue.get(),
+                    asyncio.ensure_future(self._queue.get()),
                     self._done
                 ],
                 return_when=asyncio.FIRST_COMPLETED


### PR DESCRIPTION
https://pythoninsider.blogspot.com/2021/10/python-3100-is-available.html

https://docs.python.org/release/3.10.0/whatsnew/changelog.html#python-3-10-0-final

The loop parameter has been removed from most of asyncio‘s high-level API following deprecation in Python 3.8.