### PR TITLE
stream: discard any pending incoming stanzas when the stream is stopped

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1571,7 +1571,7 @@ class TestStanzaStream(StanzaStreamTestBase):
 
         self.assertFalse(cb.mock_calls)
 
-    def test_rescue_unprocessed_incoming_stanza_on_stop(self):
+    def test_discard_unprocessed_incoming_stanza_on_stop(self):
         pres = make_test_presence()
 
         self.stream.start(self.xmlstream)
@@ -1581,26 +1581,10 @@ class TestStanzaStream(StanzaStreamTestBase):
         self.stream.recv_stanza(pres)
         self.stream.stop()
 
-        self.assertEqual(
-            (pres, None),
-            run_coroutine(self.stream._incoming_queue.get())
-        )
-
-    def test_unprocessed_incoming_stanza_does_not_get_lost_after_stop(self):
-        pres = make_test_presence()
-
-        self.stream.start(self.xmlstream)
-
         run_coroutine(asyncio.sleep(0))
 
-        self.stream.stop()
-
-        self.stream.recv_stanza(pres)
-
-        self.assertEqual(
-            (pres, None),
-            run_coroutine(self.stream._incoming_queue.get())
-        )
+        with self.assertRaises(asyncio.QueueEmpty):
+            self.stream._incoming_queue.get_nowait()
 
     def test_fail_on_unknown_stanza_class(self):
         caught_exc = None


### PR DESCRIPTION
This fixes an ugly corner case and a potential for SM counters going out
of sync. If stanzas are in the incoming queue when the broker task of
the StanzaStream gets terminated, they are put back into the incoming
queue.

However, if the stream was actually covered by stream management, this
will cause incorrect counters in the following edge case:

1. Stanzas arrive and are put in the incoming queue
2. The broker is terminated (because the underlying TCP stream gets
   killed, for instance, and on_closing of the xmlstream emits, which
   causes stop() to be called).
3. The incoming queue now has >0 elements, and the SM counter is set to
   the last element processed, *not including the incoming queue*.
4. The stream is re-established and SM is resumed. Based on the previous
   counter value, the server will now re-send all stanzas still in the
   incoming queue.
5. The broker task starts processing inbound stanzas, starting with
   those still in the incoming queue from the initial termination of the
   stream.

Those have *also* been re-sent by definition by the server, so we'll now
see, process and count those stanzas twice, causing incorrect stream
management counters.

This is not a common case during normal operations; typically, when an
SM stream gets interrupted, it is due to a network going down or
somesuch, which gives the broker task plenty of time to clear its
inbound queue before it gets terminated.