### PR TITLE
Fix docstring example from class XSOParser

### DIFF
--- a/aioxmpp/xso/model.py
+++ b/aioxmpp/xso/model.py
@@ -2571,15 +2571,16 @@ class XSOParser:
         # let Message be a XSO class, like in the XSO example
         result = None
         def catch_result(value):
-            nonlocal result
+            global result
             result = value
 
         parser = aioxmpp.xso.XSOParser()
         parser.add_class(Message, catch_result)
         sd = aioxmpp.xso.SAXDriver(parser)
-        lxml.sax.saxify(lmxl.etree.fromstring(
-            "<message id='foo' from='bar' type='chat' />"
-        ))
+        lxml.sax.saxify(lxml.etree.fromstring(
+            "<jc:message id='foo' from='bar' to='baz' type='chat' "
+            "xmlns:jc='jabber:client'/>"
+        ), sd)
 
 
     The following methods can be used to dynamically add and remove top-level


### PR DESCRIPTION
Minor adaptions to make the example work when copy pasting it:
- typo: lmxl
- [lxml.sax.saxify](https://lxml.de/api/lxml.sax-module.html#saxify) needs a content handler as 2nd argument
- message must be namespaced to work with referenced `class Message`
- message must have tag "to" to work with referenced `class Message`
- result is seemingly at global scope, so `nonlocal` doesn't work