### PR TITLE
Add missing pytz dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ install_requires = [
     'pyasn1',
     'pyasn1_modules',
     'tzlocal>=1.2',
+    'pytz>=2023.3',
 ]
 
 if tuple(map(int, setuptools.__version__.split(".")[:3])) < (6, 0, 0):


### PR DESCRIPTION
Closes #389 

Previously, `tzlocal` had a dependency of `pytz` which was implicitly used by axioxmpp. `tzlocal` now removed this dependency, so `pytz` needs to be explicitly required.